### PR TITLE
Added an additional test case for excluded_devices

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,9 +1,14 @@
 ---
 name: swift
 scm: github.com/pubnub/swift
-version: "6.0.4"
+version: "6.0.5"
 schema: 1
 changelog:
+  - date: 2023-05-18
+    version: 6.0.5
+    changes:
+      - type: bug
+        text: "Uppercasing of the `excluded_devices` field to match the format expected by the REST API."
   - date: 2023-03-16
     version: 6.0.4
     changes:
@@ -480,7 +485,7 @@ sdks:
           - distribution-type: source
             distribution-repository: GitHub release
             package-name: PubNub
-            location: https://github.com/pubnub/swift/archive/refs/tags/6.0.4.zip
+            location: https://github.com/pubnub/swift/archive/refs/tags/6.0.5.zip
             supported-platforms:
               supported-operating-systems:
                 macOS:

--- a/PubNub.xcodeproj/project.pbxproj
+++ b/PubNub.xcodeproj/project.pbxproj
@@ -3256,7 +3256,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.0.4;
+				MARKETING_VERSION = 6.0.5;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnub.swift.PubNubUser;
@@ -3303,7 +3303,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.0.4;
+				MARKETING_VERSION = 6.0.5;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnub.swift.PubNubUser;
@@ -3403,7 +3403,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.0.4;
+				MARKETING_VERSION = 6.0.5;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnub.swift.PubNubSpace;
@@ -3452,7 +3452,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.0.4;
+				MARKETING_VERSION = 6.0.5;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnub.swift.PubNubSpace;
@@ -3565,7 +3565,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.0.4;
+				MARKETING_VERSION = 6.0.5;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnub.swift.PubNubMembership;
@@ -3613,7 +3613,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.0.4;
+				MARKETING_VERSION = 6.0.5;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnub.swift.PubNubMembership;
@@ -4069,7 +4069,7 @@
 					"$(inherited)",
 					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
 				);
-				MARKETING_VERSION = 6.0.4;
+				MARKETING_VERSION = 6.0.5;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -4108,7 +4108,7 @@
 					"$(inherited)",
 					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
 				);
-				MARKETING_VERSION = 6.0.4;
+				MARKETING_VERSION = 6.0.5;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";

--- a/PubNubSwift.podspec
+++ b/PubNubSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'PubNubSwift'
-  s.version  = '6.0.4'
+  s.version  = '6.0.5'
   s.homepage = 'https://github.com/pubnub/swift'
   s.documentation_url = 'https://www.pubnub.com/docs/swift-native/pubnub-swift-sdk'
   s.authors = { 'PubNub, Inc.' => 'support@pubnub.com' }

--- a/Sources/PubNub/Helpers/Constants.swift
+++ b/Sources/PubNub/Helpers/Constants.swift
@@ -57,7 +57,7 @@ public enum Constant {
 
   static let pubnubSwiftSDKName: String = "PubNubSwift"
 
-  static let pubnubSwiftSDKVersion: String = "6.0.4"
+  static let pubnubSwiftSDKVersion: String = "6.0.5"
 
   static let appBundleId: String = {
     if let info = Bundle.main.infoDictionary,

--- a/Tests/PubNubTests/Push/PubNubPushTargetTests.swift
+++ b/Tests/PubNubTests/Push/PubNubPushTargetTests.swift
@@ -30,37 +30,42 @@ import XCTest
 
 class PubNubPushTargetTests: XCTestCase {
   func test_ExcludedDeviceTokensAreUppercased() {
-    let excludedDevices = [
-      "fafb34563ce",
-      "7654eghjkl"
-    ]
-    let pushMessage = PubNubPushMessage(
-      apns: PubNubAPNSPayload(
-        aps: APSPayload(
-          alert: .object(.init(title: "Message")),
-          badge: 2,
-          sound: .string("default")
-        ),
-        pubnub: [.init(
-          targets: [.init(topic: "com.pubnub.swift", environment: .production, excludedDevices: excludedDevices)],
-          collapseID: "SwiftSDK"
-        )],
-        payload: "Push Message from PubNub Swift SDK"
-      )
-    )
+    let excludedDevices = ["fafb3456", "7654egh"]
+    let message = testPushMessage(with: .init(topic: "com.pubnub", environment: .production, excludedDevices: excludedDevices))
     
-    let encodedData = try? Constant.jsonEncoder.encode(pushMessage)
+    let encodedData = try? Constant.jsonEncoder.encode(message)
+    let encodedStr = String(data: encodedData ?? Data(), encoding: .utf8) ?? ""
+    let expectedExclDevices = excludedDevices.map { $0.uppercased() }.jsonStringify ?? ""
+    
+    XCTAssertEqual(retrieveExcludedDevicesValue(from: encodedStr), expectedExclDevices)
+  }
+  
+  func test_ExcludedDeviceTokensAreNotSentIfNotProvided() {
+    let message = testPushMessage(with: .init(topic: "com.pubnub", environment: .production))
+    let encodedData = try? Constant.jsonEncoder.encode(message)
     let encodedStr = String(data: encodedData ?? Data(), encoding: .utf8) ?? ""
     
-    // Retrieves a value for the "excluded_devices" key:
-    let regex = try! NSRegularExpression(pattern: "(?<=\"excluded_devices\":)(.*?)](=?)")
-    let regexMatch = regex.matches(in: encodedStr, range: NSRange(location: 0, length: encodedStr.count))[0]
-    let startIdx = encodedStr.index(encodedStr.startIndex, offsetBy: regexMatch.range.location)
-    let endIdx = encodedStr.index(startIdx, offsetBy: regexMatch.range.length - 1)
-      
-    XCTAssertEqual(
-      String(encodedStr[startIdx...endIdx]),
-      excludedDevices.map { $0.uppercased() }.jsonStringify ?? ""
-    )
+    XCTAssertEqual(retrieveExcludedDevicesValue(from: encodedStr), nil)
+  }
+}
+
+fileprivate func testPushMessage(with target: PubNubPushTarget) -> PubNubAPNSPayload {
+  PubNubAPNSPayload(
+    aps: APSPayload(alert: .object(.init(title: "Apple Message")), badge: 1, sound: .string("default")),
+    pubnub: [.init(targets: [target], collapseID: "SwiftSDK")],
+    payload: "Push Message from PubNub Swift SDK"
+  )
+}
+
+fileprivate func retrieveExcludedDevicesValue(from string: String) -> String? {
+  let regex = try! NSRegularExpression(pattern: "(?<=\"excluded_devices\":)(.*?)](=?)")
+  let regexMatch = regex.matches(in: string, range: NSRange(location: 0, length: string.count)).first
+  
+  if let regexMatch = regexMatch {
+    let startIdx = string.index(string.startIndex, offsetBy: regexMatch.range.location)
+    let endIdx = string.index(startIdx, offsetBy: regexMatch.range.length - 1)
+    return String(string[startIdx...endIdx])
+  } else {
+    return nil
   }
 }


### PR DESCRIPTION
fix(notifications): uppercasing the excluded_devices field

Uppercasing of the `excluded_devices` field to match the format expected by the REST API