### PR TITLE
PubNub SDK 4.1.0

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,9 +1,22 @@
 ---
 name: swift
 scm: github.com/pubnub/swift
-version: "4.0.2"
+version: "4.1.0"
 schema: 1
 changelog:
+  - date: 2021-09-16
+    version: 4.1.0
+    changes:
+      - type: feature
+        text: "Add ability to parse permissions from token provided by servers."
+      - type: feature
+        text: "Make it possible to add component identifiers for requests."
+      - type: bug
+        text: "Fix `bufferTooSmall` and make temporary buffers for files encryption / decryption adaptive in size to provided stream buffer size."
+      - type: bug
+        text: "Don't perform HEX-encoding of `Data` with FCM token which should be used as-is."
+      - type: improvement
+        text: "Use `token` instead of `authKey` (if specified) for query `auth`."
   - date: 2021-09-16
     version: 4.1.0
     changes:

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -4,6 +4,19 @@ scm: github.com/pubnub/swift
 version: "4.0.2"
 schema: 1
 changelog:
+  - date: 2021-09-16
+    version: 4.1.0
+    changes:
+      - type: feature
+        text: "Add ability to parse permissions from token provided by servers."
+      - type: feature
+        text: "Make it possible to add component identifiers for requests."
+      - type: bug
+        text: "Fix `bufferTooSmall` and make temporary buffers for files encryption / decryption adaptive in size to provided stream buffer size."
+      - type: bug
+        text: "Don't perform HEX-encoding of `Data` with FCM token which should be used as-is."
+      - type: improvement
+        text: "Use `token` instead of `authKey` (if specified) for query `auth`."
   - changes:
     - text: "Memory leaks with captured request in subscription loop."
       type: bug

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -17,19 +17,6 @@ changelog:
         text: "Don't perform HEX-encoding of `Data` with FCM token which should be used as-is."
       - type: improvement
         text: "Use `token` instead of `authKey` (if specified) for query `auth`."
-  - date: 2021-09-16
-    version: 4.1.0
-    changes:
-      - type: feature
-        text: "Add ability to parse permissions from token provided by servers."
-      - type: feature
-        text: "Make it possible to add component identifiers for requests."
-      - type: bug
-        text: "Fix `bufferTooSmall` and make temporary buffers for files encryption / decryption adaptive in size to provided stream buffer size."
-      - type: bug
-        text: "Don't perform HEX-encoding of `Data` with FCM token which should be used as-is."
-      - type: improvement
-        text: "Use `token` instead of `authKey` (if specified) for query `auth`."
   - changes:
     - text: "Memory leaks with captured request in subscription loop."
       type: bug

--- a/PubNub.xcodeproj/project.pbxproj
+++ b/PubNub.xcodeproj/project.pbxproj
@@ -2096,7 +2096,7 @@
 					"$(inherited)",
 					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
 				);
-				MARKETING_VERSION = 4.0.2;
+				MARKETING_VERSION = 4.1.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -2129,7 +2129,7 @@
 					"$(inherited)",
 					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
 				);
-				MARKETING_VERSION = 4.0.2;
+				MARKETING_VERSION = 4.1.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";

--- a/PubNubSwift.podspec
+++ b/PubNubSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'PubNubSwift'
-  s.version  = '4.0.2'
+  s.version  = '4.1.0'
   s.homepage = 'https://github.com/pubnub/swift'
   s.documentation_url = 'https://www.pubnub.com/docs/swift-native/pubnub-swift-sdk'
   s.authors = { 'PubNub, Inc.' => 'support@pubnub.com' }

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ PubNub takes care of the infrastructure and APIs needed for the realtime communi
 
 ## Requirements
 
-* iOS 8.0+ / macOS 10.10+ / Mac Catalyst 13.0+ / tvOS 9.0+ / watchOS 2.0+
+* iOS 9.0+ / macOS 10.11+ / Mac Catalyst 13.0+ / tvOS 9.0+ / watchOS 2.0+
 * Xcode 11+
 * Swift 5+
 

--- a/Sources/PubNub/Helpers/Constants.swift
+++ b/Sources/PubNub/Helpers/Constants.swift
@@ -62,7 +62,7 @@ public struct Constant {
   }()
 
   static let pubnubSwiftSDKVersion: String = {
-    "4.0.2"
+    "4.1.0"
   }()
 
   static let appBundleId: String = {


### PR DESCRIPTION
feat(pam): add token parse

Add ability to parse permissions from token provided by servers.

refactor(pam): token has higher priority for 'auth'

Use `token` instead of `authKey` (if specified) for query `auth`.

fix(files): fix files encryption / decryption

Fix `bufferTooSmall` and make temporary buffers for files encryption / decryption adaptive in size to provided stream buffer size.

fix(push): don't convert FCM token to HEX

Don't perform HEX-encoding of `Data` with FCM token which should be used as-is.

feat: add support for components

Make it possible to add component identifiers for requests.