### PR TITLE
Change subscribe session settings

### DIFF
--- a/PubNub.xcodeproj/project.pbxproj
+++ b/PubNub.xcodeproj/project.pbxproj
@@ -134,7 +134,7 @@
 		3558068A230F4C99005CDD92 /* InstanceIdOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35580687230F4B75005CDD92 /* InstanceIdOperatorTests.swift */; };
 		3558069A2311F968005CDD92 /* SubscriptionStreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355806992311F968005CDD92 /* SubscriptionStreamTests.swift */; };
 		3558069C231303D9005CDD92 /* AutomaticRetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3558069B231303D9005CDD92 /* AutomaticRetryTests.swift */; };
-		355806DB23145749005CDD92 /* PubNub.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = PubNub::PubNub::Product /* PubNub.framework */; };
+		355806DB23145749005CDD92 /* PubNub.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "PubNub::PubNub::Product" /* PubNub.framework */; };
 		3559977B23073D53000BCFD1 /* WeakBoxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3559977A23073D53000BCFD1 /* WeakBoxTests.swift */; };
 		3559977F23078A7C000BCFD1 /* message_counts_error_invalid_arguments.json in Resources */ = {isa = PBXBuildFile; fileRef = 3559977E230787E7000BCFD1 /* message_counts_error_invalid_arguments.json */; };
 		3559978223079070000BCFD1 /* forbidden_Message.json in Resources */ = {isa = PBXBuildFile; fileRef = 3559978023078F85000BCFD1 /* forbidden_Message.json */; };
@@ -398,9 +398,9 @@
 		79407BE5271D4CFA0032076C /* PubNubFilesContractTestSteps.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79407BD1271D4CFA0032076C /* PubNubFilesContractTestSteps.swift */; };
 		79407C00271D519F0032076C /* Features in Resources */ = {isa = PBXBuildFile; fileRef = 79407BFF271D519F0032076C /* Features */; };
 		79407C01271D519F0032076C /* Features in Resources */ = {isa = PBXBuildFile; fileRef = 79407BFF271D519F0032076C /* Features */; };
-		7941EEA9270E433F0054D9EF /* PubNub.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = PubNub::PubNub::Product /* PubNub.framework */; platformFilter = ios; };
+		7941EEA9270E433F0054D9EF /* PubNub.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "PubNub::PubNub::Product" /* PubNub.framework */; platformFilter = ios; };
 		7951954E26C955CE001E308C /* PAMToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7951954D26C955CE001E308C /* PAMToken.swift */; };
-		79657AA3271A13F700BACEC5 /* PubNub.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = PubNub::PubNub::Product /* PubNub.framework */; platformFilter = ios; };
+		79657AA3271A13F700BACEC5 /* PubNub.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "PubNub::PubNub::Product" /* PubNub.framework */; platformFilter = ios; };
 		A5115F2529195AF400F6ADA1 /* PubNubObjectsMembersContractTestSteps.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5115F2429195AF400F6ADA1 /* PubNubObjectsMembersContractTestSteps.swift */; };
 		A5115F2629195AF400F6ADA1 /* PubNubObjectsMembersContractTestSteps.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5115F2429195AF400F6ADA1 /* PubNubObjectsMembersContractTestSteps.swift */; };
 		A5115F28291D54F500F6ADA1 /* PubNubObjectsMembershipsContractTestSteps.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5115F27291D54F500F6ADA1 /* PubNubObjectsMembershipsContractTestSteps.swift */; };
@@ -411,12 +411,13 @@
 		A56445F02906AFF40085B310 /* PubNubObjectsTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56445EE2906AFF40085B310 /* PubNubObjectsTestHelpers.swift */; };
 		A56445F22907D9FD0085B310 /* PubNubObjectsChannelMetadataContractTestSteps.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56445F12907D9FD0085B310 /* PubNubObjectsChannelMetadataContractTestSteps.swift */; };
 		A56445F32907D9FD0085B310 /* PubNubObjectsChannelMetadataContractTestSteps.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56445F12907D9FD0085B310 /* PubNubObjectsChannelMetadataContractTestSteps.swift */; };
+		A5A574D429C309750065D333 /* leave_success.json in Resources */ = {isa = PBXBuildFile; fileRef = A5A574D329C309750065D333 /* leave_success.json */; };
 		A5F19EE329126D8200F185A9 /* PubNubObjectsUUIDMetadataContractTestSteps.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F19EE229126D8200F185A9 /* PubNubObjectsUUIDMetadataContractTestSteps.swift */; };
 		A5F19EE429126D8200F185A9 /* PubNubObjectsUUIDMetadataContractTestSteps.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F19EE229126D8200F185A9 /* PubNubObjectsUUIDMetadataContractTestSteps.swift */; };
 		D2635DFB22FCCF080097CF64 /* message_counts_success.json in Resources */ = {isa = PBXBuildFile; fileRef = D2635DFA22FCCF080097CF64 /* message_counts_success.json */; };
 		OBJ_31 /* PubNub.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* PubNub.swift */; };
 		OBJ_49 /* PubNubTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_15 /* PubNubTests.swift */; };
-		OBJ_51 /* PubNub.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = PubNub::PubNub::Product /* PubNub.framework */; };
+		OBJ_51 /* PubNub.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "PubNub::PubNub::Product" /* PubNub.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -919,6 +920,7 @@
 		A5115F2A291D5C2700F6ADA1 /* PubNubObjectsContractTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PubNubObjectsContractTests.swift; sourceTree = "<group>"; };
 		A56445EE2906AFF40085B310 /* PubNubObjectsTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PubNubObjectsTestHelpers.swift; sourceTree = "<group>"; };
 		A56445F12907D9FD0085B310 /* PubNubObjectsChannelMetadataContractTestSteps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PubNubObjectsChannelMetadataContractTestSteps.swift; sourceTree = "<group>"; };
+		A5A574D329C309750065D333 /* leave_success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = leave_success.json; sourceTree = "<group>"; };
 		A5F19EE229126D8200F185A9 /* PubNubObjectsUUIDMetadataContractTestSteps.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PubNubObjectsUUIDMetadataContractTestSteps.swift; sourceTree = "<group>"; };
 		D2635DFA22FCCF080097CF64 /* message_counts_success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = message_counts_success.json; sourceTree = "<group>"; };
 		OBJ_11 /* PubNub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PubNub.swift; sourceTree = "<group>"; };
@@ -928,8 +930,8 @@
 		OBJ_24 /* PubNubSwift.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; path = PubNubSwift.podspec; sourceTree = "<group>"; };
 		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		OBJ_9 /* PubNub.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PubNub.h; sourceTree = "<group>"; };
-		PubNub::PubNub::Product /* PubNub.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PubNub.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		PubNub::PubNubTests::Product /* PubNubTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; path = PubNubTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		"PubNub::PubNub::Product" /* PubNub.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PubNub.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"PubNub::PubNubTests::Product" /* PubNubTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; path = PubNubTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1566,6 +1568,7 @@
 			children = (
 				35A66A8B22F9080A00AC67A9 /* getState_success.json */,
 				35E71C39249027120032A991 /* getState_single_success.json */,
+				A5A574D329C309750065D333 /* leave_success.json */,
 				35A66A8C22F9084000AC67A9 /* setState_success.json */,
 				35A66A9522F9B71200AC67A9 /* setState_missing_state.json */,
 				35A6C78022FB2E4C00E97CC5 /* herenow_success.json */,
@@ -2034,8 +2037,8 @@
 		OBJ_17 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				PubNub::PubNubTests::Product /* PubNubTests.xctest */,
-				PubNub::PubNub::Product /* PubNub.framework */,
+				"PubNub::PubNubTests::Product" /* PubNubTests.xctest */,
+				"PubNub::PubNub::Product" /* PubNub.framework */,
 				3558073723145749005CDD92 /* PubNubIntTests.xctest */,
 				7941EF40270E433F0054D9EF /* PubNubContractTests.xctest */,
 				79657AAB271A13F700BACEC5 /* PubNubContractTestsBeta.xctest */,
@@ -2336,7 +2339,7 @@
 			productReference = 79657AAB271A13F700BACEC5 /* PubNubContractTestsBeta.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		PubNub::PubNub /* PubNub */ = {
+		"PubNub::PubNub" /* PubNub */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = OBJ_27 /* Build configuration list for PBXNativeTarget "PubNub" */;
 			buildPhases = (
@@ -2349,10 +2352,10 @@
 			);
 			name = PubNub;
 			productName = PubNub;
-			productReference = PubNub::PubNub::Product /* PubNub.framework */;
+			productReference = "PubNub::PubNub::Product" /* PubNub.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		PubNub::PubNubTests /* PubNubTests */ = {
+		"PubNub::PubNubTests" /* PubNubTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = OBJ_45 /* Build configuration list for PBXNativeTarget "PubNubTests" */;
 			buildPhases = (
@@ -2367,7 +2370,7 @@
 			);
 			name = PubNubTests;
 			productName = PubNubTests;
-			productReference = PubNub::PubNubTests::Product /* PubNubTests.xctest */;
+			productReference = "PubNub::PubNubTests::Product" /* PubNubTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
@@ -2420,8 +2423,8 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				PubNub::PubNub /* PubNub */,
-				PubNub::PubNubTests /* PubNubTests */,
+				"PubNub::PubNub" /* PubNub */,
+				"PubNub::PubNubTests" /* PubNubTests */,
 				7941EE6B270E433F0054D9EF /* PubNubContractTests */,
 				79657A93271A13F700BACEC5 /* PubNubContractTestsBeta */,
 				3558069D23145749005CDD92 /* PubNubIntegration */,
@@ -2577,6 +2580,7 @@
 				35FE93EA22EF93A90051C455 /* cannotConnectToHost.json in Resources */,
 				35FE93E622EF93A90051C455 /* secureConnectionFailed.json in Resources */,
 				35A6C7B322FBD9D200E97CC5 /* push_remove_all_success.json in Resources */,
+				A5A574D429C309750065D333 /* leave_success.json in Resources */,
 				350BC40F233952F400011262 /* objects_uuid_all_success_empty.json in Resources */,
 				35293AA8236B6C5D0049A71F /* removeMessageAction_error_400_noMessage.json in Resources */,
 				35FE93EE22EF93A90051C455 /* unsupportedURL.json in Resources */,
@@ -3061,7 +3065,7 @@
 /* Begin PBXTargetDependency section */
 		3558069E23145749005CDD92 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = PubNub::PubNub /* PubNub */;
+			target = "PubNub::PubNub" /* PubNub */;
 			targetProxy = 3558069F23145749005CDD92 /* PBXContainerItemProxy */;
 		};
 		358B8917284D206B00DB0F3D /* PBXTargetDependency */ = {
@@ -3081,17 +3085,17 @@
 		};
 		358B8962284D22B100DB0F3D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = PubNub::PubNub /* PubNub */;
+			target = "PubNub::PubNub" /* PubNub */;
 			targetProxy = 358B8961284D22B100DB0F3D /* PBXContainerItemProxy */;
 		};
 		358B8966284D22D800DB0F3D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = PubNub::PubNub /* PubNub */;
+			target = "PubNub::PubNub" /* PubNub */;
 			targetProxy = 358B8965284D22D800DB0F3D /* PBXContainerItemProxy */;
 		};
 		358B8968284D22E200DB0F3D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = PubNub::PubNub /* PubNub */;
+			target = "PubNub::PubNub" /* PubNub */;
 			targetProxy = 358B8967284D22E200DB0F3D /* PBXContainerItemProxy */;
 		};
 		358B896A284D22E200DB0F3D /* PBXTargetDependency */ = {
@@ -3122,18 +3126,18 @@
 		7941EE6C270E433F0054D9EF /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			platformFilter = ios;
-			target = PubNub::PubNub /* PubNub */;
+			target = "PubNub::PubNub" /* PubNub */;
 			targetProxy = 7941EE6D270E433F0054D9EF /* PBXContainerItemProxy */;
 		};
 		79657A94271A13F700BACEC5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			platformFilter = ios;
-			target = PubNub::PubNub /* PubNub */;
+			target = "PubNub::PubNub" /* PubNub */;
 			targetProxy = 79657A95271A13F700BACEC5 /* PBXContainerItemProxy */;
 		};
 		OBJ_52 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = PubNub::PubNub /* PubNub */;
+			target = "PubNub::PubNub" /* PubNub */;
 			targetProxy = 35EA73F422B1916100D97BF0 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */

--- a/Sources/PubNub/Errors/ErrorDescription.swift
+++ b/Sources/PubNub/Errors/ErrorDescription.swift
@@ -179,6 +179,8 @@ extension PubNubError.Reason: CustomStringConvertible, LocalizedError {
       return "The request was cancelled by the system/user without error"
     case .longPollingRestart:
       return "The long polling request needed to be cancelled to restart with new data"
+    case .longPollingReset:
+      return "The long polling request needed to be cancelled because the client unsubscribed from all channels and groups."
     case .timedOut:
       return "An asynchronous operation timed out"
     case .nameResolutionFailure:

--- a/Sources/PubNub/Errors/PubNubError.swift
+++ b/Sources/PubNub/Errors/PubNubError.swift
@@ -130,6 +130,7 @@ public struct PubNubError: Error {
     case sessionInvalidated
     case clientCancelled
     case longPollingRestart
+    case longPollingReset
 
     // Response Received
     case badServerResponse
@@ -210,7 +211,7 @@ public struct PubNubError: Error {
            .secureConnectionFailure, .certificateTrustFailure, .backgroundUpdatesDisabled,
            .backgroundInsufficientResources, .backgroundUserForceQuitApplication:
         return .requestTransmission
-      case .clientCancelled, .sessionDeinitialized, .sessionInvalidated, .longPollingRestart:
+      case .clientCancelled, .sessionDeinitialized, .sessionInvalidated, .longPollingRestart, .longPollingReset:
         return .cancellation
       case .badServerResponse, .responseDecodingFailure, .dataLengthExceedsMaximum:
         return .responseReceiving

--- a/Sources/PubNub/Extensions/URLSessionConfiguration+PubNub.swift
+++ b/Sources/PubNub/Extensions/URLSessionConfiguration+PubNub.swift
@@ -66,6 +66,7 @@ public extension URLSessionConfiguration {
   static var subscription: URLSessionConfiguration {
     let configuration = URLSessionConfiguration.pubnub
     configuration.timeoutIntervalForRequest += Constant.minimumSubscribeRequestTimeout
+    configuration.httpMaximumConnectionsPerHost = 1;
 
     return configuration
   }

--- a/Sources/PubNub/Subscription/SubscriptionSession+Presence.swift
+++ b/Sources/PubNub/Subscription/SubscriptionSession+Presence.swift
@@ -98,7 +98,7 @@ extension SubscriptionSession {
   ) {
     let router = PresenceRouter(.leave(channels: channels, groups: groups), configuration: configuration)
 
-    nonSubscribeSession
+    longPollingSession
       .request(with: router, requestOperator: configuration.automaticRetry)
       .validate()
       .response(on: .main, decoder: GenericServiceResponseDecoder()) { result in

--- a/Sources/PubNub/Subscription/SubscriptionSession.swift
+++ b/Sources/PubNub/Subscription/SubscriptionSession.swift
@@ -318,7 +318,8 @@ public class SubscriptionSession {
             )
           }
 
-          if error.pubNubError?.reason == .clientCancelled || error.pubNubError?.reason == .longPollingRestart {
+          if error.pubNubError?.reason == .clientCancelled || error.pubNubError?.reason == .longPollingRestart ||
+            error.pubNubError?.reason == .longPollingReset {
             if self?.subscriptionCount == 0 {
               self?.connectionStatus = .disconnected
             } else if self?.request?.requestID == currentSubscribeID {
@@ -388,6 +389,9 @@ public class SubscriptionSession {
       notify {
         $0.emit(subscribe: .subscriptionChanged(subscribeChange))
       }
+      // Cancel previous subscribe request.
+      stopSubscribeLoop(.longPollingReset)
+      
       // Call unsubscribe to cleanup remaining state items
       unsubscribeCleanup(subscribeChange: subscribeChange)
     }

--- a/Tests/PubNubTests/Extensions/URLSessionConfiguration+PubNubTests.swift
+++ b/Tests/PubNubTests/Extensions/URLSessionConfiguration+PubNubTests.swift
@@ -55,8 +55,7 @@ final class URLSessionConfigurationPubNubTests: XCTestCase {
 
     XCTAssertEqual(config.headers, defaultHeaders)
     XCTAssertEqual(config.timeoutIntervalForRequest, defaultTimeout)
-    XCTAssertEqual(config.httpMaximumConnectionsPerHost,
-                   URLSessionConfiguration.default.httpMaximumConnectionsPerHost)
+    XCTAssertEqual(config.httpMaximumConnectionsPerHost, 1)
   }
 
   func testHeaders_GetSetHeaders() {

--- a/Tests/PubNubTests/Mocking/MockURLSession.swift
+++ b/Tests/PubNubTests/Mocking/MockURLSession.swift
@@ -399,7 +399,6 @@ extension MockURLSession {
     let urlSession = MockURLSession(configuration: .ephemeral, delegate: HTTPSessionDelegate(), delegateQueue: .main)
 
     urlSession.responseForDataTask = { mockTask, index in
-      print("~~~~~~> \(jsonResources.count) | \(dataResource.count) | \(index)")
       guard jsonResources.count + dataResource.count > index else {
         fatalError("Index out of range for next task")
       }

--- a/Tests/PubNubTests/Mocking/Responses/Presence/leave_success.json
+++ b/Tests/PubNubTests/Mocking/Responses/Presence/leave_success.json
@@ -1,0 +1,6 @@
+{
+    "status": 200,
+    "message": "OK",
+    "action": "leave",
+    "service": "Presence"
+}

--- a/Tests/PubNubTests/Networking/Routers/SubscribeRouterTests.swift
+++ b/Tests/PubNubTests/Networking/Routers/SubscribeRouterTests.swift
@@ -514,8 +514,7 @@ extension SubscribeRouterTests {
     let objectExpect = XCTestExpectation(description: "Object Event")
     let statusExpect = XCTestExpectation(description: "Status Event")
     let objectListenerExpect = XCTestExpectation(description: "Object Listener Event")
-
-    guard let session = try? MockURLSession.mockSession(for: ["subscription_membershipRemove_success"]).session else {
+    guard let session = try? MockURLSession.mockSession(for: ["subscription_membershipRemove_success", "leave_success"]).session else {
       return XCTFail("Could not create mock url session")
     }
 
@@ -583,7 +582,7 @@ extension SubscribeRouterTests {
     let statusExpect = XCTestExpectation(description: "Status Event")
     let actionListenerExpect = XCTestExpectation(description: "Action Listener Event")
 
-    guard let session = try? MockURLSession.mockSession(for: ["subscription_addMessageAction_success"]).session else {
+    guard let session = try? MockURLSession.mockSession(for: ["subscription_addMessageAction_success", "leave_success"]).session else {
       return XCTFail("Could not create mock url session")
     }
 
@@ -641,7 +640,7 @@ extension SubscribeRouterTests {
     let actionListenerExpect = XCTestExpectation(description: "Action Listener Event")
 
     guard let session = try? MockURLSession
-      .mockSession(for: ["subscription_removeMessageAction_success"])
+      .mockSession(for: ["subscription_removeMessageAction_success", "leave_success"])
       .session
     else {
       return XCTFail("Could not create mock url session")
@@ -704,7 +703,7 @@ extension SubscribeRouterTests {
     let signalExpect = XCTestExpectation(description: "Signal Event")
     let statusExpect = XCTestExpectation(description: "Status Event")
 
-    guard let session = try? MockURLSession.mockSession(for: ["subscription_mixed_success"]).session else {
+    guard let session = try? MockURLSession.mockSession(for: ["subscription_mixed_success", "leave_success"]).session else {
       return XCTFail("Could not create mock url session")
     }
 


### PR DESCRIPTION
Change settings for subscribe URLSession and limit number of concurrent connections per host.

refactor(presence): presence leave on subscribe session

Call presence leave using subscribe URLSession to avoid potential presence race of condition.