### PR TITLE
PubNub SDK 4.0.0 Release

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,9 +1,16 @@
 ---
 name: swift
 scm: github.com/pubnub/swift
-version: "3.1.3"
+version: "4.0.0"
 schema: 1
 changelog:
+  - changes:
+    - text: "Crypto by default initialized with `randomizeIV` set to `true` which will encrypt / decrypt data with publish / subscribe / history API calls using randomized initialization vector"
+      type: feature
+    - text: "Add new `sdks` section to `.pubnub.yml` with information about available artifacts and distribution variants"
+      type: improvement
+    date: 2021-06-08
+    version: v4.0.0
   - changes:
     - text: "Custom error messages (from functions) will be included inside PubNub Error Details"
       type: improvement

--- a/PubNub.xcodeproj/project.pbxproj
+++ b/PubNub.xcodeproj/project.pbxproj
@@ -2096,7 +2096,7 @@
 					"$(inherited)",
 					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
 				);
-				MARKETING_VERSION = 3.1.3;
+				MARKETING_VERSION = 4.0.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -2129,7 +2129,7 @@
 					"$(inherited)",
 					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
 				);
-				MARKETING_VERSION = 3.1.3;
+				MARKETING_VERSION = 4.0.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";

--- a/PubNubSwift.podspec
+++ b/PubNubSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'PubNubSwift'
-  s.version  = '3.1.3'
+  s.version  = '4.0.0'
   s.homepage = 'https://github.com/pubnub/swift'
   s.documentation_url = 'https://www.pubnub.com/docs/swift-native/pubnub-swift-sdk'
   s.authors = { 'PubNub, Inc.' => 'support@pubnub.com' }


### PR DESCRIPTION
## ⭐️ _Crypto_: use randomized IV by default

Crypto by default initialized with `randomizeIV` set to `true` which will encrypt / decrypt data with publish / subscribe / history API calls using randomized initialization vector.

## _Docs_: add 'sdks' section to .pubnub.yml

Add new `sdks` section to `.pubnub.yml` with information about available artifacts and distribution variants.