### PR TITLE
MessageActionEvent improvement to expose the full message response

### DIFF
--- a/Sources/PubNub/Networking/Routers/SubscribeRouter.swift
+++ b/Sources/PubNub/Networking/Routers/SubscribeRouter.swift
@@ -583,15 +583,17 @@ public struct MessageActionSubscribePayload: Codable, Hashable {
   let source: String
   let version: String
   let event: MessageActionEventType
-  public let data: MessageActionEvent
+  public let data: MessageActionEventPayload
 }
+
+public typealias MessageActionEvent = MessageResponse<MessageActionSubscribePayload>
 
 enum MessageActionEventType: String, Codable, Hashable {
   case added
   case removed
 }
 
-public struct MessageActionEvent: Codable, Hashable {
+public struct MessageActionEventPayload: Codable, Hashable {
   public let type: String
   public let value: String
   public let actionTimetoken: Timetoken

--- a/Sources/PubNub/Subscription/SubscriptionSession.swift
+++ b/Sources/PubNub/Subscription/SubscriptionSession.swift
@@ -293,9 +293,9 @@ public class SubscriptionSession {
             case let .messageAction(action):
               switch action.payload.event {
               case .added:
-                self?.notify { $0.emitDidReceive(subscription: .messageActionAdded(action.payload.data)) }
+                self?.notify { $0.emitDidReceive(subscription: .messageActionAdded(action)) }
               case .removed:
-                self?.notify { $0.emitDidReceive(subscription: .messageActionRemoved(action.payload.data)) }
+                self?.notify { $0.emitDidReceive(subscription: .messageActionRemoved(action)) }
               }
             }
           }

--- a/Tests/PubNubTests/Networking/Routers/SubscribeRouterTests.swift
+++ b/Tests/PubNubTests/Networking/Routers/SubscribeRouterTests.swift
@@ -32,7 +32,7 @@ final class SubscribeRouterTests: XCTestCase {
   let config = PubNubConfiguration(publishKey: "FakeTestString", subscribeKey: "FakeTestString")
   let testChannel = "TestChannel"
 
-  let testAction = MessageActionEvent(type: "reaction", value: "winky_face",
+  let testAction = MessageActionEventPayload(type: "reaction", value: "winky_face",
                                       actionTimetoken: 15_725_459_793_173_220, messageTimetoken: 15_725_459_448_096_144)
 
   // MARK: - Endpoint Tests
@@ -626,7 +626,7 @@ extension SubscribeRouterTests {
           statusExpect.fulfill()
         }
       case let .messageActionAdded(action):
-        XCTAssertEqual(action, self?.testAction)
+        XCTAssertEqual(action.payload.data, self?.testAction)
         actionExpect.fulfill()
       case let .subscriptionChanged(change):
         switch change {
@@ -642,7 +642,7 @@ extension SubscribeRouterTests {
     listener.didReceiveMessageAction = { [weak self] event in
       switch event {
       case let .added(action):
-        XCTAssertEqual(action, self?.testAction)
+        XCTAssertEqual(action.payload.data, self?.testAction)
 
         subscription.unsubscribeAll()
 
@@ -682,7 +682,7 @@ extension SubscribeRouterTests {
           statusExpect.fulfill()
         }
       case let .messageActionRemoved(action):
-        XCTAssertEqual(action, self?.testAction)
+        XCTAssertEqual(action.payload.data, self?.testAction)
         actionExpect.fulfill()
       case let .subscriptionChanged(change):
         switch change {
@@ -698,7 +698,7 @@ extension SubscribeRouterTests {
     listener.didReceiveMessageAction = { [weak self] event in
       switch event {
       case let .removed(action):
-        XCTAssertEqual(action, self?.testAction)
+        XCTAssertEqual(action.payload.data, self?.testAction)
 
         subscription.unsubscribeAll()
 


### PR DESCRIPTION
Message actions loaded from history contain a uuid to identify the user. This is an important piece of information useful for either displaying who reacted to a message or showing a selected state if the current user reacted.

This user id is missing from the message action event when received from a subscription. This means it's impossible to identify who the action belongs to. There is also no way to know which channel the message action belongs to.

This pull request exposes the full message response instead of only the 'payload'. MessageActionEvent is now a typealias for MessageResponse<MessageActionSubscribePayload>. To get the MessageActionEventPayload simply use event.payload.data.

@CraigLn