### PR TITLE
Fixed a couple issues related to APNS2 payload publishing

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,9 +1,19 @@
 ---
 name: swift
 scm: github.com/pubnub/swift
-version: "2.3.0"
+version: "2.3.1"
 schema: 1
 changelog:
+  -
+    changes:
+      - test: "Added missing APNS2 pubnub config field to publish payload object"
+        type: bug
+      - test: "Fixed Coding issue when a scalar value is used for APNS2 publish payload object"
+        type: bug
+      - test: "Subscription will no long attempt to automatically reconnect after an unexpected disconnet"
+        type: bug
+    date: 2019-12-03
+    version: v2.3.1
   -
     changes:
       - test: "Added convenience objects for creating push publish messages"

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -6,6 +6,8 @@ schema: 1
 changelog:
   -
     changes:
+      - test: "Duplicate subscription will no longer start if a current subscription is connecting"
+        type: bug
       - test: "Added missing APNS2 pubnub config field to publish payload object"
         type: bug
       - test: "Fixed Coding issue when a scalar value is used for APNS2 publish payload object"

--- a/PubNub.xcodeproj/project.pbxproj
+++ b/PubNub.xcodeproj/project.pbxproj
@@ -1863,7 +1863,7 @@
 					"$(inherited)",
 					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
 				);
-				MARKETING_VERSION = 2.2.0;
+				MARKETING_VERSION = 2.3.1;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -1897,7 +1897,7 @@
 					"$(inherited)",
 					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
 				);
-				MARKETING_VERSION = 2.2.0;
+				MARKETING_VERSION = 2.3.1;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";

--- a/PubNubSwift.podspec
+++ b/PubNubSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'PubNubSwift'
-  s.version  = '2.3.0'
+  s.version  = '2.3.1'
   s.homepage = 'https://github.com/pubnub/swift'
   s.documentation_url = 'https://www.pubnub.com/docs/swift-native/pubnub-swift-sdk'
   s.authors = { 'PubNub, Inc.' => 'support@pubnub.com' }

--- a/Sources/PubNub/Helpers/AnyJSONType.swift
+++ b/Sources/PubNub/Helpers/AnyJSONType.swift
@@ -428,6 +428,29 @@ extension AnyJSONType: Hashable {
 // MARK: - AnyJSONType Collections
 
 extension AnyJSONType {
+  var isScalar: Bool {
+    switch self {
+    case .string:
+      return true
+    case .integer:
+      return true
+    case .double:
+      return true
+    case .boolean:
+      return true
+    case .null:
+      return true
+    case .array:
+      return false
+    case .dictionary:
+      return false
+    case .codable:
+      return false
+    case .unknown:
+      return true
+    }
+  }
+
   var rawArray: [AnyJSONType] {
     switch self {
     case let .array(arrayValue):

--- a/Sources/PubNub/Helpers/JSONCodable.swift
+++ b/Sources/PubNub/Helpers/JSONCodable.swift
@@ -46,6 +46,10 @@ extension JSONCodable {
     return AnyJSON(self)
   }
 
+  public var isScalar: Bool {
+    return codableValue.value.isScalar
+  }
+
   /// A `Result` that is either the underlying value as a JSON `String` or an error why it couldn't be created
   var jsonStringifyResult: Result<String, Error> {
     return codableValue.jsonStringifyResult

--- a/Sources/PubNub/Networking/Routers/PushRouter.swift
+++ b/Sources/PubNub/Networking/Routers/PushRouter.swift
@@ -253,11 +253,13 @@ struct ModifyPushResponseDecoder: ResponseDecoder {
 // MARK: - Response Body
 
 public struct ModifiedPushChannelsPayloadResponse: Codable {
+  /// Response message
   public let message: EndpointResponseMessage = .acknowledge
-
+  /// Channels that had push support added
   public let added: [String]
+  /// Channels that had push support removed
   public let removed: [String]
-
+  /// All channels that were modified
   public var channels: [String] {
     return added + removed
   }

--- a/Sources/PubNub/PubNub.swift
+++ b/Sources/PubNub/PubNub.swift
@@ -600,8 +600,8 @@ extension PubNub {
   /// All channels on which APNS push notification has been enabled using specified device token and topic.
   /// - Parameters:
   ///   - for: The device token used during registration
-  ///   - on: The topic of the device
-  ///   - environment: The environment to register the device
+  ///   - on: The topic of the remote notification (which is typically the bundle ID for your app)
+  ///   - environment: The APS environment to register the device
   ///   - with: Additional network configuration to use on the request
   ///   - respondOn: The queue the completion handler should be returned on
   ///   - completion: The async result of the method call
@@ -628,8 +628,8 @@ extension PubNub {
   ///   - byRemoving: The list of channels to remove the device registration from
   ///   - thenAdding: The list of channels to add the device registration to
   ///   - device: The device to add/remove from the channels
-  ///   - on: The topic of the device
-  ///   - environment: The environment to register the device
+  ///   - on: The topic of the remote notification (which is typically the bundle ID for your app)
+  ///   - environment: The APS environment to register the device
   ///   - with: Additional network configuration to use on the request
   ///   - respondOn: The queue the completion handler should be returned on
   ///   - completion: The async result of the method call
@@ -667,8 +667,8 @@ extension PubNub {
   /// Disable APNS push notifications from all channels which is registered with specified pushToken.
   /// - Parameters:
   ///   - for: The device token to remove from all channels
-  ///   - on: The topic of the device
-  ///   - environment: TThe environment to register the device
+  ///   - on: The topic of the remote notification (which is typically the bundle ID for your app)
+  ///   - environment: The APS environment to register the device
   ///   - with: Additional network configuration to use on the request
   ///   - respondOn: The queue the completion handler should be returned on
   ///   - completion: The async result of the method call

--- a/Sources/PubNub/Subscription/SubscriptionSession.swift
+++ b/Sources/PubNub/Subscription/SubscriptionSession.swift
@@ -294,7 +294,6 @@ public class SubscriptionSession {
             }
           } else {
             self?.connectionStatus = .disconnectedUnexpectedly
-            self?.reconnect(at: self?.previousTokenResponse?.timetoken)
           }
         }
       }

--- a/Sources/PubNub/Subscription/SubscriptionSession.swift
+++ b/Sources/PubNub/Subscription/SubscriptionSession.swift
@@ -130,7 +130,7 @@ public class SubscriptionSession {
       notify { $0.emitDidReceive(subscription: .subscriptionChanged(subscribeChange)) }
     }
 
-    if subscribeChange.didChange || connectionStatus != .connected {
+    if subscribeChange.didChange || !connectionStatus.isActive {
       reconnect(at: timetoken)
     }
   }

--- a/Tests/PubNubTests/Integration/PublishEndpointIntegrationTests.swift
+++ b/Tests/PubNubTests/Integration/PublishEndpointIntegrationTests.swift
@@ -140,4 +140,40 @@ class PublishEndpointIntegrationTests: XCTestCase {
 
     wait(for: [publishExpect], timeout: 10.0)
   }
+
+  func testPublishPushPayload() {
+    let publishExpect = expectation(description: "Publish Response")
+
+    // Instantiate PubNub
+    let configuration = PubNubConfiguration(from: testsBundle)
+    let client = PubNub(configuration: configuration)
+
+    let pushMessage = PubNubPushMessage(
+      apns: PubNubAPNSPayload(
+        aps: APSPayload(alert: .object(.init(title: "Apple Message")), badge: 1, sound: .string("default")),
+        pubnub: [.init(targets: [.init(topic: "com.pubnub.swift", environment: .production)], collapseID: "SwiftSDK")],
+        payload: "Push Message from PubNub Swift SDK"
+      ),
+      fcm: PubNubFCMPayload(
+        payload: "Push Message from PubNub Swift SDK",
+        target: .topic("com.pubnub.swift"),
+        notification: FCMNotificationPayload(title: "Android Message"),
+        android: FCMAndroidPayload(collapseKey: "SwiftSDK", notification: FCMAndroidNotification(sound: "default"))
+      ),
+      additional: "Push Message from PubNub Swift SDK"
+    )
+
+    // Publish a simple message to the demo_tutorial channel
+    client.publish(channel: "SwiftITest", message: pushMessage) { result in
+      switch result {
+      case .success:
+        break
+      case let .failure(error):
+        XCTFail("Failed due to error: \(error)")
+      }
+      publishExpect.fulfill()
+    }
+
+    wait(for: [publishExpect], timeout: 10.0)
+  }
 }


### PR DESCRIPTION
Proposed 2.3.1 release includes the following:
- Server team updated the PubNub Push Config to include an additional field.
- Fixed an issue if a scalar value was published inside the push payload. I followed the Android structure of adding 'data' as the key
- Updated some of the push doc headers to provide more clarity in their usage
- Fixed an issue with subscribe continuously trying to reconnect to the loop in the even of an unexpected disconnect.  Short term solution is to manually reconnect, but an automatic solution should be added.