### PR TITLE
Rename http headers class to fix Alamofire naming scheme conflicts

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Sources/PubNub/Extensions/HTTPURLResponse+PubNub.swift
+++ b/Sources/PubNub/Extensions/HTTPURLResponse+PubNub.swift
@@ -29,8 +29,8 @@ import Foundation
 
 extension HTTPURLResponse {
   /// The `allHeaderFields` represented as a collection of `HTTPHeader` values
-  public var headers: HTTPHeaders {
-    return (allHeaderFields as? [String: String]).map(HTTPHeaders.init) ?? []
+  public var headers: PubNubHTTPHeaders {
+    return (allHeaderFields as? [String: String]).map(PubNubHTTPHeaders.init) ?? []
   }
 
   /// If the `HTTPURLResponse` can be considered successful based on its status code

--- a/Sources/PubNub/Extensions/URLRequest+PubNub.swift
+++ b/Sources/PubNub/Extensions/URLRequest+PubNub.swift
@@ -43,9 +43,9 @@ public extension URLRequest {
   }
 
   /// Convience for assigning `HTTPHeader` values to `allHTTPHeaderFields`
-  var headers: HTTPHeaders {
+  var headers: PubNubHTTPHeaders {
     get {
-      return allHTTPHeaderFields.map(HTTPHeaders.init) ?? []
+      return allHTTPHeaderFields.map(PubNubHTTPHeaders.init) ?? []
     }
     set {
       allHTTPHeaderFields = newValue.allHTTPHeaderFields

--- a/Sources/PubNub/Extensions/URLSessionConfiguration+PubNub.swift
+++ b/Sources/PubNub/Extensions/URLSessionConfiguration+PubNub.swift
@@ -56,9 +56,9 @@ public extension URLSessionConfiguration {
   }
 
   /// Convience for assigning `HTTPHeader` values to `httpAdditionalHeaders`
-  var headers: HTTPHeaders {
+  var headers: PubNubHTTPHeaders {
     get {
-      return (httpAdditionalHeaders as? [String: String]).map(HTTPHeaders.init) ?? []
+      return (httpAdditionalHeaders as? [String: String]).map(PubNubHTTPHeaders.init) ?? []
     }
     set {
       httpAdditionalHeaders = newValue.allHTTPHeaderFields

--- a/Sources/PubNub/Helpers/PubNubHTTPHeaders.swift
+++ b/Sources/PubNub/Helpers/PubNubHTTPHeaders.swift
@@ -1,5 +1,5 @@
 //
-//  HTTPHeaders.swift
+//  PubNumbHTTPHeaders.swift
 //
 //  PubNub Real-time Cloud-Hosted Push API and Push Notification Client Frameworks
 //  Copyright © 2019 PubNub Inc.
@@ -28,7 +28,7 @@
 import Foundation
 
 /// A Collection whose elements are HTTPHeader values objects
-public struct HTTPHeaders: Hashable {
+public struct PubNubHTTPHeaders: Hashable {
   var headers: [HTTPHeader] = []
 
   private init() { /* no-op */ }
@@ -70,7 +70,7 @@ public struct HTTPHeaders: Hashable {
   }
 }
 
-extension HTTPHeaders: ExpressibleByDictionaryLiteral {
+extension PubNubHTTPHeaders: ExpressibleByDictionaryLiteral {
   public init(dictionaryLiteral: (String, String)...) {
     self.init()
 
@@ -78,19 +78,19 @@ extension HTTPHeaders: ExpressibleByDictionaryLiteral {
   }
 }
 
-extension HTTPHeaders: ExpressibleByArrayLiteral {
+extension PubNubHTTPHeaders: ExpressibleByArrayLiteral {
   public init(arrayLiteral: HTTPHeader...) {
     self.init(arrayLiteral)
   }
 }
 
-extension HTTPHeaders: Sequence {
+extension PubNubHTTPHeaders: Sequence {
   public func makeIterator() -> IndexingIterator<[HTTPHeader]> {
     return headers.makeIterator()
   }
 }
 
-extension HTTPHeaders: Collection {
+extension PubNubHTTPHeaders: Collection {
   public var startIndex: Int {
     return headers.startIndex
   }

--- a/Sources/PubNub/Networking/Endpoints/PubNubRouter.swift
+++ b/Sources/PubNub/Networking/Endpoints/PubNubRouter.swift
@@ -470,7 +470,7 @@ extension PubNubRouter: Router {
     return .success(query)
   }
 
-  var additionalHeaders: HTTPHeaders {
+  var additionalHeaders: PubNubHTTPHeaders {
     return [:]
   }
 

--- a/Sources/PubNub/Networking/Router.swift
+++ b/Sources/PubNub/Networking/Router.swift
@@ -102,7 +102,7 @@ public protocol Router: URLRequestConvertible, CustomStringConvertible, Validate
   /// The collection of `URLQueryItem` or the `Error` during its creation
   var queryItems: Result<[URLQueryItem], Error> { get }
   /// Additional requred headers
-  var additionalHeaders: HTTPHeaders { get }
+  var additionalHeaders: PubNubHTTPHeaders { get }
   /// The `Data` that will be put inside the request or the `Error` generate during its creation
   var body: Result<Data?, Error> { get }
 

--- a/Tests/PubNubTests/Extensions/HTTPURLResponse+PubNubTests.swift
+++ b/Tests/PubNubTests/Extensions/HTTPURLResponse+PubNubTests.swift
@@ -37,7 +37,7 @@ final class HTTPURLResponsePubNubTests: XCTestCase {
       "TestKey": "TestValue"
     ]
 
-    let httpHeaders = HTTPHeaders(headers)
+    let httpHeaders = PubNubHTTPHeaders(headers)
     let response = HTTPURLResponse(url: url,
                                    statusCode: 200,
                                    httpVersion: "1.2",

--- a/Tests/PubNubTests/Extensions/URLRequest+PubNubTests.swift
+++ b/Tests/PubNubTests/Extensions/URLRequest+PubNubTests.swift
@@ -81,7 +81,7 @@ final class URLRequestPubNubTests: XCTestCase {
     ]
 
     request.allHTTPHeaderFields = dictionary
-    let headers = HTTPHeaders(dictionary)
+    let headers = PubNubHTTPHeaders(dictionary)
 
     XCTAssertEqual(request.headers.allHTTPHeaderFields,
                    headers.allHTTPHeaderFields)
@@ -107,7 +107,7 @@ final class URLRequestPubNubTests: XCTestCase {
       "key": "value",
       "otherKey": "otherValue"
     ]
-    let headers = HTTPHeaders(dictionary)
+    let headers = PubNubHTTPHeaders(dictionary)
 
     request.headers = headers
 

--- a/Tests/PubNubTests/Extensions/URLSessionConfiguration+PubNubTests.swift
+++ b/Tests/PubNubTests/Extensions/URLSessionConfiguration+PubNubTests.swift
@@ -32,7 +32,7 @@ final class URLSessionConfigurationPubNubTests: XCTestCase {
   func testPubNubConfiguration() {
     let config = URLSessionConfiguration.pubnub
 
-    let defaultHeaders: HTTPHeaders = [
+    let defaultHeaders: PubNubHTTPHeaders = [
       .defaultAcceptEncoding,
       .defaultContentType,
       .defaultUserAgent
@@ -44,7 +44,7 @@ final class URLSessionConfigurationPubNubTests: XCTestCase {
   func testSubscriptionConfiguration() {
     let config = URLSessionConfiguration.subscription
 
-    let defaultHeaders: HTTPHeaders = [
+    let defaultHeaders: PubNubHTTPHeaders = [
       .defaultAcceptEncoding,
       .defaultContentType,
       .defaultUserAgent
@@ -64,7 +64,7 @@ final class URLSessionConfigurationPubNubTests: XCTestCase {
 
   func testHeaders_GetSetHeaders() {
     let config = URLSessionConfiguration.default
-    let defaultHeaders: HTTPHeaders = [
+    let defaultHeaders: PubNubHTTPHeaders = [
       .defaultAcceptEncoding,
       .defaultContentType,
       .defaultUserAgent

--- a/Tests/PubNubTests/Helpers/HTTPHeadersTests.swift
+++ b/Tests/PubNubTests/Helpers/HTTPHeadersTests.swift
@@ -31,28 +31,28 @@ import XCTest
 class HTTPHeadersTests: XCTestCase {
   func testDictionaryInit() {
     let dict = ["Key": "Value"]
-    let headers = HTTPHeaders(dict)
+    let headers = PubNubHTTPHeaders(dict)
 
     XCTAssertEqual(headers.allHTTPHeaderFields, dict)
   }
 
   func testHTTPHeaderArrayInit() {
     let list = [HTTPHeader(name: "Key", value: "Value")]
-    let headers = HTTPHeaders(list)
+    let headers = PubNubHTTPHeaders(list)
 
     XCTAssertEqual(headers.first?.name, list.first?.name)
     XCTAssertEqual(headers.first?.value, list.first?.value)
   }
 
   func testUpdate_NoCollision() {
-    var headers = HTTPHeaders(["Key": "Value"])
+    var headers = PubNubHTTPHeaders(["Key": "Value"])
     headers.update(HTTPHeader(name: "OtherKey", value: "Other"))
 
     XCTAssertEqual(headers.count, 2)
   }
 
   func testUpdate_Collision() {
-    var headers = HTTPHeaders(["Key": "Value"])
+    var headers = PubNubHTTPHeaders(["Key": "Value"])
     headers.update(HTTPHeader(name: "Key", value: "Other"))
 
     XCTAssertEqual(headers.count, 1)
@@ -60,14 +60,14 @@ class HTTPHeadersTests: XCTestCase {
   }
 
   func testUpdateNameValue_NoCollision() {
-    var headers = HTTPHeaders(["Key": "Value"])
+    var headers = PubNubHTTPHeaders(["Key": "Value"])
     headers.update(name: "OtherKey", value: "Other")
 
     XCTAssertEqual(headers.count, 2)
   }
 
   func testUpdateNameValue_Collision() {
-    var headers = HTTPHeaders(["Key": "Value"])
+    var headers = PubNubHTTPHeaders(["Key": "Value"])
     headers.update(name: "Key", value: "Other")
 
     XCTAssertEqual(headers.count, 1)
@@ -79,20 +79,20 @@ class HTTPHeadersTests: XCTestCase {
       HTTPHeader(name: "Key", value: "Value"),
       HTTPHeader(name: "Key", value: "NextValue")
     ]
-    let headers = HTTPHeaders(list)
+    let headers = PubNubHTTPHeaders(list)
 
     XCTAssertEqual(headers.allHTTPHeaderFields.count, 1)
     XCTAssertEqual(headers.allHTTPHeaderFields, ["Key": "NextValue"])
   }
 
   func testExpressibleByDictionary() {
-    let headers: HTTPHeaders = ["Key": "Value", "Key": "NextValue"]
+    let headers: PubNubHTTPHeaders = ["Key": "Value", "Key": "NextValue"]
 
     XCTAssertEqual(headers.allHTTPHeaderFields, ["Key": "NextValue"])
   }
 
   func testExpressibleByArray() {
-    let headers: HTTPHeaders = [
+    let headers: PubNubHTTPHeaders = [
       HTTPHeader(name: "Key", value: "Value"),
       HTTPHeader(name: "Key", value: "NextValue")
     ]
@@ -101,7 +101,7 @@ class HTTPHeadersTests: XCTestCase {
   }
 
   func testMakeIterator() {
-    let headers: HTTPHeaders = [
+    let headers: PubNubHTTPHeaders = [
       "Key": "Value",
       "OtherKey": "NextValue"
     ]

--- a/Tests/PubNubTests/Networking/RouterTests.swift
+++ b/Tests/PubNubTests/Networking/RouterTests.swift
@@ -54,7 +54,7 @@ class RouterTests: XCTestCase {
       }
     }
 
-    var additionalHeaders: HTTPHeaders = []
+    var additionalHeaders: PubNubHTTPHeaders = []
     var queryItems: Result<[URLQueryItem], Error> {
       return .success([])
     }


### PR DESCRIPTION
I renamed HttpHeaders to PubNubHttpHeaders because it conflicts with Alamofire's HttpHeaders naming.  I think many developers rely on Alamofire for Http requests so I think avoiding this issue is a crucial fix. 