### PR TITLE
Fix listeners retain cycle

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,9 +1,14 @@
 ---
 name: swift
 scm: github.com/pubnub/swift
-version: "6.0.2"
+version: "6.0.3"
 schema: 1
 changelog:
+  - date: 2023-01-04
+    version: 6.0.3
+    changes:
+      - type: bug
+        text: "Fix issue because of which listener wasn't `deinit` even when reference on it has been nullified."
   - date: 2022-12-12
     version: 6.0.2
     changes:
@@ -468,7 +473,7 @@ sdks:
           - distribution-type: source
             distribution-repository: GitHub release
             package-name: PubNub
-            location: https://github.com/pubnub/swift/archive/refs/tags/6.0.2.zip
+            location: https://github.com/pubnub/swift/archive/refs/tags/6.0.3.zip
             supported-platforms:
               supported-operating-systems:
                 macOS:

--- a/PubNub.xcodeproj/project.pbxproj
+++ b/PubNub.xcodeproj/project.pbxproj
@@ -3240,7 +3240,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.0.2;
+				MARKETING_VERSION = 6.0.3;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnub.swift.PubNubUser;
@@ -3287,7 +3287,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.0.2;
+				MARKETING_VERSION = 6.0.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnub.swift.PubNubUser;
@@ -3387,7 +3387,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.0.2;
+				MARKETING_VERSION = 6.0.3;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnub.swift.PubNubSpace;
@@ -3436,7 +3436,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.0.2;
+				MARKETING_VERSION = 6.0.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnub.swift.PubNubSpace;
@@ -3549,7 +3549,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.0.2;
+				MARKETING_VERSION = 6.0.3;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnub.swift.PubNubMembership;
@@ -3597,7 +3597,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.0.2;
+				MARKETING_VERSION = 6.0.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnub.swift.PubNubMembership;
@@ -4053,7 +4053,7 @@
 					"$(inherited)",
 					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
 				);
-				MARKETING_VERSION = 6.0.2;
+				MARKETING_VERSION = 6.0.3;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -4092,7 +4092,7 @@
 					"$(inherited)",
 					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
 				);
-				MARKETING_VERSION = 6.0.2;
+				MARKETING_VERSION = 6.0.3;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";

--- a/PubNubSwift.podspec
+++ b/PubNubSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'PubNubSwift'
-  s.version  = '6.0.2'
+  s.version  = '6.0.3'
   s.homepage = 'https://github.com/pubnub/swift'
   s.documentation_url = 'https://www.pubnub.com/docs/swift-native/pubnub-swift-sdk'
   s.authors = { 'PubNub, Inc.' => 'support@pubnub.com' }

--- a/Sources/PubNub/Helpers/Constants.swift
+++ b/Sources/PubNub/Helpers/Constants.swift
@@ -57,7 +57,7 @@ public enum Constant {
 
   static let pubnubSwiftSDKName: String = "PubNubSwift"
 
-  static let pubnubSwiftSDKVersion: String = "6.0.2"
+  static let pubnubSwiftSDKVersion: String = "6.0.3"
 
   static let appBundleId: String = {
     if let info = Bundle.main.infoDictionary,

--- a/Sources/PubNub/Subscription/SubscriptionSession.swift
+++ b/Sources/PubNub/Subscription/SubscriptionSession.swift
@@ -442,8 +442,10 @@ extension SubscriptionSession: EventStreamEmitter {
     listener.token?.cancel()
 
     // Add new token to the listener
-    listener.token = ListenerToken { [weak self] in
-      self?.privateListeners.remove(listener)
+    listener.token = ListenerToken { [weak self, weak listener] in
+      if let listener = listener {
+        self?.privateListeners.remove(listener)
+      }
     }
     privateListeners.update(listener)
   }


### PR DESCRIPTION
fix(listener): fix listeners retain cycle

Fix issue because of which listener wasn't `deinit` even when reference on it has been nullified.

Closes #92 