### PR TITLE
Add PAM authKey to listChannels(for: channelGroup)

### DIFF
--- a/Sources/PubNub/Networking/Routers/ChannelGroupsRouter.swift
+++ b/Sources/PubNub/Networking/Routers/ChannelGroupsRouter.swift
@@ -1,4 +1,4 @@
-//
+c//
 //  ChannelGroups.swift
 //
 //  PubNub Real-time Cloud-Hosted Push API and Push Notification Client Frameworks
@@ -108,7 +108,7 @@ struct ChannelGroupsRouter: HTTPRouter {
   var pamVersion: PAMVersionRequirement {
     switch endpoint {
     case .channelsForGroup:
-      return .none
+      return .version2
     case .channelGroups:
       return .none
     default:


### PR DESCRIPTION
Fixed: If PAM is turned on, `listChannels(for: channelGroup)` returns a 403 because it doesn't include the authToken in the underlying HTTP get.