### PR TITLE
feat/event-engine-poc

### DIFF
--- a/PubNub.xcodeproj/project.pbxproj
+++ b/PubNub.xcodeproj/project.pbxproj
@@ -376,6 +376,9 @@
 		35FE941822EFCB7F0051C455 /* SessionStreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35FE941722EFCB7F0051C455 /* SessionStreamTests.swift */; };
 		35FE941B22EFE5400051C455 /* EventStreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35FE941A22EFE5400051C455 /* EventStreamTests.swift */; };
 		35FE941F22F0929A0051C455 /* RequestRetrierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35FE941E22F0929A0051C455 /* RequestRetrierTests.swift */; };
+		3D11200929C9C9360025225D /* SubscribeEffectFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D11200829C9C9360025225D /* SubscribeEffectFactory.swift */; };
+		3D11200B29C9C9600025225D /* SubscribeTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D11200A29C9C9600025225D /* SubscribeTransition.swift */; };
+		3D11201029C9CD6F0025225D /* HandshakeRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D11200F29C9CD6F0025225D /* HandshakeRequest.swift */; };
 		3DF66BF229C34B2C001C7BDB /* Dispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF66BEC29C34B2C001C7BDB /* Dispatcher.swift */; };
 		3DF66BF329C34B2C001C7BDB /* EffectHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF66BED29C34B2C001C7BDB /* EffectHandler.swift */; };
 		3DF66BF429C34B2C001C7BDB /* EventEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF66BEE29C34B2C001C7BDB /* EventEngine.swift */; };
@@ -903,6 +906,9 @@
 		35FE941A22EFE5400051C455 /* EventStreamTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventStreamTests.swift; sourceTree = "<group>"; };
 		35FE941E22F0929A0051C455 /* RequestRetrierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestRetrierTests.swift; sourceTree = "<group>"; };
 		39F8A326548760AB6DB4774A /* Pods-PubNubContractTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PubNubContractTests.release.xcconfig"; path = "Target Support Files/Pods-PubNubContractTests/Pods-PubNubContractTests.release.xcconfig"; sourceTree = "<group>"; };
+		3D11200829C9C9360025225D /* SubscribeEffectFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscribeEffectFactory.swift; sourceTree = "<group>"; };
+		3D11200A29C9C9600025225D /* SubscribeTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscribeTransition.swift; sourceTree = "<group>"; };
+		3D11200F29C9CD6F0025225D /* HandshakeRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HandshakeRequest.swift; sourceTree = "<group>"; };
 		3DF66BEC29C34B2C001C7BDB /* Dispatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dispatcher.swift; sourceTree = "<group>"; };
 		3DF66BED29C34B2C001C7BDB /* EffectHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EffectHandler.swift; sourceTree = "<group>"; };
 		3DF66BEE29C34B2C001C7BDB /* EventEngine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventEngine.swift; sourceTree = "<group>"; };
@@ -1891,6 +1897,14 @@
 			path = EndpointError;
 			sourceTree = "<group>";
 		};
+		3D11200E29C9CD6F0025225D /* Effects */ = {
+			isa = PBXGroup;
+			children = (
+				3D11200F29C9CD6F0025225D /* HandshakeRequest.swift */,
+			);
+			path = Effects;
+			sourceTree = "<group>";
+		};
 		3DBD7CDD58292DFFDF108B95 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -1906,7 +1920,7 @@
 			isa = PBXGroup;
 			children = (
 				3DF66BEB29C34B2C001C7BDB /* Core */,
-				3DF66BF029C34B2C001C7BDB /* Showcase */,
+				3DF66BF029C34B2C001C7BDB /* Subscribe */,
 			);
 			path = EventEngine;
 			sourceTree = "<group>";
@@ -1922,12 +1936,15 @@
 			path = Core;
 			sourceTree = "<group>";
 		};
-		3DF66BF029C34B2C001C7BDB /* Showcase */ = {
+		3DF66BF029C34B2C001C7BDB /* Subscribe */ = {
 			isa = PBXGroup;
 			children = (
+				3D11200E29C9CD6F0025225D /* Effects */,
 				3DF66BF129C34B2C001C7BDB /* Subscribe.swift */,
+				3D11200A29C9C9600025225D /* SubscribeTransition.swift */,
+				3D11200829C9C9360025225D /* SubscribeEffectFactory.swift */,
 			);
-			path = Showcase;
+			path = Subscribe;
 			sourceTree = "<group>";
 		};
 		4FE4B403E611F731B37A5B6F /* Frameworks */ = {
@@ -3031,6 +3048,7 @@
 			buildActionMask = 0;
 			files = (
 				3556E37224806E33004FDC25 /* CaseAccessible.swift in Sources */,
+				3D11201029C9CD6F0025225D /* HandshakeRequest.swift in Sources */,
 				35CDA4D02510068A00218137 /* XMLSerialization.swift in Sources */,
 				35481BF6252275B5004E07B5 /* PubNubFile.swift in Sources */,
 				35CDA4CC2510031E00218137 /* XMLDecoder.swift in Sources */,
@@ -3110,6 +3128,7 @@
 				352DBFE9237C937F00A0106E /* HTTPSessionDelegate.swift in Sources */,
 				3DF66BF229C34B2C001C7BDB /* Dispatcher.swift in Sources */,
 				35CF548E248971CD0099FE81 /* ObjectsChannelRouter.swift in Sources */,
+				3D11200B29C9C9600025225D /* SubscribeTransition.swift in Sources */,
 				35A6C7BE22FCCBF900E97CC5 /* HistoryRouter.swift in Sources */,
 				35A66A9022F913B200AC67A9 /* ConnectionStatus.swift in Sources */,
 				3585033722CD4A1A00A11D9A /* RequestOperator.swift in Sources */,
@@ -3128,6 +3147,7 @@
 				35DB0C4B2874768C001E1F76 /* FlatJSONCodable.swift in Sources */,
 				35CF54962489B3760099FE81 /* PubNubMembershipMetadata.swift in Sources */,
 				3556E370248023B2004FDC25 /* BoundedValue.swift in Sources */,
+				3D11200929C9C9360025225D /* SubscribeEffectFactory.swift in Sources */,
 				35270C0323AC124800501388 /* CBORDecoder.swift in Sources */,
 				3559978C230A02B7000BCFD1 /* PubNubLogger.swift in Sources */,
 				35AE6A3224FD6CEE00BBFA37 /* FileManagementRouter.swift in Sources */,

--- a/PubNub.xcodeproj/project.pbxproj
+++ b/PubNub.xcodeproj/project.pbxproj
@@ -134,7 +134,7 @@
 		3558068A230F4C99005CDD92 /* InstanceIdOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35580687230F4B75005CDD92 /* InstanceIdOperatorTests.swift */; };
 		3558069A2311F968005CDD92 /* SubscriptionStreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355806992311F968005CDD92 /* SubscriptionStreamTests.swift */; };
 		3558069C231303D9005CDD92 /* AutomaticRetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3558069B231303D9005CDD92 /* AutomaticRetryTests.swift */; };
-		355806DB23145749005CDD92 /* PubNub.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = PubNub::PubNub::Product /* PubNub.framework */; };
+		355806DB23145749005CDD92 /* PubNub.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "PubNub::PubNub::Product" /* PubNub.framework */; };
 		3559977B23073D53000BCFD1 /* WeakBoxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3559977A23073D53000BCFD1 /* WeakBoxTests.swift */; };
 		3559977F23078A7C000BCFD1 /* message_counts_error_invalid_arguments.json in Resources */ = {isa = PBXBuildFile; fileRef = 3559977E230787E7000BCFD1 /* message_counts_error_invalid_arguments.json */; };
 		3559978223079070000BCFD1 /* forbidden_Message.json in Resources */ = {isa = PBXBuildFile; fileRef = 3559978023078F85000BCFD1 /* forbidden_Message.json */; };
@@ -376,6 +376,12 @@
 		35FE941822EFCB7F0051C455 /* SessionStreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35FE941722EFCB7F0051C455 /* SessionStreamTests.swift */; };
 		35FE941B22EFE5400051C455 /* EventStreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35FE941A22EFE5400051C455 /* EventStreamTests.swift */; };
 		35FE941F22F0929A0051C455 /* RequestRetrierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35FE941E22F0929A0051C455 /* RequestRetrierTests.swift */; };
+		3DF66BF229C34B2C001C7BDB /* Dispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF66BEC29C34B2C001C7BDB /* Dispatcher.swift */; };
+		3DF66BF329C34B2C001C7BDB /* EffectHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF66BED29C34B2C001C7BDB /* EffectHandler.swift */; };
+		3DF66BF429C34B2C001C7BDB /* EventEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF66BEE29C34B2C001C7BDB /* EventEngine.swift */; };
+		3DF66BF529C34B2C001C7BDB /* TransitionProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF66BEF29C34B2C001C7BDB /* TransitionProtocol.swift */; };
+		3DF66BF629C34B2C001C7BDB /* Subscribe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF66BF129C34B2C001C7BDB /* Subscribe.swift */; };
+		5E2A66D6828E4676B5013F2F /* Pods_PubNubContractTestsBeta.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4DFF8F32FAE8CF54FE26F4F9 /* Pods_PubNubContractTestsBeta.framework */; };
 		79407BD2271D4CFA0032076C /* PubNubContractTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79407BBF271D4CFA0032076C /* PubNubContractTestCase.swift */; };
 		79407BD3271D4CFA0032076C /* PubNubContractTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79407BBF271D4CFA0032076C /* PubNubContractTestCase.swift */; };
 		79407BD4271D4CFA0032076C /* PubNubContractCucumberTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 79407BC0271D4CFA0032076C /* PubNubContractCucumberTest.m */; };
@@ -398,9 +404,9 @@
 		79407BE5271D4CFA0032076C /* PubNubFilesContractTestSteps.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79407BD1271D4CFA0032076C /* PubNubFilesContractTestSteps.swift */; };
 		79407C00271D519F0032076C /* Features in Resources */ = {isa = PBXBuildFile; fileRef = 79407BFF271D519F0032076C /* Features */; };
 		79407C01271D519F0032076C /* Features in Resources */ = {isa = PBXBuildFile; fileRef = 79407BFF271D519F0032076C /* Features */; };
-		7941EEA9270E433F0054D9EF /* PubNub.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = PubNub::PubNub::Product /* PubNub.framework */; platformFilter = ios; };
+		7941EEA9270E433F0054D9EF /* PubNub.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "PubNub::PubNub::Product" /* PubNub.framework */; platformFilter = ios; };
 		7951954E26C955CE001E308C /* PAMToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7951954D26C955CE001E308C /* PAMToken.swift */; };
-		79657AA3271A13F700BACEC5 /* PubNub.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = PubNub::PubNub::Product /* PubNub.framework */; platformFilter = ios; };
+		79657AA3271A13F700BACEC5 /* PubNub.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "PubNub::PubNub::Product" /* PubNub.framework */; platformFilter = ios; };
 		A5115F2529195AF400F6ADA1 /* PubNubObjectsMembersContractTestSteps.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5115F2429195AF400F6ADA1 /* PubNubObjectsMembersContractTestSteps.swift */; };
 		A5115F2629195AF400F6ADA1 /* PubNubObjectsMembersContractTestSteps.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5115F2429195AF400F6ADA1 /* PubNubObjectsMembersContractTestSteps.swift */; };
 		A5115F28291D54F500F6ADA1 /* PubNubObjectsMembershipsContractTestSteps.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5115F27291D54F500F6ADA1 /* PubNubObjectsMembershipsContractTestSteps.swift */; };
@@ -413,10 +419,11 @@
 		A56445F32907D9FD0085B310 /* PubNubObjectsChannelMetadataContractTestSteps.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56445F12907D9FD0085B310 /* PubNubObjectsChannelMetadataContractTestSteps.swift */; };
 		A5F19EE329126D8200F185A9 /* PubNubObjectsUUIDMetadataContractTestSteps.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F19EE229126D8200F185A9 /* PubNubObjectsUUIDMetadataContractTestSteps.swift */; };
 		A5F19EE429126D8200F185A9 /* PubNubObjectsUUIDMetadataContractTestSteps.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F19EE229126D8200F185A9 /* PubNubObjectsUUIDMetadataContractTestSteps.swift */; };
+		C72BADCC557B67B8D143E791 /* Pods_PubNubContractTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D3AC6E1DC466C3A1E50E72F8 /* Pods_PubNubContractTests.framework */; };
 		D2635DFB22FCCF080097CF64 /* message_counts_success.json in Resources */ = {isa = PBXBuildFile; fileRef = D2635DFA22FCCF080097CF64 /* message_counts_success.json */; };
 		OBJ_31 /* PubNub.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* PubNub.swift */; };
 		OBJ_49 /* PubNubTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_15 /* PubNubTests.swift */; };
-		OBJ_51 /* PubNub.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = PubNub::PubNub::Product /* PubNub.framework */; };
+		OBJ_51 /* PubNub.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "PubNub::PubNub::Product" /* PubNub.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -895,6 +902,13 @@
 		35FE941722EFCB7F0051C455 /* SessionStreamTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStreamTests.swift; sourceTree = "<group>"; };
 		35FE941A22EFE5400051C455 /* EventStreamTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventStreamTests.swift; sourceTree = "<group>"; };
 		35FE941E22F0929A0051C455 /* RequestRetrierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestRetrierTests.swift; sourceTree = "<group>"; };
+		39F8A326548760AB6DB4774A /* Pods-PubNubContractTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PubNubContractTests.release.xcconfig"; path = "Target Support Files/Pods-PubNubContractTests/Pods-PubNubContractTests.release.xcconfig"; sourceTree = "<group>"; };
+		3DF66BEC29C34B2C001C7BDB /* Dispatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dispatcher.swift; sourceTree = "<group>"; };
+		3DF66BED29C34B2C001C7BDB /* EffectHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EffectHandler.swift; sourceTree = "<group>"; };
+		3DF66BEE29C34B2C001C7BDB /* EventEngine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventEngine.swift; sourceTree = "<group>"; };
+		3DF66BEF29C34B2C001C7BDB /* TransitionProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransitionProtocol.swift; sourceTree = "<group>"; };
+		3DF66BF129C34B2C001C7BDB /* Subscribe.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Subscribe.swift; sourceTree = "<group>"; };
+		4DFF8F32FAE8CF54FE26F4F9 /* Pods_PubNubContractTestsBeta.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PubNubContractTestsBeta.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		793079152667C63700F23B72 /* CODEOWNERS */ = {isa = PBXFileReference; lastKnownFileType = text; path = CODEOWNERS; sourceTree = "<group>"; };
 		793079172667C63700F23B72 /* validate-yml.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = "validate-yml.js"; sourceTree = "<group>"; };
 		793079182667C63700F23B72 /* validate-pubnub-yml.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = "validate-pubnub-yml.yml"; sourceTree = "<group>"; };
@@ -914,13 +928,17 @@
 		7941EF47270E46B40054D9EF /* PubNubContractTests_Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = PubNubContractTests_Info.plist; path = PubNub.xcodeproj/PubNubContractTests_Info.plist; sourceTree = SOURCE_ROOT; };
 		7951954D26C955CE001E308C /* PAMToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PAMToken.swift; sourceTree = "<group>"; };
 		79657AAB271A13F700BACEC5 /* PubNubContractTestsBeta.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PubNubContractTestsBeta.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		90AAAE4CD20FD22798B9BE85 /* Pods-PubNubContractTestsBeta.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PubNubContractTestsBeta.debug.xcconfig"; path = "Target Support Files/Pods-PubNubContractTestsBeta/Pods-PubNubContractTestsBeta.debug.xcconfig"; sourceTree = "<group>"; };
+		951D7D83E33CBF8D3570CA4D /* Pods-PubNubContractTestsBeta.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PubNubContractTestsBeta.release.xcconfig"; path = "Target Support Files/Pods-PubNubContractTestsBeta/Pods-PubNubContractTestsBeta.release.xcconfig"; sourceTree = "<group>"; };
 		A5115F2429195AF400F6ADA1 /* PubNubObjectsMembersContractTestSteps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PubNubObjectsMembersContractTestSteps.swift; sourceTree = "<group>"; };
 		A5115F27291D54F500F6ADA1 /* PubNubObjectsMembershipsContractTestSteps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PubNubObjectsMembershipsContractTestSteps.swift; sourceTree = "<group>"; };
 		A5115F2A291D5C2700F6ADA1 /* PubNubObjectsContractTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PubNubObjectsContractTests.swift; sourceTree = "<group>"; };
 		A56445EE2906AFF40085B310 /* PubNubObjectsTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PubNubObjectsTestHelpers.swift; sourceTree = "<group>"; };
 		A56445F12907D9FD0085B310 /* PubNubObjectsChannelMetadataContractTestSteps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PubNubObjectsChannelMetadataContractTestSteps.swift; sourceTree = "<group>"; };
 		A5F19EE229126D8200F185A9 /* PubNubObjectsUUIDMetadataContractTestSteps.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PubNubObjectsUUIDMetadataContractTestSteps.swift; sourceTree = "<group>"; };
+		CCADB72BD88F5B561D189EF5 /* Pods-PubNubContractTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PubNubContractTests.debug.xcconfig"; path = "Target Support Files/Pods-PubNubContractTests/Pods-PubNubContractTests.debug.xcconfig"; sourceTree = "<group>"; };
 		D2635DFA22FCCF080097CF64 /* message_counts_success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = message_counts_success.json; sourceTree = "<group>"; };
+		D3AC6E1DC466C3A1E50E72F8 /* Pods_PubNubContractTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PubNubContractTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		OBJ_11 /* PubNub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PubNub.swift; sourceTree = "<group>"; };
 		OBJ_15 /* PubNubTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PubNubTests.swift; sourceTree = "<group>"; };
 		OBJ_21 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
@@ -928,8 +946,8 @@
 		OBJ_24 /* PubNubSwift.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; path = PubNubSwift.podspec; sourceTree = "<group>"; };
 		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		OBJ_9 /* PubNub.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PubNub.h; sourceTree = "<group>"; };
-		PubNub::PubNub::Product /* PubNub.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PubNub.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		PubNub::PubNubTests::Product /* PubNubTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; path = PubNubTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		"PubNub::PubNub::Product" /* PubNub.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PubNub.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"PubNub::PubNubTests::Product" /* PubNubTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; path = PubNubTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1015,6 +1033,7 @@
 			buildActionMask = 0;
 			files = (
 				7941EEA9270E433F0054D9EF /* PubNub.framework in Frameworks */,
+				C72BADCC557B67B8D143E791 /* Pods_PubNubContractTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1023,6 +1042,7 @@
 			buildActionMask = 0;
 			files = (
 				79657AA3271A13F700BACEC5 /* PubNub.framework in Frameworks */,
+				5E2A66D6828E4676B5013F2F /* Pods_PubNubContractTestsBeta.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1874,8 +1894,49 @@
 		3DBD7CDD58292DFFDF108B95 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
+				CCADB72BD88F5B561D189EF5 /* Pods-PubNubContractTests.debug.xcconfig */,
+				39F8A326548760AB6DB4774A /* Pods-PubNubContractTests.release.xcconfig */,
+				90AAAE4CD20FD22798B9BE85 /* Pods-PubNubContractTestsBeta.debug.xcconfig */,
+				951D7D83E33CBF8D3570CA4D /* Pods-PubNubContractTestsBeta.release.xcconfig */,
 			);
 			path = Pods;
+			sourceTree = "<group>";
+		};
+		3DF66BEA29C34B2C001C7BDB /* EventEngine */ = {
+			isa = PBXGroup;
+			children = (
+				3DF66BEB29C34B2C001C7BDB /* Core */,
+				3DF66BF029C34B2C001C7BDB /* Showcase */,
+			);
+			path = EventEngine;
+			sourceTree = "<group>";
+		};
+		3DF66BEB29C34B2C001C7BDB /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				3DF66BEC29C34B2C001C7BDB /* Dispatcher.swift */,
+				3DF66BED29C34B2C001C7BDB /* EffectHandler.swift */,
+				3DF66BEE29C34B2C001C7BDB /* EventEngine.swift */,
+				3DF66BEF29C34B2C001C7BDB /* TransitionProtocol.swift */,
+			);
+			path = Core;
+			sourceTree = "<group>";
+		};
+		3DF66BF029C34B2C001C7BDB /* Showcase */ = {
+			isa = PBXGroup;
+			children = (
+				3DF66BF129C34B2C001C7BDB /* Subscribe.swift */,
+			);
+			path = Showcase;
+			sourceTree = "<group>";
+		};
+		4FE4B403E611F731B37A5B6F /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				D3AC6E1DC466C3A1E50E72F8 /* Pods_PubNubContractTests.framework */,
+				4DFF8F32FAE8CF54FE26F4F9 /* Pods_PubNubContractTestsBeta.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		793079142667C63700F23B72 /* .github */ = {
@@ -2034,8 +2095,8 @@
 		OBJ_17 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				PubNub::PubNubTests::Product /* PubNubTests.xctest */,
-				PubNub::PubNub::Product /* PubNub.framework */,
+				"PubNub::PubNubTests::Product" /* PubNubTests.xctest */,
+				"PubNub::PubNub::Product" /* PubNub.framework */,
 				3558073723145749005CDD92 /* PubNubIntTests.xctest */,
 				7941EF40270E433F0054D9EF /* PubNubContractTests.xctest */,
 				79657AAB271A13F700BACEC5 /* PubNubContractTestsBeta.xctest */,
@@ -2064,6 +2125,7 @@
 				OBJ_12 /* Tests */,
 				OBJ_17 /* Products */,
 				3DBD7CDD58292DFFDF108B95 /* Pods */,
+				4FE4B403E611F731B37A5B6F /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -2072,6 +2134,7 @@
 			children = (
 				OBJ_11 /* PubNub.swift */,
 				359152A022BA9AA30048842D /* PubNubConfiguration.swift */,
+				3DF66BEA29C34B2C001C7BDB /* EventEngine */,
 				35B0ACE4252BE37C00537A18 /* APIs */,
 				35DB0C49287475F9001E1F76 /* Core */,
 				3580A59B22F128A300B12E5E /* Errors */,
@@ -2304,9 +2367,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 7941EF3D270E433F0054D9EF /* Build configuration list for PBXNativeTarget "PubNubContractTests" */;
 			buildPhases = (
+				DAE84ACA6D075FDF4B11EE0B /* [CP] Check Pods Manifest.lock */,
 				7941EE6E270E433F0054D9EF /* Sources */,
 				7941EEA8270E433F0054D9EF /* Frameworks */,
 				7941EEAA270E433F0054D9EF /* Resources */,
+				24B7402537CAC40F7CE4ED7E /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -2322,9 +2387,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 79657AA8271A13F700BACEC5 /* Build configuration list for PBXNativeTarget "PubNubContractTestsBeta" */;
 			buildPhases = (
+				7D6A46EEE1CBC774CAF7D905 /* [CP] Check Pods Manifest.lock */,
 				79657A97271A13F700BACEC5 /* Sources */,
 				79657AA2271A13F700BACEC5 /* Frameworks */,
 				79657AA5271A13F700BACEC5 /* Resources */,
+				231D40FEFDF810A9FBBB7C41 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -2336,7 +2403,7 @@
 			productReference = 79657AAB271A13F700BACEC5 /* PubNubContractTestsBeta.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		PubNub::PubNub /* PubNub */ = {
+		"PubNub::PubNub" /* PubNub */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = OBJ_27 /* Build configuration list for PBXNativeTarget "PubNub" */;
 			buildPhases = (
@@ -2349,10 +2416,10 @@
 			);
 			name = PubNub;
 			productName = PubNub;
-			productReference = PubNub::PubNub::Product /* PubNub.framework */;
+			productReference = "PubNub::PubNub::Product" /* PubNub.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		PubNub::PubNubTests /* PubNubTests */ = {
+		"PubNub::PubNubTests" /* PubNubTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = OBJ_45 /* Build configuration list for PBXNativeTarget "PubNubTests" */;
 			buildPhases = (
@@ -2367,7 +2434,7 @@
 			);
 			name = PubNubTests;
 			productName = PubNubTests;
-			productReference = PubNub::PubNubTests::Product /* PubNubTests.xctest */;
+			productReference = "PubNub::PubNubTests::Product" /* PubNubTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
@@ -2420,8 +2487,8 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				PubNub::PubNub /* PubNub */,
-				PubNub::PubNubTests /* PubNubTests */,
+				"PubNub::PubNub" /* PubNub */,
+				"PubNub::PubNubTests" /* PubNubTests */,
 				7941EE6B270E433F0054D9EF /* PubNubContractTests */,
 				79657A93271A13F700BACEC5 /* PubNubContractTestsBeta */,
 				3558069D23145749005CDD92 /* PubNubIntegration */,
@@ -2682,6 +2749,40 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		231D40FEFDF810A9FBBB7C41 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-PubNubContractTestsBeta/Pods-PubNubContractTestsBeta-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-PubNubContractTestsBeta/Pods-PubNubContractTestsBeta-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-PubNubContractTestsBeta/Pods-PubNubContractTestsBeta-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		24B7402537CAC40F7CE4ED7E /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-PubNubContractTests/Pods-PubNubContractTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-PubNubContractTests/Pods-PubNubContractTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-PubNubContractTests/Pods-PubNubContractTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		359152A822BA9F5B0048842D /* Swift Format */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -2717,6 +2818,50 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "swiftlint\n";
+		};
+		7D6A46EEE1CBC774CAF7D905 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-PubNubContractTestsBeta-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		DAE84ACA6D075FDF4B11EE0B /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-PubNubContractTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -2892,6 +3037,7 @@
 				35D0615F2304830600FDB2F9 /* GenericServicePayloadResponse.swift in Sources */,
 				35A66A8E22F911DB00AC67A9 /* SubscribeSessionFactory.swift in Sources */,
 				35D8D4C522EB4600001B07D9 /* AnyJSON.swift in Sources */,
+				3DF66BF329C34B2C001C7BDB /* EffectHandler.swift in Sources */,
 				35AC16332487179400A66030 /* PubNubPage.swift in Sources */,
 				35AC162F2486C9A400A66030 /* PubNubMessageAction.swift in Sources */,
 				3585033B22CD545400A11D9A /* URLRequest+PubNub.swift in Sources */,
@@ -2909,6 +3055,7 @@
 				356D48B32360BD6B00C65C40 /* EventStream.swift in Sources */,
 				35C6B6E322F515760054F242 /* SubscribeRouter.swift in Sources */,
 				35C6B6DD22F501780054F242 /* Encodable+PubNub.swift in Sources */,
+				3DF66BF429C34B2C001C7BDB /* EventEngine.swift in Sources */,
 				35580682230F3A34005CDD92 /* RequestIdOperator.swift in Sources */,
 				35A66A8322F861BA00AC67A9 /* PubNubMessage.swift in Sources */,
 				35A66A8022F861BA00AC67A9 /* AutomaticRetry.swift in Sources */,
@@ -2933,10 +3080,12 @@
 				35133196253115C500242CC2 /* CryptoStream.swift in Sources */,
 				35D8D4CD22EB90F1001B07D9 /* Int+PubNub.swift in Sources */,
 				35B3824A233AAB8C0028803F /* JSONCodable.swift in Sources */,
+				3DF66BF629C34B2C001C7BDB /* Subscribe.swift in Sources */,
 				35599792230A3F11000BCFD1 /* Thread+PubNub.swift in Sources */,
 				3567434822E1E4F700BF2639 /* Collection+PubNub.swift in Sources */,
 				354FC4C122D04D3600318932 /* DispatchQueue+PubNub.swift in Sources */,
 				359512102301DCAB00C9D3AE /* Crypto.swift in Sources */,
+				3DF66BF529C34B2C001C7BDB /* TransitionProtocol.swift in Sources */,
 				354ADA8E22DA7F280093EFFB /* SessionStream.swift in Sources */,
 				3534D4E822C67D0E008E89FA /* OperationQueue+PubNub.swift in Sources */,
 				3585A02423C63EE900FDA860 /* CBORSerialization.swift in Sources */,
@@ -2959,6 +3108,7 @@
 				353F78C42527934500FFB72C /* InputStream+PubNub.swift in Sources */,
 				353E8CE423C68F01003FBFF5 /* Float32+PubNub.swift in Sources */,
 				352DBFE9237C937F00A0106E /* HTTPSessionDelegate.swift in Sources */,
+				3DF66BF229C34B2C001C7BDB /* Dispatcher.swift in Sources */,
 				35CF548E248971CD0099FE81 /* ObjectsChannelRouter.swift in Sources */,
 				35A6C7BE22FCCBF900E97CC5 /* HistoryRouter.swift in Sources */,
 				35A66A9022F913B200AC67A9 /* ConnectionStatus.swift in Sources */,
@@ -3061,7 +3211,7 @@
 /* Begin PBXTargetDependency section */
 		3558069E23145749005CDD92 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = PubNub::PubNub /* PubNub */;
+			target = "PubNub::PubNub" /* PubNub */;
 			targetProxy = 3558069F23145749005CDD92 /* PBXContainerItemProxy */;
 		};
 		358B8917284D206B00DB0F3D /* PBXTargetDependency */ = {
@@ -3081,17 +3231,17 @@
 		};
 		358B8962284D22B100DB0F3D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = PubNub::PubNub /* PubNub */;
+			target = "PubNub::PubNub" /* PubNub */;
 			targetProxy = 358B8961284D22B100DB0F3D /* PBXContainerItemProxy */;
 		};
 		358B8966284D22D800DB0F3D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = PubNub::PubNub /* PubNub */;
+			target = "PubNub::PubNub" /* PubNub */;
 			targetProxy = 358B8965284D22D800DB0F3D /* PBXContainerItemProxy */;
 		};
 		358B8968284D22E200DB0F3D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = PubNub::PubNub /* PubNub */;
+			target = "PubNub::PubNub" /* PubNub */;
 			targetProxy = 358B8967284D22E200DB0F3D /* PBXContainerItemProxy */;
 		};
 		358B896A284D22E200DB0F3D /* PBXTargetDependency */ = {
@@ -3122,18 +3272,18 @@
 		7941EE6C270E433F0054D9EF /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			platformFilter = ios;
-			target = PubNub::PubNub /* PubNub */;
+			target = "PubNub::PubNub" /* PubNub */;
 			targetProxy = 7941EE6D270E433F0054D9EF /* PBXContainerItemProxy */;
 		};
 		79657A94271A13F700BACEC5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			platformFilter = ios;
-			target = PubNub::PubNub /* PubNub */;
+			target = "PubNub::PubNub" /* PubNub */;
 			targetProxy = 79657A95271A13F700BACEC5 /* PBXContainerItemProxy */;
 		};
 		OBJ_52 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = PubNub::PubNub /* PubNub */;
+			target = "PubNub::PubNub" /* PubNub */;
 			targetProxy = 35EA73F422B1916100D97BF0 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
@@ -3871,6 +4021,7 @@
 		};
 		7941EF3E270E433F0054D9EF /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = CCADB72BD88F5B561D189EF5 /* Pods-PubNubContractTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
@@ -3912,6 +4063,7 @@
 		};
 		7941EF3F270E433F0054D9EF /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 39F8A326548760AB6DB4774A /* Pods-PubNubContractTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
@@ -3952,6 +4104,7 @@
 		};
 		79657AA9271A13F700BACEC5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 90AAAE4CD20FD22798B9BE85 /* Pods-PubNubContractTestsBeta.debug.xcconfig */;
 			buildSettings = {
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
@@ -3994,6 +4147,7 @@
 		};
 		79657AAA271A13F700BACEC5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 951D7D83E33CBF8D3570CA4D /* Pods-PubNubContractTestsBeta.release.xcconfig */;
 			buildSettings = {
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;

--- a/Sources/PubNub/EventEngine/Core/Dispatcher.swift
+++ b/Sources/PubNub/EventEngine/Core/Dispatcher.swift
@@ -31,31 +31,31 @@ import Foundation
 /// Protocol for any type that can dispatch, track and schedule Effects.
 /// Concrete implementations are responsible to schedule effects, tracking pending operations, and canceling them on behalf caller's request.
 ///
-protocol Dispatcher<Kind, Action> {
-  associatedtype Kind
+protocol Dispatcher<EffectKind, Action> {
+  associatedtype EffectKind
   associatedtype Action
     
-  var factory: any EffectHandlerFactory<Kind, Action> { get }
+  var factory: any EffectHandlerFactory<EffectKind, Action> { get }
   
-  func dispatch(invocations: [EffectInvocation<Kind, Action>])
+  func dispatch(invocations: [EffectInvocation<EffectKind, Action>])
 }
 
 ///
 /// Default implementation for Dispatcher.
 ///
-class EffectDispatcher<Kind, Action>: Dispatcher {
-  private(set) var factory: any EffectHandlerFactory<Kind, Action>
-  // private(set) var pendingEffects: [String: any EffectHandler<Kind, Action>] = [:]
+class EffectDispatcher<EffectKind, Action>: Dispatcher {
+  private(set) var factory: any EffectHandlerFactory<EffectKind, Action>
+  private(set) var pendingEffects: [String: any EffectHandler] = [:]
   
-  init(factory: some EffectHandlerFactory<Kind, Action>) {
+  init(factory: some EffectHandlerFactory<EffectKind, Action>) {
     self.factory = factory
   }
   
-  func dispatch(invocations: [EffectInvocation<Kind, Action>]) {
+  func dispatch(invocations: [EffectInvocation<EffectKind, Action>]) {
     for invocation in invocations {
       let effect = factory.effect(for: invocation)
-//      pendingEffects[invocation.identifier]?.cancel()
-//      pendingEffects[invocation.identifier] = effect
+      pendingEffects[invocation.identifier]?.cancel()
+      pendingEffects[invocation.identifier] = effect
       effect.start()
     }
   }

--- a/Sources/PubNub/EventEngine/Core/Dispatcher.swift
+++ b/Sources/PubNub/EventEngine/Core/Dispatcher.swift
@@ -37,7 +37,10 @@ protocol Dispatcher<EffectKind, Event> {
     
   var factory: any EffectHandlerFactory<EffectKind, Event> { get }
   
-  func dispatch(invocations: [EffectInvocation<EffectKind, Event>])
+  func dispatch(
+    invocations: [EffectInvocation<EffectKind, Event>],
+    eventDispatcher: some EventDispatcher<Event>
+  )
 }
 
 ///
@@ -59,9 +62,12 @@ class EffectDispatcher<EffectKind, Event>: Dispatcher {
     self.factory = factory
   }
   
-  func dispatch(invocations: [EffectInvocation<EffectKind, Event>]) {
+  func dispatch(
+    invocations: [EffectInvocation<EffectKind, Event>],
+    eventDispatcher: some EventDispatcher<Event>
+  ) {
     for invocation in invocations {
-      let effect = factory.effect(for: invocation)
+      let effect = factory.effect(for: invocation, with: eventDispatcher)
       pendingEffects[invocation.identifier]?.effect.cancel()
       pendingEffects[invocation.identifier] = Box<EffectKind, Event>(effect: effect)
       effect.start()

--- a/Sources/PubNub/EventEngine/Core/Dispatcher.swift
+++ b/Sources/PubNub/EventEngine/Core/Dispatcher.swift
@@ -39,7 +39,7 @@ protocol Dispatcher<EffectKind, Event> {
   
   func dispatch(
     invocations: [EffectInvocation<EffectKind, Event>],
-    eventDispatcher: some EventDispatcher<Event>
+    receiver: some EventReceiver<Event>
   )
 }
 
@@ -64,13 +64,13 @@ class EffectDispatcher<EffectKind, Event>: Dispatcher {
   
   func dispatch(
     invocations: [EffectInvocation<EffectKind, Event>],
-    eventDispatcher: some EventDispatcher<Event>
+    receiver: some EventReceiver<Event>
   ) {
     for invocation in invocations {
       let effect = factory.effect(for: invocation, with: eventDispatcher)
       pendingEffects[invocation.identifier]?.effect.cancel()
       pendingEffects[invocation.identifier] = Box<EffectKind, Event>(effect: effect)
-      effect.start()
+      effect.start(onCompletion: {})
     }
   }
 }

--- a/Sources/PubNub/EventEngine/Core/Dispatcher.swift
+++ b/Sources/PubNub/EventEngine/Core/Dispatcher.swift
@@ -1,0 +1,62 @@
+//
+//  Dispatcher.swift
+//
+//  PubNub Real-time Cloud-Hosted Push API and Push Notification Client Frameworks
+//  Copyright © 2019 PubNub Inc.
+//  https://www.pubnub.com/
+//  https://www.pubnub.com/terms
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+///
+/// Protocol for any type that can dispatch, track and schedule Effects.
+/// Concrete implementations are responsible to schedule effects, tracking pending operations, and canceling them on behalf caller's request.
+///
+protocol Dispatcher<Kind, Action> {
+  associatedtype Kind
+  associatedtype Action
+    
+  var factory: any EffectHandlerFactory<Kind, Action> { get }
+  
+  func dispatch(invocations: [EffectInvocation<Kind, Action>])
+}
+
+///
+/// Default implementation for Dispatcher.
+///
+class EffectDispatcher<Kind, Action>: Dispatcher {
+  private(set) var factory: any EffectHandlerFactory<Kind, Action>
+  // private(set) var pendingEffects: [String: any EffectHandler<Kind, Action>] = [:]
+  
+  init(factory: some EffectHandlerFactory<Kind, Action>) {
+    self.factory = factory
+  }
+  
+  func dispatch(invocations: [EffectInvocation<Kind, Action>]) {
+    for invocation in invocations {
+      let effect = factory.effect(for: invocation)
+//      pendingEffects[invocation.identifier]?.cancel()
+//      pendingEffects[invocation.identifier] = effect
+      effect.start()
+    }
+  }
+}

--- a/Sources/PubNub/EventEngine/Core/EffectHandler.swift
+++ b/Sources/PubNub/EventEngine/Core/EffectHandler.swift
@@ -34,7 +34,10 @@ protocol EffectHandlerFactory<EffectKind, Event> {
   associatedtype EffectKind
   associatedtype Event
   
-  func effect(for invocation: EffectInvocation<EffectKind, Event>) -> any EffectHandler<EffectKind, Event>
+  func effect(
+    for invocation: EffectInvocation<EffectKind, Event>,
+    with eventDispatcher: some EventDispatcher<Event>
+  ) -> any EffectHandler<EffectKind, Event>
 }
 
 ///
@@ -47,6 +50,7 @@ protocol EffectHandler<EffectKind, Event> {
   associatedtype Event
   
   var invocation: EffectInvocation<EffectKind, Event> { get }
+  var eventDispatcher: any EventDispatcher<Event> { get }
   
   func start()
   func cancel()
@@ -58,9 +62,14 @@ protocol EffectHandler<EffectKind, Event> {
 ///
 class BaseEffectHandler<EffectKind, Event>: EffectHandler {
   var invocation: EffectInvocation<EffectKind, Event>
+  var eventDispatcher: any EventDispatcher<Event>
   
-  init(invocation: EffectInvocation<EffectKind, Event>) {
+  init(
+    invocation: EffectInvocation<EffectKind, Event>,
+    eventDispatcher: some EventDispatcher<Event>
+  ) {
     self.invocation = invocation
+    self.eventDispatcher = eventDispatcher
   }
   
   func start() {}

--- a/Sources/PubNub/EventEngine/Core/EffectHandler.swift
+++ b/Sources/PubNub/EventEngine/Core/EffectHandler.swift
@@ -2,7 +2,7 @@
 //  Dispatcher.swift
 //
 //  PubNub Real-time Cloud-Hosted Push API and Push Notification Client Frameworks
-//  Copyright © 2019 PubNub Inc.
+//  Copyright © 2023 PubNub Inc.
 //  https://www.pubnub.com/
 //  https://www.pubnub.com/terms
 //
@@ -30,11 +30,11 @@ import Foundation
 /// Protocol for any type that's responsible for returning a concrete Effect according to provided `EffectInvocation`
 /// This should be the only one allowed way to create a new Effect.
 ///
-protocol EffectHandlerFactory<EffectKind, Action> {
+protocol EffectHandlerFactory<EffectKind, Event> {
   associatedtype EffectKind
-  associatedtype Action
+  associatedtype Event
   
-  func effect(for invocation: EffectInvocation<EffectKind, Action>) -> any EffectHandler
+  func effect(for invocation: EffectInvocation<EffectKind, Event>) -> any EffectHandler<EffectKind, Event>
 }
 
 ///
@@ -42,11 +42,11 @@ protocol EffectHandlerFactory<EffectKind, Action> {
 /// Concrete types are responsible to implement both `start()` and `cancel()` methods.
 /// It's also required to call either `onCompletion:` or `onCancel:` on the underlying `invocation` object in order to notify that the Effect's job has been finished.
 ///
-protocol EffectHandler {
+protocol EffectHandler<EffectKind, Event> {
   associatedtype EffectKind
-  associatedtype Action
+  associatedtype Event
   
-  var invocation: EffectInvocation<EffectKind, Action> { get }
+  var invocation: EffectInvocation<EffectKind, Event> { get }
   
   func start()
   func cancel()
@@ -56,10 +56,13 @@ protocol EffectHandler {
 /// Base effect handler class you can inherit from.
 /// You don't have to specify the `invocation` field due to conformance for `EffectHandler`,  inherit from this class.
 ///
-class BaseEffectHandler<EffectKind, Action> {
-  var invocation: EffectInvocation<EffectKind, Action>
+class BaseEffectHandler<EffectKind, Event>: EffectHandler {
+  var invocation: EffectInvocation<EffectKind, Event>
   
-  init(invocation: EffectInvocation<EffectKind, Action>) {
+  init(invocation: EffectInvocation<EffectKind, Event>) {
     self.invocation = invocation
   }
+  
+  func start() {}
+  func cancel() {}
 }

--- a/Sources/PubNub/EventEngine/Core/EffectHandler.swift
+++ b/Sources/PubNub/EventEngine/Core/EffectHandler.swift
@@ -27,27 +27,39 @@
 import Foundation
 
 ///
-/// Protocol for any type that's responsible to return a concrete Effect according to provided `EffectInvocation`
+/// Protocol for any type that's responsible for returning a concrete Effect according to provided `EffectInvocation`
 /// This should be the only one allowed way to create a new Effect.
 ///
-protocol EffectHandlerFactory<Kind, Action> {
-  associatedtype Kind
+protocol EffectHandlerFactory<EffectKind, Action> {
+  associatedtype EffectKind
   associatedtype Action
   
-  func effect(for invocation: EffectInvocation<Kind, Action>) -> any EffectHandler<Kind, Action>
+  func effect(for invocation: EffectInvocation<EffectKind, Action>) -> any EffectHandler
 }
 
 ///
-/// Protocol for any type that can perform an Effect. Effect can be returned from the factory mentioned above.
+/// Protocol for any type that can perform an Effect. An effect can be returned from the factory mentioned above.
 /// Concrete types are responsible to implement both `start()` and `cancel()` methods.
 /// It's also required to call either `onCompletion:` or `onCancel:` on the underlying `invocation` object in order to notify that the Effect's job has been finished.
 ///
-protocol EffectHandler<Kind, Action> {
-  associatedtype Kind
+protocol EffectHandler {
+  associatedtype EffectKind
   associatedtype Action
   
-  var invocation: EffectInvocation<Kind, Action> { get }
+  var invocation: EffectInvocation<EffectKind, Action> { get }
   
   func start()
   func cancel()
+}
+
+///
+/// Base effect handler class you can inherit from.
+/// You don't have to specify the `invocation` field due to conformance for `EffectHandler`,  inherit from this class.
+///
+class BaseEffectHandler<EffectKind, Action> {
+  var invocation: EffectInvocation<EffectKind, Action>
+  
+  init(invocation: EffectInvocation<EffectKind, Action>) {
+    self.invocation = invocation
+  }
 }

--- a/Sources/PubNub/EventEngine/Core/EffectHandler.swift
+++ b/Sources/PubNub/EventEngine/Core/EffectHandler.swift
@@ -1,0 +1,53 @@
+//
+//  Dispatcher.swift
+//
+//  PubNub Real-time Cloud-Hosted Push API and Push Notification Client Frameworks
+//  Copyright © 2019 PubNub Inc.
+//  https://www.pubnub.com/
+//  https://www.pubnub.com/terms
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+import Foundation
+
+///
+/// Protocol for any type that's responsible to return a concrete Effect according to provided `EffectInvocation`
+/// This should be the only one allowed way to create a new Effect.
+///
+protocol EffectHandlerFactory<Kind, Action> {
+  associatedtype Kind
+  associatedtype Action
+  
+  func effect(for invocation: EffectInvocation<Kind, Action>) -> any EffectHandler<Kind, Action>
+}
+
+///
+/// Protocol for any type that can perform an Effect. Effect can be returned from the factory mentioned above.
+/// Concrete types are responsible to implement both `start()` and `cancel()` methods.
+/// It's also required to call either `onCompletion:` or `onCancel:` on the underlying `invocation` object in order to notify that the Effect's job has been finished.
+///
+protocol EffectHandler<Kind, Action> {
+  associatedtype Kind
+  associatedtype Action
+  
+  var invocation: EffectInvocation<Kind, Action> { get }
+  
+  func start()
+  func cancel()
+}

--- a/Sources/PubNub/EventEngine/Core/EventEngine.swift
+++ b/Sources/PubNub/EventEngine/Core/EventEngine.swift
@@ -2,7 +2,7 @@
 //  EventEngine.swift
 //
 //  PubNub Real-time Cloud-Hosted Push API and Push Notification Client Frameworks
-//  Copyright © 2019 PubNub Inc.
+//  Copyright © 2023 PubNub Inc.
 //  https://www.pubnub.com/
 //  https://www.pubnub.com/terms
 //
@@ -32,24 +32,25 @@ import Foundation
 /// This class provides a template that allows a caller to specify the concrete types for Event Engine like its State, possible Actions to take, or Effects kind that this Engine produces.
 /// See the `Showcase.swift` file in order to see the example usage.
 ///
-class EventEngine<State: AnyState, Action, EffectKind> {
-  var transition: any TransitionProtocol<State, Action, EffectKind>
-  var dispatcher: any Dispatcher<EffectKind, Action>
+class EventEngine<State: AnyState, Event, EffectKind> {
+  var transition: any TransitionProtocol<State, Event, EffectKind>
+  var dispatcher: any Dispatcher<EffectKind, Event>
   var currentState: State
   
   init(
-    transition: some TransitionProtocol<State, Action, EffectKind>,
-    dispatcher: some Dispatcher<EffectKind, Action>
+    state: State,
+    transition: some TransitionProtocol<State, Event, EffectKind>,
+    dispatcher: some Dispatcher<EffectKind, Event>
   ) {
     self.transition = transition
-    self.currentState = transition.defaultState()
+    self.currentState = state
     self.dispatcher = dispatcher
   }
   
-  func send(action: Action) {
+  func send(event: Event) {
     let result = transition.transition(
       from: currentState,
-      action: action
+      event: event
     )
     
     currentState = result.state
@@ -57,9 +58,9 @@ class EventEngine<State: AnyState, Action, EffectKind> {
     for var invocation in result.invocations {
       invocation.onCompletion = { [weak self] result in
         switch result {
-        case .success(let action):
-          if let action = action {
-            self?.send(action: action)
+        case .success(let actions):
+          actions.forEach() {
+            self?.send(event: $0)
           }
         case .failure(let error):
           debugPrint("Error: \(error)")

--- a/Sources/PubNub/EventEngine/Core/EventEngine.swift
+++ b/Sources/PubNub/EventEngine/Core/EventEngine.swift
@@ -1,0 +1,75 @@
+//
+//  EventEngine.swift
+//
+//  PubNub Real-time Cloud-Hosted Push API and Push Notification Client Frameworks
+//  Copyright © 2019 PubNub Inc.
+//  https://www.pubnub.com/
+//  https://www.pubnub.com/terms
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+///
+/// The class that represents the Event Engine.
+/// This class provides a template that allows a caller to specify the concrete types for Event Engine like its State, possible Actions to receive or Effects kind that this engine produces.
+/// See the `Showcase.swift` file in order to see the example usage.
+///
+class EventEngine<State, Action, Kind> {
+  var transition: any TransitionProtocol<State, Action, Kind>
+  var dispatcher: any Dispatcher<Kind, Action>
+  var currentState: State
+  
+  init(
+    transition: some TransitionProtocol<State, Action, Kind>,
+    dispatcher: some Dispatcher<Kind, Action>
+  ) {
+    self.transition = transition
+    self.currentState = transition.defaultState()
+    self.dispatcher = dispatcher
+  }
+  
+  func dispatch(action: Action) {
+    let result = transition.transition(
+      from: currentState,
+      action: action
+    )
+    
+    currentState = result.state
+    
+    for var invocation in result.invocations {
+      invocation.onCompletion = { [weak self] result in
+        switch result {
+        case .success(let action):
+          if let action = action {
+            self?.dispatch(action: action)
+          }
+        case .failure(let error):
+          debugPrint("Error: \(error)")
+        }
+      }
+      invocation.onCancel = {
+        debugPrint("On cancel")
+      }
+    }
+    
+    dispatcher.dispatch(invocations: result.invocations)
+  }
+}

--- a/Sources/PubNub/EventEngine/Core/EventEngine.swift
+++ b/Sources/PubNub/EventEngine/Core/EventEngine.swift
@@ -28,11 +28,20 @@
 import Foundation
 
 ///
+/// Protocol for any type that can take and dispatch an `Event`
+///
+protocol EventDispatcher<Event> {
+  associatedtype Event
+  
+  func send(event: Event)
+}
+
+///
 /// The class that represents the Event Engine.
 /// This class provides a template that allows a caller to specify the concrete types for Event Engine like its State, possible Actions to take, or Effects kind that this Engine produces.
 /// See the `Showcase.swift` file in order to see the example usage.
 ///
-class EventEngine<State: AnyState, Event, EffectKind> {
+class EventEngine<State: AnyState, Event, EffectKind>: EventDispatcher {
   var transition: any TransitionProtocol<State, Event, EffectKind>
   var dispatcher: any Dispatcher<EffectKind, Event>
   var currentState: State
@@ -55,22 +64,9 @@ class EventEngine<State: AnyState, Event, EffectKind> {
     
     currentState = result.state
     
-    for var invocation in result.invocations {
-      invocation.onCompletion = { [weak self] result in
-        switch result {
-        case .success(let actions):
-          actions.forEach() {
-            self?.send(event: $0)
-          }
-        case .failure(let error):
-          debugPrint("Error: \(error)")
-        }
-      }
-      invocation.onCancel = {
-        debugPrint("On cancel")
-      }
-    }
-    
-    dispatcher.dispatch(invocations: result.invocations)
+    dispatcher.dispatch(
+      invocations: result.invocations,
+      eventDispatcher: self
+    )
   }
 }

--- a/Sources/PubNub/EventEngine/Core/EventEngine.swift
+++ b/Sources/PubNub/EventEngine/Core/EventEngine.swift
@@ -29,24 +29,24 @@ import Foundation
 
 ///
 /// The class that represents the Event Engine.
-/// This class provides a template that allows a caller to specify the concrete types for Event Engine like its State, possible Actions to receive or Effects kind that this engine produces.
+/// This class provides a template that allows a caller to specify the concrete types for Event Engine like its State, possible Actions to take, or Effects kind that this Engine produces.
 /// See the `Showcase.swift` file in order to see the example usage.
 ///
-class EventEngine<State, Action, Kind> {
-  var transition: any TransitionProtocol<State, Action, Kind>
-  var dispatcher: any Dispatcher<Kind, Action>
+class EventEngine<State: AnyState, Action, EffectKind> {
+  var transition: any TransitionProtocol<State, Action, EffectKind>
+  var dispatcher: any Dispatcher<EffectKind, Action>
   var currentState: State
   
   init(
-    transition: some TransitionProtocol<State, Action, Kind>,
-    dispatcher: some Dispatcher<Kind, Action>
+    transition: some TransitionProtocol<State, Action, EffectKind>,
+    dispatcher: some Dispatcher<EffectKind, Action>
   ) {
     self.transition = transition
     self.currentState = transition.defaultState()
     self.dispatcher = dispatcher
   }
   
-  func dispatch(action: Action) {
+  func send(action: Action) {
     let result = transition.transition(
       from: currentState,
       action: action
@@ -59,7 +59,7 @@ class EventEngine<State, Action, Kind> {
         switch result {
         case .success(let action):
           if let action = action {
-            self?.dispatch(action: action)
+            self?.send(action: action)
           }
         case .failure(let error):
           debugPrint("Error: \(error)")

--- a/Sources/PubNub/EventEngine/Core/TransitionProtocol.swift
+++ b/Sources/PubNub/EventEngine/Core/TransitionProtocol.swift
@@ -2,7 +2,7 @@
 //  Transition.swift
 //
 //  PubNub Real-time Cloud-Hosted Push API and Push Notification Client Frameworks
-//  Copyright © 2019 PubNub Inc.
+//  Copyright © 2023 PubNub Inc.
 //  https://www.pubnub.com/
 //  https://www.pubnub.com/terms
 //
@@ -42,27 +42,26 @@ extension AnyState {
 
 /// Typealias for transition result.
 /// It assumes that transition result returns a new State and Effect invocations that describes system's intent to perform some operations
-typealias TransitionResult<State: AnyState, Action, EffectKind> = (state: State, invocations: [EffectInvocation<EffectKind, Action>])
+typealias TransitionResult<State: AnyState, Event, EffectKind> = (state: State, invocations: [EffectInvocation<EffectKind, Event>])
 
 ///
 /// Protocol for any type that can perform the transition between states given the action.
 /// Concrete types are responsible to implement `transition(from state: State, action: Action)` and return a list of `EffectInvocation` that needs to be executed.
 ///
-protocol TransitionProtocol<State, Action, EffectKind> {
+protocol TransitionProtocol<State, Event, EffectKind> {
   associatedtype State: AnyState
-  associatedtype Action
+  associatedtype Event
   associatedtype EffectKind
   
-  func defaultState() -> State
-  func transition(from state: State, action: Action) -> TransitionResult<State, Action, EffectKind>
+  func transition(from state: State, event: Event) -> TransitionResult<State, Event, EffectKind>
 }
 
 ///
 /// The goal of this type is to specify the system's intent to perform an Effect without having to specify its concrete implementation.
 ///
-struct EffectInvocation<EffectKind, Action> {
+struct EffectInvocation<EffectKind, Event> {
   var kind: EffectKind
   var identifier: String
-  var onCompletion: ((Result<Action?, Error>) -> Void)?
+  var onCompletion: ((Result<[Event], Error>) -> Void)?
   var onCancel: (() -> Void)?
 }

--- a/Sources/PubNub/EventEngine/Core/TransitionProtocol.swift
+++ b/Sources/PubNub/EventEngine/Core/TransitionProtocol.swift
@@ -62,6 +62,10 @@ protocol TransitionProtocol<State, Event, EffectKind> {
 struct EffectInvocation<EffectKind, Event> {
   var kind: EffectKind
   var identifier: String
-  var onCompletion: ((Result<[Event], Error>) -> Void)?
-  var onCancel: (() -> Void)?
+}
+
+extension EffectInvocation where EffectKind: RawRepresentable<String> {
+  static func withEffectKind(_ kind: EffectKind) -> EffectInvocation<EffectKind, Event> {
+    EffectInvocation(kind: kind, identifier: kind.rawValue)
+  }
 }

--- a/Sources/PubNub/EventEngine/Core/TransitionProtocol.swift
+++ b/Sources/PubNub/EventEngine/Core/TransitionProtocol.swift
@@ -1,0 +1,53 @@
+//
+//  Transition.swift
+//
+//  PubNub Real-time Cloud-Hosted Push API and Push Notification Client Frameworks
+//  Copyright © 2019 PubNub Inc.
+//  https://www.pubnub.com/
+//  https://www.pubnub.com/terms
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+typealias TransitionResult<S,A,K> = (state: S, invocations: [EffectInvocation<K,A>])
+
+///
+/// Protocol for any type that can perform the transition between states given the action.
+/// Concrete types are responsible to implement `transition(from state: State, action: Action)` and return a list of `EffectInvocation` that needs to be executed.
+///
+protocol TransitionProtocol<State,Action,Kind> {
+  associatedtype State
+  associatedtype Action
+  associatedtype Kind
+  
+  func defaultState() -> State
+  func transition(from state: State, action: Action) -> TransitionResult<State,Action,Kind>
+}
+
+///
+/// The goal of this type is to specify the system's intent to perform an Effect without having to specify its concrete implementation.
+///
+struct EffectInvocation<Kind, Action> {
+  var kind: Kind
+  var identifier: String
+  var onCompletion: ((Result<Action?, Error>) -> Void)?
+  var onCancel: (() -> Void)?
+}

--- a/Sources/PubNub/EventEngine/Core/TransitionProtocol.swift
+++ b/Sources/PubNub/EventEngine/Core/TransitionProtocol.swift
@@ -27,26 +27,41 @@
 
 import Foundation
 
-typealias TransitionResult<S,A,K> = (state: S, invocations: [EffectInvocation<K,A>])
+///
+/// Protocol for any type that can describe the Event Engine's state.
+///
+protocol AnyState {
+  func didEnter()
+  func didLeave()
+}
+
+extension AnyState {
+  func didEnter() {}
+  func didLeave() {}
+}
+
+/// Typealias for transition result.
+/// It assumes that transition result returns a new State and Effect invocations that describes system's intent to perform some operations
+typealias TransitionResult<State: AnyState, Action, EffectKind> = (state: State, invocations: [EffectInvocation<EffectKind, Action>])
 
 ///
 /// Protocol for any type that can perform the transition between states given the action.
 /// Concrete types are responsible to implement `transition(from state: State, action: Action)` and return a list of `EffectInvocation` that needs to be executed.
 ///
-protocol TransitionProtocol<State,Action,Kind> {
-  associatedtype State
+protocol TransitionProtocol<State, Action, EffectKind> {
+  associatedtype State: AnyState
   associatedtype Action
-  associatedtype Kind
+  associatedtype EffectKind
   
   func defaultState() -> State
-  func transition(from state: State, action: Action) -> TransitionResult<State,Action,Kind>
+  func transition(from state: State, action: Action) -> TransitionResult<State, Action, EffectKind>
 }
 
 ///
 /// The goal of this type is to specify the system's intent to perform an Effect without having to specify its concrete implementation.
 ///
-struct EffectInvocation<Kind, Action> {
-  var kind: Kind
+struct EffectInvocation<EffectKind, Action> {
+  var kind: EffectKind
   var identifier: String
   var onCompletion: ((Result<Action?, Error>) -> Void)?
   var onCancel: (() -> Void)?

--- a/Sources/PubNub/EventEngine/Showcase/Subscribe.swift
+++ b/Sources/PubNub/EventEngine/Showcase/Subscribe.swift
@@ -2,7 +2,7 @@
 //  Subscribe.swift
 //
 //  PubNub Real-time Cloud-Hosted Push API and Push Notification Client Frameworks
-//  Copyright © 2019 PubNub Inc.
+//  Copyright © 2023 PubNub Inc.
 //  https://www.pubnub.com/
 //  https://www.pubnub.com/terms
 //
@@ -36,7 +36,7 @@ enum Subscribe {
   class Reconnecting: State {}
   
   // TODO: Provide real actions
-  enum Actions {
+  enum Events {
     case connect
     case disconnect
     case reconnect
@@ -52,15 +52,15 @@ enum Subscribe {
 
 class SubscribeTransition: TransitionProtocol {
   typealias State = Subscribe.State
-  typealias Action = Subscribe.Actions
+  typealias Event = Subscribe.Events
   typealias EffectKind = Subscribe.EffectInvocation
   
   func defaultState() -> Subscribe.State {
     Subscribe.Disconnected()
   }
   
-  func transition(from state: State, action: Action) -> TransitionResult<State, Action, EffectKind> {
-    switch action {
+  func transition(from state: State, event: Event) -> TransitionResult<State, Event, EffectKind> {
+    switch event {
     case .connect, .disconnect, .reconnect:
       fatalError("Not implemented yet")
     }
@@ -68,10 +68,10 @@ class SubscribeTransition: TransitionProtocol {
 }
 
 class SubscribeEffectFactory: EffectHandlerFactory {
-  typealias Action = Subscribe.Actions
+  typealias Event = Subscribe.Events
   typealias EffectKind = Subscribe.EffectInvocation
   
-  func effect(for invocation: EffectInvocation<EffectKind, Action>) -> any EffectHandler {
+  func effect(for invocation: EffectInvocation<EffectKind, Event>) -> any EffectHandler<EffectKind, Event> {
     switch invocation.kind {
     case .effectInv1, .effectInv2, .effectInv3:
       fatalError("Not implemented yet")
@@ -83,6 +83,7 @@ class SubscribeEffectFactory: EffectHandlerFactory {
 /// This is how you can use an EventEngine instance that's configured to handle a Subscribe loop:
 ///
 let subscribeEventEngine = EventEngine(
+  state: Subscribe.State(),
   transition: SubscribeTransition(),
   dispatcher: EffectDispatcher(factory: SubscribeEffectFactory())
 )

--- a/Sources/PubNub/EventEngine/Showcase/Subscribe.swift
+++ b/Sources/PubNub/EventEngine/Showcase/Subscribe.swift
@@ -26,45 +26,42 @@
 //
 import Foundation
 
-/// This enum acts like a namespace in order to keep State, Actions and EffectInvocations for Subscribe in one place
+/// This acts like a namespace in order to keep State, Actions and Effect invocations for Subscribe in a one place:
 enum Subscribe {
   
-  struct State {
-    var x: Int
-    var y: Int
-    var z: Int
-  }
+  // TODO: Provide real states
+  class State: AnyState {}
+  class Connected: State {}
+  class Disconnected: State {}
+  class Reconnecting: State {}
   
+  // TODO: Provide real actions
   enum Actions {
-    case a1
-    case a2
-    case a3
-    case a4
-    case a5
+    case connect
+    case disconnect
+    case reconnect
   }
   
+  // TODO: Provide real invocations to describe Effects
   enum EffectInvocation {
-    case e1
-    case e2
-    case e3
+    case effectInv1
+    case effectInv2
+    case effectInv3
   }
 }
 
 class SubscribeTransition: TransitionProtocol {
   typealias State = Subscribe.State
   typealias Action = Subscribe.Actions
-  typealias Kind = Subscribe.EffectInvocation
+  typealias EffectKind = Subscribe.EffectInvocation
   
   func defaultState() -> Subscribe.State {
-    Subscribe.State(x: 0, y: 0, z: 0)
+    Subscribe.Disconnected()
   }
   
-  func transition(
-    from state: State,
-    action: Action
-  ) -> TransitionResult<State,Action,Kind> {
+  func transition(from state: State, action: Action) -> TransitionResult<State, Action, EffectKind> {
     switch action {
-    case .a1, .a2, .a3, .a4, .a5:
+    case .connect, .disconnect, .reconnect:
       fatalError("Not implemented yet")
     }
   }
@@ -72,35 +69,13 @@ class SubscribeTransition: TransitionProtocol {
 
 class SubscribeEffectFactory: EffectHandlerFactory {
   typealias Action = Subscribe.Actions
-  typealias Kind = Subscribe.EffectInvocation
+  typealias EffectKind = Subscribe.EffectInvocation
   
-  func effect(
-    for invocation: EffectInvocation<Subscribe.EffectInvocation, Subscribe.Actions>
-  ) -> any EffectHandler<Kind,Action> {
+  func effect(for invocation: EffectInvocation<EffectKind, Action>) -> any EffectHandler {
     switch invocation.kind {
-    case .e1, .e2, .e3:
-      return CustomEH(invocation: invocation)
+    case .effectInv1, .effectInv2, .effectInv3:
       fatalError("Not implemented yet")
     }
-  }
-}
-
-class CustomEH: EffectHandler {
-  var invocation: EffectInvocation<Subscribe.EffectInvocation, Subscribe.Actions>
-  
-  typealias Action = Subscribe.Actions
-  typealias Kind = Subscribe.EffectInvocation
-    
-  init(invocation: EffectInvocation<Subscribe.EffectInvocation, Subscribe.Actions>) {
-    self.invocation = invocation
-  }
-  
-  func start() {
-    invocation.onCompletion?(.success(.a4))
-  }
-  
-  func cancel() {
-    
   }
 }
 

--- a/Sources/PubNub/EventEngine/Showcase/Subscribe.swift
+++ b/Sources/PubNub/EventEngine/Showcase/Subscribe.swift
@@ -29,12 +29,18 @@ import Foundation
 /// This acts like a namespace in order to keep State, Actions and Effect invocations for Subscribe in a one place:
 enum Subscribe {
   
-  // TODO: Provide real states
   class State: AnyState {}
-  class Connected: State {}
-  class Disconnected: State {}
+  class Unsubscribed: State {}
+  class Preparing: State {}
+  class Handshaking: State {}
+  class HandshakingFailed: State {}
+  class Receiving: State {}
+  class Delivering: State {}
   class Reconnecting: State {}
-  
+  class ReconnectingFailed: State {}
+  class Stopped: State {}
+  class CancelPendingRequest: State {}
+
   // TODO: Provide real actions
   enum Events {
     case connect
@@ -43,7 +49,7 @@ enum Subscribe {
   }
   
   // TODO: Provide real invocations to describe Effects
-  enum EffectInvocation {
+  enum EffectInvocation: String {
     case effectInv1
     case effectInv2
     case effectInv3
@@ -54,11 +60,7 @@ class SubscribeTransition: TransitionProtocol {
   typealias State = Subscribe.State
   typealias Event = Subscribe.Events
   typealias EffectKind = Subscribe.EffectInvocation
-  
-  func defaultState() -> Subscribe.State {
-    Subscribe.Disconnected()
-  }
-  
+    
   func transition(from state: State, event: Event) -> TransitionResult<State, Event, EffectKind> {
     switch event {
     case .connect, .disconnect, .reconnect:
@@ -71,7 +73,10 @@ class SubscribeEffectFactory: EffectHandlerFactory {
   typealias Event = Subscribe.Events
   typealias EffectKind = Subscribe.EffectInvocation
   
-  func effect(for invocation: EffectInvocation<EffectKind, Event>) -> any EffectHandler<EffectKind, Event> {
+  func effect(
+    for invocation: EffectInvocation<EffectKind, Event>,
+    with eventDispatcher: some EventDispatcher<Event>
+  ) -> any EffectHandler<EffectKind, Event> {
     switch invocation.kind {
     case .effectInv1, .effectInv2, .effectInv3:
       fatalError("Not implemented yet")

--- a/Sources/PubNub/EventEngine/Showcase/Subscribe.swift
+++ b/Sources/PubNub/EventEngine/Showcase/Subscribe.swift
@@ -1,0 +1,113 @@
+//
+//  Subscribe.swift
+//
+//  PubNub Real-time Cloud-Hosted Push API and Push Notification Client Frameworks
+//  Copyright © 2019 PubNub Inc.
+//  https://www.pubnub.com/
+//  https://www.pubnub.com/terms
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+import Foundation
+
+/// This enum acts like a namespace in order to keep State, Actions and EffectInvocations for Subscribe in one place
+enum Subscribe {
+  
+  struct State {
+    var x: Int
+    var y: Int
+    var z: Int
+  }
+  
+  enum Actions {
+    case a1
+    case a2
+    case a3
+    case a4
+    case a5
+  }
+  
+  enum EffectInvocation {
+    case e1
+    case e2
+    case e3
+  }
+}
+
+class SubscribeTransition: TransitionProtocol {
+  typealias State = Subscribe.State
+  typealias Action = Subscribe.Actions
+  typealias Kind = Subscribe.EffectInvocation
+  
+  func defaultState() -> Subscribe.State {
+    Subscribe.State(x: 0, y: 0, z: 0)
+  }
+  
+  func transition(
+    from state: State,
+    action: Action
+  ) -> TransitionResult<State,Action,Kind> {
+    switch action {
+    case .a1, .a2, .a3, .a4, .a5:
+      fatalError("Not implemented yet")
+    }
+  }
+}
+
+class SubscribeEffectFactory: EffectHandlerFactory {
+  typealias Action = Subscribe.Actions
+  typealias Kind = Subscribe.EffectInvocation
+  
+  func effect(
+    for invocation: EffectInvocation<Subscribe.EffectInvocation, Subscribe.Actions>
+  ) -> any EffectHandler<Kind,Action> {
+    switch invocation.kind {
+    case .e1, .e2, .e3:
+      return CustomEH(invocation: invocation)
+      fatalError("Not implemented yet")
+    }
+  }
+}
+
+class CustomEH: EffectHandler {
+  var invocation: EffectInvocation<Subscribe.EffectInvocation, Subscribe.Actions>
+  
+  typealias Action = Subscribe.Actions
+  typealias Kind = Subscribe.EffectInvocation
+    
+  init(invocation: EffectInvocation<Subscribe.EffectInvocation, Subscribe.Actions>) {
+    self.invocation = invocation
+  }
+  
+  func start() {
+    invocation.onCompletion?(.success(.a4))
+  }
+  
+  func cancel() {
+    
+  }
+}
+
+///
+/// This is how you can use an EventEngine instance that's configured to handle a Subscribe loop:
+///
+let subscribeEventEngine = EventEngine(
+  transition: SubscribeTransition(),
+  dispatcher: EffectDispatcher(factory: SubscribeEffectFactory())
+)

--- a/Sources/PubNub/EventEngine/Subscribe/Effects/HandshakeRequest.swift
+++ b/Sources/PubNub/EventEngine/Subscribe/Effects/HandshakeRequest.swift
@@ -1,0 +1,91 @@
+//
+//  HandshakeRequest.swift
+//
+//  PubNub Real-time Cloud-Hosted Push API and Push Notification Client Frameworks
+//  Copyright © 2023 PubNub Inc.
+//  https://www.pubnub.com/
+//  https://www.pubnub.com/terms
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+class HandshakeRequest: BaseEffectHandler<Subscribe.EffectInvocation, Subscribe.Events> {
+  let session: SessionReplaceable
+  let configuration: SubscriptionConfiguration
+  let channels: [String]
+  let groups: [String]
+  
+  private var router: HTTPRouter?
+  private var request: RequestReplaceable?
+  
+  init(
+    invocation: EffectInvocation<EffectKind, Event>,
+    receiver: some EventReceiver<Event>,
+    session: SessionReplaceable,
+    configuration: SubscriptionConfiguration,
+    channels: [String],
+    groups: [String]
+  ) {
+    self.session = session
+    self.configuration = configuration
+    self.channels = channels
+    self.groups = groups
+    
+    super.init(
+      invocation: invocation,
+      receiver: receiver
+    )
+  }
+  
+  override func performEffectTask() {
+    let router = SubscribeRouter(
+      .subscribe(
+        channels: channels,
+        groups: groups,
+        timetoken: nil,
+        region: nil,
+        heartbeat: configuration.durationUntilTimeout,
+        filter: configuration.filterExpression
+      ), configuration: configuration
+    )
+    
+    request = session.request(
+      with: router,
+      requestOperator: configuration.automaticRetry
+    )
+    request?.validate().response(
+      on: .main,
+      decoder: SubscribeDecoder(),
+      completion: { result in
+        switch result {
+        case .success(let response):
+          debugPrint("TODO: \(response)")
+        case .failure(let error):
+          debugPrint("TODO: \(error)")
+        }
+      }
+    )
+  }
+  
+  override func cancelEffectTask() {
+    request?.cancel(PubNubError(.clientCancelled, router: router))
+  }
+}

--- a/Sources/PubNub/EventEngine/Subscribe/Subscribe.swift
+++ b/Sources/PubNub/EventEngine/Subscribe/Subscribe.swift
@@ -26,7 +26,9 @@
 //
 import Foundation
 
-/// This acts like a namespace in order to keep State, Actions and Effect invocations for Subscribe in a one place:
+///
+/// This acts like a namespace in order to keep State, Actions and Effect invocations for Subscribe in one place:
+///
 enum Subscribe {
   
   class State: AnyState {}
@@ -40,55 +42,40 @@ enum Subscribe {
   class ReconnectingFailed: State {}
   class Stopped: State {}
   class CancelPendingRequest: State {}
-
-  // TODO: Provide real actions
+  
   enum Events {
-    case connect
-    case disconnect
+    case restore
+    case giveUp
     case reconnect
+    case subscribe(channels: [String], groups: [String], configuration: SubscriptionConfiguration)
+    case success
+    case subscriptionChanged
+    case authorizationChanged
+    case fail
+    case allChannelsUnsubscribed
+    case disconnect
+    case handshakeFailed
+    case handshakeSucceeded
+    case reconnectionDelayExpired
+    case deliveryDone
+    case reconnectionLimitExceeded
   }
   
-  // TODO: Provide real invocations to describe Effects
-  enum EffectInvocation: String {
-    case effectInv1
-    case effectInv2
-    case effectInv3
-  }
-}
-
-class SubscribeTransition: TransitionProtocol {
-  typealias State = Subscribe.State
-  typealias Event = Subscribe.Events
-  typealias EffectKind = Subscribe.EffectInvocation
-    
-  func transition(from state: State, event: Event) -> TransitionResult<State, Event, EffectKind> {
-    switch event {
-    case .connect, .disconnect, .reconnect:
-      fatalError("Not implemented yet")
-    }
-  }
-}
-
-class SubscribeEffectFactory: EffectHandlerFactory {
-  typealias Event = Subscribe.Events
-  typealias EffectKind = Subscribe.EffectInvocation
-  
-  func effect(
-    for invocation: EffectInvocation<EffectKind, Event>,
-    with eventDispatcher: some EventDispatcher<Event>
-  ) -> any EffectHandler<EffectKind, Event> {
-    switch invocation.kind {
-    case .effectInv1, .effectInv2, .effectInv3:
-      fatalError("Not implemented yet")
-    }
+  enum EffectInvocation {
+    case receiveMessageRequest
+    case cancelPendingReceviceMessageRequest
+    case handshakeRequest(channels: [String], groups: [String], configuration: SubscriptionConfiguration)
+    case cancelPendingHandshakeRequest
+    case startReconnectionDelayTimer
+    case cancelReconnectionDelayTimer
   }
 }
 
 ///
-/// This is how you can use an EventEngine instance that's configured to handle a Subscribe loop:
+/// This is how you can use an EventEngine instance that's configured to handle the Subscribe loop:
 ///
 let subscribeEventEngine = EventEngine(
-  state: Subscribe.State(),
+  state: Subscribe.Stopped(),
   transition: SubscribeTransition(),
   dispatcher: EffectDispatcher(factory: SubscribeEffectFactory())
 )


### PR DESCRIPTION
Few assumptions regarding POC:

`EventEngine` is a class with generic parameters (`State`, `Action`, `EffectKind`) that reduces effort and performs some operations related to handling `EffectInvocation` instances, setting a new State for you. This allows you to focus only on providing necessary input in place of generic parameters. These generic parameters are:

1. Provide a `Transition` concrete type. Its requirement is a pure function that returns the new `State` and array of `EffectInvocation` objects for the given `Action`
2. Provide a `Dispatcher` concrete type with `EffectHandlerFactory`. A factory produces an Effect according to provided `EffectInvocation`. This factory returns concrete `Effect` implementation that's tied to the domain described by `EffectKind`

Take a look at the example code I've included in the `Subscribe.swift` file. I assume that everything contained in the `Core` directory should be flexible enough and not require modification. You as a caller should focus only on providing necessary input to the `EventEngine` class. It means that you may also use `Event Engine` for other requirements than Subscribe if you create another instance with different arguments in place of Generics.