### PR TITLE
Don't convert FCM token to HEX

### DIFF
--- a/Sources/PubNub/Errors/ErrorDescription.swift
+++ b/Sources/PubNub/Errors/ErrorDescription.swift
@@ -115,6 +115,10 @@ extension ErrorDescription {
     "Device Token is an empty `Data`"
   }()
 
+  static let malformedDeviceTokenData: String = {
+    "Device Token `Data` cannot be converted to `String`"
+  }()
+
   static let emptyUUIDMetadataId: String = {
     "The UUID MetadataId `String` cannot be empty"
   }()

--- a/Tests/PubNubTests/Networking/Routers/PushRouterTests.swift
+++ b/Tests/PubNubTests/Networking/Routers/PushRouterTests.swift
@@ -40,6 +40,28 @@ final class PushRouterTests: XCTestCase {
 // MARK: - List Push Channels
 
 extension PushRouterTests {
+  func testListFCMPushProvisions_Router() {
+    let data = "A1b2".data(using: .utf8)!
+    let router = PushRouter(.listPushChannels(pushToken: data, pushType: .gcm), configuration: config)
+
+    XCTAssertEqual(router.endpoint.description, "List Push Channels")
+    XCTAssertEqual(router.endpoint.pushToken, "A1b2")
+    XCTAssertEqual(router.category, "List Push Channels")
+    XCTAssertEqual(router.service, .push)
+  }
+  
+  func testListFCMPushProvisions_Router_TokenError() {
+    guard let data = Data(hexEncodedString: "A1b2") else {
+      return XCTFail("Could not encode Data from hex string")
+    }
+    let router = PushRouter(.listPushChannels(pushToken: data, pushType: .gcm), configuration: config)
+
+    XCTAssertEqual(router.endpoint.description, "List Push Channels")
+    XCTAssertEqual(router.category, "List Push Channels")
+    XCTAssertNil(router.endpoint.pushToken)
+    XCTAssertEqual(router.service, .push)
+  }
+
   func testListPushProvisions_Router() {
     guard let data = Data(hexEncodedString: "A1B2") else {
       return XCTFail("Could not encode Data from hex string")


### PR DESCRIPTION
## 🐛 _push_: don't convert FCM token to HEX
Don't perform HEX-encoding of `Data` with FCM token which should be used as-is.