### PR TITLE
PubNub SDK 2.4.2 Release

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,9 +1,14 @@
 ---
 name: swift
 scm: github.com/pubnub/swift
-version: "2.4.1"
+version: "2.4.2"
 schema: 1
 changelog:
+  - changes:
+    - text: "Make `region` optional during `originTimetoken` parsing and set to 0 by default"
+      type: bug
+    date: 2020-03-12
+    version: v2.4.2
   - changes:
     - text: "A `reconnecting` event will be emitted once subscription starts retrying"
       type: bug

--- a/PubNubSwift.podspec
+++ b/PubNubSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'PubNubSwift'
-  s.version  = '2.4.1'
+  s.version  = '2.4.2'
   s.homepage = 'https://github.com/pubnub/swift'
   s.documentation_url = 'https://www.pubnub.com/docs/swift-native/pubnub-swift-sdk'
   s.authors = { 'PubNub, Inc.' => 'support@pubnub.com' }


### PR DESCRIPTION
## 🐛: fix `originTimetoken` parsing

Make `region` optional during `originTimetoken` parsing and set to **0** by default.