### PR TITLE
Make 'name' field optional

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,9 +1,14 @@
 ---
 name: swift
 scm: github.com/pubnub/swift
-version: "4.1.1"
+version: "4.1.2"
 schema: 1
 changelog:
+  - date: 2021-11-08
+    version: 4.1.2
+    changes:
+      - type: bug
+        text: "Make `name` field optional for channel and UUID metadata."
   - date: 2021-11-05
     version: 4.1.1
     changes:
@@ -424,7 +429,7 @@ sdks:
           - distribution-type: source
             distribution-repository: GitHub release
             package-name: PubNub
-            location: https://github.com/pubnub/swift/archive/refs/tags/4.1.1.zip
+            location: https://github.com/pubnub/swift/archive/refs/tags/4.1.2.zip
             supported-platforms:
               supported-operating-systems:
                 macOS:

--- a/PubNub.xcodeproj/project.pbxproj
+++ b/PubNub.xcodeproj/project.pbxproj
@@ -2514,7 +2514,7 @@
 					"$(inherited)",
 					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
 				);
-				MARKETING_VERSION = 4.1.1;
+				MARKETING_VERSION = 4.1.2;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -2547,7 +2547,7 @@
 					"$(inherited)",
 					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
 				);
-				MARKETING_VERSION = 4.1.1;
+				MARKETING_VERSION = 4.1.2;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";

--- a/PubNubSwift.podspec
+++ b/PubNubSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'PubNubSwift'
-  s.version  = '4.1.1'
+  s.version  = '4.1.2'
   s.homepage = 'https://github.com/pubnub/swift'
   s.documentation_url = 'https://www.pubnub.com/docs/swift-native/pubnub-swift-sdk'
   s.authors = { 'PubNub, Inc.' => 'support@pubnub.com' }

--- a/Sources/PubNub/Helpers/Constants.swift
+++ b/Sources/PubNub/Helpers/Constants.swift
@@ -62,7 +62,7 @@ public struct Constant {
   }()
 
   static let pubnubSwiftSDKVersion: String = {
-    "4.1.1"
+    "4.1.2"
   }()
 
   static let appBundleId: String = {

--- a/Sources/PubNub/Models/PubNubChannelMetadata.swift
+++ b/Sources/PubNub/Models/PubNubChannelMetadata.swift
@@ -34,7 +34,7 @@ public protocol PubNubChannelMetadata {
   /// The unique identifier of the Channel
   var metadataId: String { get }
   /// The name of the Channel
-  var name: String { get set }
+  var name: String? { get set }
   /// Text describing the purpose of the channel
   var channelDescription: String? { get set }
   /// The last updated timestamp for the object
@@ -75,7 +75,7 @@ extension PubNubChannelMetadata {
 /// The default implementation of the `PubNubChannelMetadata` protocol
 public struct PubNubChannelMetadataBase: PubNubChannelMetadata, Hashable {
   public let metadataId: String
-  public var name: String
+  public var name: String?
   public var channelDescription: String?
 
   public var updated: Date?
@@ -89,7 +89,7 @@ public struct PubNubChannelMetadataBase: PubNubChannelMetadata, Hashable {
 
   public init(
     metadataId: String = UUID().uuidString,
-    name: String,
+    name: String? = nil,
     channelDescription: String? = nil,
     custom concreteCustom: [String: JSONCodableScalar]? = nil,
     updated: Date? = nil,

--- a/Sources/PubNub/Models/PubNubUUIDMetadata.swift
+++ b/Sources/PubNub/Models/PubNubUUIDMetadata.swift
@@ -34,7 +34,7 @@ public protocol PubNubUUIDMetadata {
   /// The unique identifier of the UUID
   var metadataId: String { get }
   /// The name of the UUID
-  var name: String { get set }
+  var name: String? { get set }
   /// The external identifier for the object
   var externalId: String? { get set }
   /// The profile URL for the object
@@ -79,7 +79,7 @@ extension PubNubUUIDMetadata {
 /// The default implementation of the `PubNubUUIDMetadata` protocol
 public struct PubNubUUIDMetadataBase: PubNubUUIDMetadata, Hashable {
   public let metadataId: String
-  public var name: String
+  public var name: String?
   public var externalId: String?
   public var profileURL: String?
   public var email: String?
@@ -94,7 +94,7 @@ public struct PubNubUUIDMetadataBase: PubNubUUIDMetadata, Hashable {
 
   public init(
     metadataId: String = UUID().uuidString,
-    name: String,
+    name: String? = nil,
     externalId: String? = nil,
     profileURL: String? = nil,
     email: String? = nil,

--- a/Sources/PubNub/Networking/Routers/ObjectsChannelRouter.swift
+++ b/Sources/PubNub/Networking/Routers/ObjectsChannelRouter.swift
@@ -52,7 +52,7 @@ struct ObjectsChannelRouter: HTTPRouter {
 
   // Custom request body object for .set endpoint
   struct SetChannelMetadataRequestBody: JSONCodable {
-    var name: String
+    var name: String?
     var description: String?
     var custom: [String: JSONCodableScalarType]?
   }
@@ -156,8 +156,7 @@ struct ObjectsChannelRouter: HTTPRouter {
       return isInvalidForReason((metadataId.isEmpty, ErrorDescription.emptyChannelMetadataId))
     case let .set(metadata, _):
       return isInvalidForReason(
-        (metadata.metadataId.isEmpty && metadata.name.isEmpty,
-         ErrorDescription.invalidChannelMetadata))
+        (metadata.metadataId.isEmpty, ErrorDescription.invalidChannelMetadata))
     case let .remove(metadataId):
       return isInvalidForReason((metadataId.isEmpty, ErrorDescription.emptyChannelMetadataId))
     }

--- a/Sources/PubNub/Networking/Routers/ObjectsMembershipsRouter.swift
+++ b/Sources/PubNub/Networking/Routers/ObjectsMembershipsRouter.swift
@@ -362,13 +362,9 @@ struct ObjectMetadataPartial: Codable {
     } else if let uuid = try? container.decodeIfPresent(PubNubUUIDMetadataBase.self, forKey: .uuid) {
       self.uuid = .init(metadataId: uuid.metadataId, metadataObject: uuid)
       channel = nil
-    } else if let nestedContainer = try? container.nestedContainer(keyedBy: NestedCodingKeys.self, forKey: .channel) {
-      channel = .init(metadataId: try nestedContainer.decode(String.self, forKey: .id), metadataObject: nil)
-      uuid = nil
     } else {
-      let nestedContainer = try container.nestedContainer(keyedBy: NestedCodingKeys.self, forKey: .uuid)
-      uuid = .init(metadataId: try nestedContainer.decode(String.self, forKey: .id), metadataObject: nil)
       channel = nil
+      uuid = nil
     }
   }
 

--- a/Sources/PubNub/Networking/Routers/ObjectsUUIDRouter.swift
+++ b/Sources/PubNub/Networking/Routers/ObjectsUUIDRouter.swift
@@ -52,7 +52,7 @@ struct ObjectsUUIDRouter: HTTPRouter {
 
   // Custom request body object for .set endpoint
   struct SetUUIDMetadataRequestBody: JSONCodable {
-    var name: String
+    var name: String?
     var externalId: String?
     var profileURL: String?
     var email: String?
@@ -167,7 +167,7 @@ struct ObjectsUUIDRouter: HTTPRouter {
       return isInvalidForReason((metadataId.isEmpty, ErrorDescription.emptyUUIDMetadataId))
     case let .set(metadata, _):
       return isInvalidForReason(
-        (metadata.metadataId.isEmpty && metadata.name.isEmpty, ErrorDescription.invalidUUIDMetadata))
+        (metadata.metadataId.isEmpty, ErrorDescription.invalidUUIDMetadata))
     case let .remove(metadataId):
       return isInvalidForReason((metadataId.isEmpty, ErrorDescription.emptyUUIDMetadataId))
     }

--- a/Sources/PubNub/Networking/Routers/Subscribe Payloads/SubscribeObjectPayload.swift
+++ b/Sources/PubNub/Networking/Routers/Subscribe Payloads/SubscribeObjectPayload.swift
@@ -183,7 +183,7 @@ extension PubNubUUIDMetadataChangeset: Codable {
 
     var changes = [PubNubMetadataChange<PubNubUUIDMetadata>]()
     if let name = try container.decodeIfPresent(String.self, forKey: .name) {
-      changes.append(.string(\.name, name))
+      changes.append(.stringOptional(\.name, name))
     }
     if let externalId = try container.decodeIfPresent(ValueOptionJSON<String>.self, forKey: .externalId) {
       changes.append(.stringOptional(\.externalId, externalId.value))
@@ -267,7 +267,7 @@ extension PubNubChannelMetadataChangeset: Codable {
 
     var changes = [PubNubMetadataChange<PubNubChannelMetadata>]()
     if let name = try container.decodeIfPresent(String.self, forKey: .name) {
-      changes.append(.string(\.name, name))
+      changes.append(.stringOptional(\.name, name))
     }
     if let description = try container.decodeIfPresent(ValueOptionJSON<String>.self, forKey: .channelDescription) {
       changes.append(.stringOptional(\.channelDescription, description.value))

--- a/Tests/PubNubTests/Networking/Routers/ObjectsMembershipsRouterTests.swift
+++ b/Tests/PubNubTests/Networking/Routers/ObjectsMembershipsRouterTests.swift
@@ -72,11 +72,13 @@ extension ObjectsMembershipsRouterTests {
     else {
       return XCTFail("Could not create mock url session")
     }
-
+    
     let firstChannel = PubNubChannelMetadataBase(
       metadataId: "FirstChannel", name: "First Channel",
       channelDescription: "Channel Description", updated: channeDate, eTag: "ChanneleTag"
     )
+    
+    let lastChannel = PubNubChannelMetadataBase(metadataId: "LastChannel")
     let firstMembership = PubNubMembershipMetadataBase(
       uuidMetadataId: "TestUser", channelMetadataId: firstChannel.metadataId,
       channel: firstChannel,
@@ -84,6 +86,7 @@ extension ObjectsMembershipsRouterTests {
     )
     let lastMembership = PubNubMembershipMetadataBase(
       uuidMetadataId: "TestUser", channelMetadataId: "LastChannel",
+      channel: lastChannel,
       updated: lastDate, eTag: "LastETag"
     )
 
@@ -171,11 +174,12 @@ extension ObjectsMembershipsRouterTests {
     else {
       return XCTFail("Could not create mock url session")
     }
-
+    
     let firstChannel = PubNubChannelMetadataBase(
       metadataId: "FirstChannel", name: "First Channel",
       channelDescription: "Channel Description", updated: channeDate, eTag: "ChanneleTag"
     )
+    let lastChannel = PubNubChannelMetadataBase(metadataId: "LastChannel")
     let firstMembership = PubNubMembershipMetadataBase(
       uuidMetadataId: "TestUser", channelMetadataId: firstChannel.metadataId,
       channel: firstChannel,
@@ -183,6 +187,7 @@ extension ObjectsMembershipsRouterTests {
     )
     let lastMembership = PubNubMembershipMetadataBase(
       uuidMetadataId: "TestUser", channelMetadataId: "LastChannel",
+      channel: lastChannel,
       updated: lastDate, eTag: "LastETag"
     )
 
@@ -218,6 +223,7 @@ extension ObjectsMembershipsRouterTests {
       metadataId: "FirstChannel", name: "First Channel",
       channelDescription: "Channel Description", updated: channeDate, eTag: "ChanneleTag"
     )
+    let lastChannel = PubNubChannelMetadataBase(metadataId: "LastChannel")
     let firstMembership = PubNubMembershipMetadataBase(
       uuidMetadataId: "TestUser", channelMetadataId: firstChannel.metadataId,
       channel: firstChannel,
@@ -225,6 +231,7 @@ extension ObjectsMembershipsRouterTests {
     )
     let lastMembership = PubNubMembershipMetadataBase(
       uuidMetadataId: "TestUser", channelMetadataId: "LastChannel",
+      channel: lastChannel,
       updated: lastDate, eTag: "LastETag"
     )
 
@@ -286,6 +293,7 @@ extension ObjectsMembershipsRouterTests {
     let firstUUID = PubNubUUIDMetadataBase(
       metadataId: "FirstUser", name: "First User", updated: uuidDate, eTag: "UserETag"
     )
+    let lastUUID = PubNubUUIDMetadataBase(metadataId: "LastUser")
 
     let firstMembership = PubNubMembershipMetadataBase(
       uuidMetadataId: firstUUID.metadataId, channelMetadataId: "TestChannel",
@@ -294,6 +302,7 @@ extension ObjectsMembershipsRouterTests {
     )
     let lastMembership = PubNubMembershipMetadataBase(
       uuidMetadataId: "LastUser", channelMetadataId: "TestChannel",
+      uuid: lastUUID,
       custom: ["starred": true],
       updated: lastDate, eTag: "LastETag"
     )
@@ -305,6 +314,10 @@ extension ObjectsMembershipsRouterTests {
       ) { result in
         switch result {
         case let .success((memberships, nextPage)):
+          let membs1: [PubNubMembershipMetadataBase] = memberships.compactMap { try? $0.transcode() }
+          let membs2 = [firstMembership, lastMembership]
+          print("MEMBS 1: \(membs1)")
+          print("MEMBS 2: \(membs2)")
           XCTAssertEqual(memberships.compactMap { try? $0.transcode() }, [firstMembership, lastMembership])
           XCTAssertEqual(try? nextPage?.transcode(), page)
         case let .failure(error):
@@ -381,10 +394,11 @@ extension ObjectsMembershipsRouterTests {
     else {
       return XCTFail("Could not create mock url session")
     }
-
+    
     let firstUUID = PubNubUUIDMetadataBase(
       metadataId: "FirstUser", name: "First User", updated: uuidDate, eTag: "UserETag"
     )
+    let lastUUID = PubNubUUIDMetadataBase(metadataId: "LastUser")
 
     let firstMembership = PubNubMembershipMetadataBase(
       uuidMetadataId: firstUUID.metadataId, channelMetadataId: "TestChannel",
@@ -393,6 +407,7 @@ extension ObjectsMembershipsRouterTests {
     )
     let lastMembership = PubNubMembershipMetadataBase(
       uuidMetadataId: "LastUser", channelMetadataId: "TestChannel",
+      uuid: lastUUID,
       custom: ["starred": true],
       updated: lastDate, eTag: "LastETag"
     )
@@ -428,6 +443,7 @@ extension ObjectsMembershipsRouterTests {
     let firstUUID = PubNubUUIDMetadataBase(
       metadataId: "FirstUser", name: "First User", updated: uuidDate, eTag: "UserETag"
     )
+    let lastUUID = PubNubUUIDMetadataBase(metadataId: "LastUser")
 
     let firstMembership = PubNubMembershipMetadataBase(
       uuidMetadataId: firstUUID.metadataId, channelMetadataId: "TestChannel",
@@ -436,6 +452,7 @@ extension ObjectsMembershipsRouterTests {
     )
     let lastMembership = PubNubMembershipMetadataBase(
       uuidMetadataId: "LastUser", channelMetadataId: "TestChannel",
+      uuid: lastUUID,
       custom: ["starred": true],
       updated: lastDate, eTag: "LastETag"
     )

--- a/Tests/PubNubTests/Networking/Routers/SubscribeRouterTests.swift
+++ b/Tests/PubNubTests/Networking/Routers/SubscribeRouterTests.swift
@@ -451,9 +451,11 @@ extension SubscribeRouterTests {
     }
 
     let subscription = SubscribeSessionFactory.shared.getSession(from: config, with: session)
-
+    
+    let channel = PubNubChannelMetadataBase(metadataId: "TestSpaceID")
+    let uuid = PubNubUUIDMetadataBase(metadataId: "TestUserID")
     let testMembership = PubNubMembershipMetadataBase(
-      uuidMetadataId: "TestUserID", channelMetadataId: "TestSpaceID", custom: ["something": true],
+      uuidMetadataId: "TestUserID", channelMetadataId: "TestSpaceID", uuid: uuid, channel: channel, custom: ["something": true],
       updated: DateFormatter.iso8601.date(from: "2019-10-05T23:35:38.457823306Z"), eTag: "TestETag"
     )
 
@@ -514,9 +516,11 @@ extension SubscribeRouterTests {
     }
 
     let subscription = SubscribeSessionFactory.shared.getSession(from: config, with: session)
-
+    
+    let channel = PubNubChannelMetadataBase(metadataId: "TestSpaceID")
+    let uuid = PubNubUUIDMetadataBase(metadataId: "TestUserID")
     let testMembership = PubNubMembershipMetadataBase(
-      uuidMetadataId: "TestUserID", channelMetadataId: "TestSpaceID",
+      uuidMetadataId: "TestUserID", channelMetadataId: "TestSpaceID", uuid: uuid, channel: channel,
       updated: DateFormatter.iso8601.date(from: "2019-10-05T23:35:38.457823306Z"), eTag: "TestETag"
     )
 


### PR DESCRIPTION
fix: make 'name' field optional

Make `name` field optional for channel and UUID metadata.