### PR TITLE
Wrapper to associate userId with MessageActionEvent

### DIFF
--- a/Sources/PubNub/Events/Subscription/MessageActionEvents.swift
+++ b/Sources/PubNub/Events/Subscription/MessageActionEvents.swift
@@ -30,14 +30,14 @@ import Foundation
 /// The type of action the Message Action event represents
 public enum MessageActionEvents {
   /// The Message Action was added to a message
-  case added(MessageActionEvent)
+  case added(MessageActionIdentifiable)
   /// The Message Action was removed from a message
-  case removed(MessageActionEvent)
+  case removed(MessageActionIdentifiable)
 }
 
 extension MessageActionEvents {
   /// The underlying Message Action associated value
-  public var associatedValue: MessageActionEvent {
+  public var associatedValue: MessageActionIdentifiable {
     switch self {
     case let .added(event):
       return event

--- a/Sources/PubNub/Events/Subscription/SubscriptionStream.swift
+++ b/Sources/PubNub/Events/Subscription/SubscriptionStream.swift
@@ -72,9 +72,9 @@ public enum SubscriptionEvent {
   /// A Membership object has been deleted
   case membershipDeleted(MembershipIdentifiable)
   /// A MessageAction was added to a published message
-  case messageActionAdded(MessageActionEvent)
+  case messageActionAdded(MessageActionIdentifiable)
   /// A MessageAction was removed from a published message
-  case messageActionRemoved(MessageActionEvent)
+  case messageActionRemoved(MessageActionIdentifiable)
   /// A subscription error has occurred
   case subscribeError(PubNubError)
 

--- a/Sources/PubNub/Networking/Routers/SubscribeRouter.swift
+++ b/Sources/PubNub/Networking/Routers/SubscribeRouter.swift
@@ -617,6 +617,16 @@ public struct MessageActionEvent: Codable, Hashable {
   }
 }
 
+public struct MessageActionIdentifiable {
+  public let userId: String
+  public let event: MessageActionEvent
+
+  public init(userId: String, event: MessageActionEvent) {
+    self.userId = userId
+    self.event = event
+  }
+}
+
 // MARK: Presence Response
 
 public struct PresenceResponse: Codable, Hashable {

--- a/Sources/PubNub/Subscription/SubscriptionSession.swift
+++ b/Sources/PubNub/Subscription/SubscriptionSession.swift
@@ -293,9 +293,11 @@ public class SubscriptionSession {
             case let .messageAction(action):
               switch action.payload.event {
               case .added:
-                self?.notify { $0.emitDidReceive(subscription: .messageActionAdded(action.payload.data)) }
+                self?.notify { $0.emitDidReceive(subscription:
+                    .messageActionAdded(MessageActionIdentifiable(userId: action.issuer ?? "", event: action.payload.data))) }
               case .removed:
-                self?.notify { $0.emitDidReceive(subscription: .messageActionRemoved(action.payload.data)) }
+                self?.notify { $0.emitDidReceive(subscription:
+                    .messageActionRemoved(MessageActionIdentifiable(userId: action.issuer ?? "", event: action.payload.data))) }
               }
             }
           }

--- a/Tests/PubNubTests/Networking/Routers/SubscribeRouterTests.swift
+++ b/Tests/PubNubTests/Networking/Routers/SubscribeRouterTests.swift
@@ -626,7 +626,7 @@ extension SubscribeRouterTests {
           statusExpect.fulfill()
         }
       case let .messageActionAdded(action):
-        XCTAssertEqual(action, self?.testAction)
+        XCTAssertEqual(action.event, self?.testAction)
         actionExpect.fulfill()
       case let .subscriptionChanged(change):
         switch change {
@@ -642,7 +642,7 @@ extension SubscribeRouterTests {
     listener.didReceiveMessageAction = { [weak self] event in
       switch event {
       case let .added(action):
-        XCTAssertEqual(action, self?.testAction)
+        XCTAssertEqual(action.event, self?.testAction)
 
         subscription.unsubscribeAll()
 
@@ -682,7 +682,7 @@ extension SubscribeRouterTests {
           statusExpect.fulfill()
         }
       case let .messageActionRemoved(action):
-        XCTAssertEqual(action, self?.testAction)
+        XCTAssertEqual(action.event, self?.testAction)
         actionExpect.fulfill()
       case let .subscriptionChanged(change):
         switch change {
@@ -698,7 +698,7 @@ extension SubscribeRouterTests {
     listener.didReceiveMessageAction = { [weak self] event in
       switch event {
       case let .removed(action):
-        XCTAssertEqual(action, self?.testAction)
+        XCTAssertEqual(action.event, self?.testAction)
 
         subscription.unsubscribeAll()
 


### PR DESCRIPTION
Message actions loaded from history contain a uuid to identify the user. This is an important piece of information useful for either displaying who reacted to a message or showing a selected state if the current user reacted.

This user id is missing from the message action event when received from a subscription. This means it's impossible to identify who the action belongs to. This pull request adds a wrapper called 'MessageActionIdentifiable' that includes the user id along with the event.

@CraigLn