### PR TITLE
Use randomized IV by default

### DIFF
--- a/Sources/PubNub/Helpers/Crypto/Crypto.swift
+++ b/Sources/PubNub/Helpers/Crypto/Crypto.swift
@@ -55,7 +55,7 @@ public struct Crypto: Hashable {
     }
   }
 
-  public init(key data: Data, cipher: Cipher = .aes, withRandomIV: Bool = false, encoding: String.Encoding = .utf8) {
+  public init(key data: Data, cipher: Cipher = .aes, withRandomIV: Bool = true, encoding: String.Encoding = .utf8) {
     key = data
     self.cipher = cipher
     defaultStringEncoding = encoding
@@ -79,7 +79,7 @@ public struct Crypto: Hashable {
   public init?(
     key: String,
     cipher: Cipher = .aes,
-    withRandomIV: Bool = false,
+    withRandomIV: Bool = true,
     encoding: String.Encoding = .utf8
   ) {
     guard let data = key.data(using: encoding), let keyData = SHA256.hash(data: data) else {

--- a/Tests/PubNubTests/Helpers/CryptoTests.swift
+++ b/Tests/PubNubTests/Helpers/CryptoTests.swift
@@ -76,9 +76,31 @@ class CryptoTests: XCTestCase {
     let decryptedString = String(bytes: decryptedData, encoding: .utf8)?.reverseJSONDescription
     XCTAssertEqual(testMessage, decryptedString)
   }
+    
+  func testRandomizedIVEncryptDecrypt() {
+    let testMessage = "Test Message To Be Encrypted"
+    guard let crypto = Crypto(key: "MyCoolCipherKey", withRandomIV: true) else {
+      return XCTFail("Could not create crypto instance")
+    }
+    guard let encryptedString1 = try? crypto.encrypt(plaintext: testMessage).get() else {
+      return XCTFail("Encrypted Data should not be nil")
+    }
+    guard let encryptedString2 = try? crypto.encrypt(plaintext: testMessage).get() else {
+      return XCTFail("Encrypted Data should not be nil")
+    }
+    guard let decryptedString1 = try? crypto.decrypt(base64Encoded: encryptedString1).get() else {
+      return XCTFail("Decrypted Data should not be nil")
+    }
+    guard let decryptedString2 = try? crypto.decrypt(base64Encoded: encryptedString2).get() else {
+      return XCTFail("Decrypted Data should not be nil")
+    }
+    XCTAssertNotEqual(encryptedString1, encryptedString2)
+    XCTAssertEqual(decryptedString1, decryptedString2)
+    XCTAssertEqual(testMessage, decryptedString1)
+  }
 
   func testOtherSDKContractTest() {
-    guard let crypto = Crypto(key: "MyCoolCipherKey") else {
+    guard let crypto = Crypto(key: "MyCoolCipherKey", withRandomIV: false) else {
       return XCTFail("Could not create crypto instance")
     }
 

--- a/Tests/PubNubTests/Helpers/CryptoTests.swift
+++ b/Tests/PubNubTests/Helpers/CryptoTests.swift
@@ -77,9 +77,9 @@ class CryptoTests: XCTestCase {
     XCTAssertEqual(testMessage, decryptedString)
   }
     
-  func testRandomizedIVEncryptDecrypt() {
+  func testDefaultRandomizedIVEncryptDecrypt() {
     let testMessage = "Test Message To Be Encrypted"
-    guard let crypto = Crypto(key: "MyCoolCipherKey", withRandomIV: true) else {
+    guard let crypto = Crypto(key: "MyCoolCipherKey") else {
       return XCTFail("Could not create crypto instance")
     }
     guard let encryptedString1 = try? crypto.encrypt(plaintext: testMessage).get() else {

--- a/Tests/PubNubTests/Networking/Routers/HistoryRouterTests.swift
+++ b/Tests/PubNubTests/Networking/Routers/HistoryRouterTests.swift
@@ -163,7 +163,7 @@ extension HistoryRouterTests {
     }
 
     var configWithCipher = config
-    configWithCipher.cipherKey = Crypto(key: "SomeTestString")
+    configWithCipher.cipherKey = Crypto(key: "SomeTestString", withRandomIV: false)
 
     PubNub(configuration: configWithCipher, session: sessions.session)
       .fetchMessageHistory(for: testMultiChannels) { result in
@@ -190,7 +190,7 @@ extension HistoryRouterTests {
     }
 
     var configWithCipher = config
-    configWithCipher.cipherKey = Crypto(key: "NotTheRightKey")
+    configWithCipher.cipherKey = Crypto(key: "NotTheRightKey", withRandomIV: false)
 
     PubNub(configuration: configWithCipher, session: sessions.session)
       .fetchMessageHistory(for: testMultiChannels) { result in
@@ -218,7 +218,7 @@ extension HistoryRouterTests {
     }
 
     var configWithCipher = config
-    configWithCipher.cipherKey = Crypto(key: "SomeTestString")
+    configWithCipher.cipherKey = Crypto(key: "SomeTestString", withRandomIV: false)
 
     PubNub(configuration: configWithCipher, session: sessions.session)
       .fetchMessageHistory(for: testMultiChannels) { result in


### PR DESCRIPTION
## _Crypto_: use randomized IV by default

Crypto by default initialized with `randomizeIV` set to `true` which will encrypt / decrypt data with publish / subscribe / history API calls using randomized initialization vector.

**Warning:** This PR contains **BREAKING CHANGES** which affects how messages are sent with enabled encryption. Randomized IV used by default will make old data inaccessible w/o explicit switch to static IV usage.