### PR TITLE
Custom error messages (from functions) will be included inside PubNubError

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -5,6 +5,8 @@ version: "3.1.3"
 schema: 1
 changelog:
   - changes:
+    - text: "Custom error messages (from functions) will be included inside PubNub Error Details"
+      type: enchancement
     - text: "Fix Coding issue when setting UUIDMetadata objects"
       type: bug
     date: 2021-5-28

--- a/Sources/PubNub/Networking/Response/GenericServicePayloadResponse.swift
+++ b/Sources/PubNub/Networking/Response/GenericServicePayloadResponse.swift
@@ -207,6 +207,15 @@ enum EndpointResponseMessage: RawRepresentable, Codable, Hashable, ExpressibleBy
   init(stringLiteral value: String) {
     self.init(rawValue: value)
   }
+
+  var unknownMessage: String? {
+    switch self {
+    case let .unknown(message):
+      return message
+    default:
+      return nil
+    }
+  }
 }
 
 struct GenericServicePayloadResponse: Codable, Hashable {
@@ -273,6 +282,9 @@ struct GenericServicePayloadResponse: Codable, Hashable {
       service = try container.decodeIfPresent(String.self, forKey: .service)
       error = nil
       isError = try container.decodeIfPresent(Bool.self, forKey: .error) ?? false
+      if let unknownMessage = message?.unknownMessage {
+        details = [ErrorDetail(message: unknownMessage, location: "Unknown", locationType: "Unknown")]
+      }
     }
 
     let status = try container.decodeIfPresent(Int.self, forKey: .status)


### PR DESCRIPTION
This is a minor patch fix to include a custom error message (from Functions) inside the error payload.  

Example usage would be a function aborts a request with a custom message:
```
export default (request) => {
    request.status = 400
    return request.abort('Message dropped')
};
```

The resulting error can be filtered using:
```  
pubnub.publish(channel: "shouldFail", message: payload) { result in
  switch result {
  case let .success(response):
    print("Successful Publish Response: \(response)")
  case let .failure(error as PubNubError):
    if error.reason == .badRequest && error.details.contains("Message dropped") {
      print("Publish Rejected from Function: \(error)")
    } else {
      print("Failed Publish Response: \(error)")
    }
  case let .failure(error):
    print("Failed Publish Response: \(error)")
  }
}
```