### PR TITLE
Fixing up release information for VSP modules.

### DIFF
--- a/.github/workflows/release/versions.json
+++ b/.github/workflows/release/versions.json
@@ -1,7 +1,7 @@
 {
   ".pubnub.yml": [
     { "pattern": "^version: \"(.+)\"$", "cleared": true },
-    { "pattern": "\/refs\/tags\/((\\d+\\.?){2,}(-[a-zA-Z]+(.\\d+)?)?)\\.zip", "cleared": false }
+    { "pattern": "\/refs\/tags\/((\\d+\\.?){2,}(-[a-zA-Z]+(.\\d+)?)?)\\.zip", "cleared": true }
   ],
   "PubNubSwift.podspec": [
     { "pattern": "s.version.+'(.+)'", "cleared": true }
@@ -10,6 +10,6 @@
     { "pattern": "MARKETING_VERSION = ([0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+)?);", "cleared": true }
   ],
   "Sources/PubNub/Helpers/Constants.swift": [
-    { "pattern": "^\\s{2,}\"((\\d+\\.?){2,})\"$", "cleared": true }
+    { "pattern": "pubnubSwiftSDKVersion\\:.+\"((\\d+\\.?){2,})\"$", "cleared": true }
   ]
 }

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,20 +1,9 @@
 ---
 name: swift
 scm: github.com/pubnub/swift
-version: "6.0.0"
+version: "5.1.0"
 schema: 1
 changelog:
-  - date: 2022-07-05
-    version: v6.0.0
-    changes:
-      - type: feature
-        text: "VSP methods and models have been exposed via modules on the PubNub instance."
-      - type: feature
-        text: "JSONCodableScalar]` inside the VSP models."
-      - type: improvement
-        text: "PubNub instances has been changed from a `struct` to a `class`."
-      - type: improvement
-        text: "`HTTPSession` has been made public for easier per-request overrides of the Network Session."
   - date: 2022-02-02
     version: 5.1.0
     changes:
@@ -454,7 +443,7 @@ sdks:
           - distribution-type: source
             distribution-repository: GitHub release
             package-name: PubNub
-            location: https://github.com/pubnub/swift/archive/refs/tags/v6.0.0.zip
+            location: https://github.com/pubnub/swift/archive/refs/tags/5.1.0.zip
             supported-platforms:
               supported-operating-systems:
                 macOS:

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,9 +1,20 @@
 ---
 name: swift
 scm: github.com/pubnub/swift
-version: "5.1.0"
+version: "6.0.0"
 schema: 1
 changelog:
+  - date: 2022-07-05
+    version: 6.0.0
+    changes:
+      - type: feature
+        text: "VSP methods and models have been exposed via modules on the PubNub instance."
+      - type: feature
+        text: "JSONCodableScalar]` inside the VSP models."
+      - type: improvement
+        text: "PubNub instances has been changed from a `struct` to a `class`."
+      - type: improvement
+        text: "`HTTPSession` has been made public for easier per-request overrides of the Network Session."
   - date: 2022-02-02
     version: 5.1.0
     changes:
@@ -443,7 +454,7 @@ sdks:
           - distribution-type: source
             distribution-repository: GitHub release
             package-name: PubNub
-            location: https://github.com/pubnub/swift/archive/refs/tags/5.1.0.zip
+            location: https://github.com/pubnub/swift/archive/refs/tags/6.0.0.zip
             supported-platforms:
               supported-operating-systems:
                 macOS:

--- a/PubNub.xcodeproj/project.pbxproj
+++ b/PubNub.xcodeproj/project.pbxproj
@@ -3181,7 +3181,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 6.0.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnub.swift.PubNubUser;
@@ -3226,7 +3226,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 6.0.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnub.swift.PubNubUser;
@@ -3320,7 +3320,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 6.0.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnub.swift.PubNubSpace;
@@ -3367,7 +3367,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 6.0.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnub.swift.PubNubSpace;
@@ -3474,7 +3474,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 6.0.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnub.swift.PubNubMembership;
@@ -3520,7 +3520,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 6.0.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnub.swift.PubNubMembership;

--- a/PubNub.xcodeproj/project.pbxproj
+++ b/PubNub.xcodeproj/project.pbxproj
@@ -3181,7 +3181,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnub.swift.PubNubUser;
@@ -3226,7 +3226,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnub.swift.PubNubUser;
@@ -3320,7 +3320,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnub.swift.PubNubSpace;
@@ -3367,7 +3367,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnub.swift.PubNubSpace;
@@ -3474,7 +3474,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnub.swift.PubNubMembership;
@@ -3520,7 +3520,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnub.swift.PubNubMembership;

--- a/PubNubSwift.podspec
+++ b/PubNubSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'PubNubSwift'
-  s.version  = '6.0.0'
+  s.version  = '5.1.0'
   s.homepage = 'https://github.com/pubnub/swift'
   s.documentation_url = 'https://www.pubnub.com/docs/swift-native/pubnub-swift-sdk'
   s.authors = { 'PubNub, Inc.' => 'support@pubnub.com' }

--- a/PubNubSwift.podspec
+++ b/PubNubSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'PubNubSwift'
-  s.version  = '5.1.0'
+  s.version  = '6.0.0'
   s.homepage = 'https://github.com/pubnub/swift'
   s.documentation_url = 'https://www.pubnub.com/docs/swift-native/pubnub-swift-sdk'
   s.authors = { 'PubNub, Inc.' => 'support@pubnub.com' }


### PR DESCRIPTION
feat: VSP methods and models have been exposed via modules on the PubNub instance

feat: `FlatJSONCodable` replaces `[String: JSONCodableScalar]` inside the VSP models

refactor: PubNub instances has been changed from a `struct` to a `class`

refactor: `HTTPSession` has been made public for easier per-request overrides of the Network Session