### PR TITLE
feat/event-engine-effects

### DIFF
--- a/PubNub.xcodeproj/project.pbxproj
+++ b/PubNub.xcodeproj/project.pbxproj
@@ -381,16 +381,18 @@
 		3D1321C429ED2DFC0049EAB0 /* EffectHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1321B529ED2DFC0049EAB0 /* EffectHandler.swift */; };
 		3D1321C529ED2DFC0049EAB0 /* EventEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1321B629ED2DFC0049EAB0 /* EventEngine.swift */; };
 		3D1321C629ED2DFC0049EAB0 /* SubscribeState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1321B929ED2DFC0049EAB0 /* SubscribeState.swift */; };
-		3D1321C729ED2DFC0049EAB0 /* EmitMessagesEffect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1321BB29ED2DFC0049EAB0 /* EmitMessagesEffect.swift */; };
-		3D1321C829ED2DFC0049EAB0 /* SubscribeEffect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1321BC29ED2DFC0049EAB0 /* SubscribeEffect.swift */; };
-		3D1321C929ED2DFC0049EAB0 /* EmitStatusEffect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1321BD29ED2DFC0049EAB0 /* EmitStatusEffect.swift */; };
-		3D1321CA29ED2DFC0049EAB0 /* SubscribeRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1321BE29ED2DFC0049EAB0 /* SubscribeRequest.swift */; };
 		3D1321CB29ED2DFC0049EAB0 /* SubscribeEffectFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1321BF29ED2DFC0049EAB0 /* SubscribeEffectFactory.swift */; };
 		3D1321CC29ED2DFC0049EAB0 /* Subscribe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1321C029ED2DFC0049EAB0 /* Subscribe.swift */; };
 		3D1321CD29ED2DFC0049EAB0 /* SubscribeTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1321C129ED2DFC0049EAB0 /* SubscribeTransition.swift */; };
 		3D1321D029ED2EBD0049EAB0 /* SubscribeTransitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1321CF29ED2EBD0049EAB0 /* SubscribeTransitionTests.swift */; };
-		3D9134942A0D0484000A5124 /* SubscribeEffectsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D9134932A0D0484000A5124 /* SubscribeEffectsTests.swift */; };
+		3D6795312A1F88C7003BFF39 /* SubscribeRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D6795302A1F88C7003BFF39 /* SubscribeRequest.swift */; };
 		3DA4848A29F91133005152A4 /* DispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DA4848929F91133005152A4 /* DispatcherTests.swift */; };
+		3DE20C392A1E358B0067B543 /* SubscribeEffects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DE20C362A1E358B0067B543 /* SubscribeEffects.swift */; };
+		3DE20C3D2A1E361F0067B543 /* EmitMessagesEffect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DE20C3C2A1E361F0067B543 /* EmitMessagesEffect.swift */; };
+		3DE20C3F2A1E36650067B543 /* EmitStatusEffect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DE20C3E2A1E36650067B543 /* EmitStatusEffect.swift */; };
+		3DE20C462A1E37940067B543 /* SubscribeEffectsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DE20C402A1E377B0067B543 /* SubscribeEffectsTests.swift */; };
+		3DE20C472A1E379C0067B543 /* EmitMessagesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DE20C412A1E377B0067B543 /* EmitMessagesTests.swift */; };
+		3DE20C482A1E37A00067B543 /* EmitStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DE20C422A1E377B0067B543 /* EmitStatusTests.swift */; };
 		79407BD2271D4CFA0032076C /* PubNubContractTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79407BBF271D4CFA0032076C /* PubNubContractTestCase.swift */; };
 		79407BD3271D4CFA0032076C /* PubNubContractTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79407BBF271D4CFA0032076C /* PubNubContractTestCase.swift */; };
 		79407BD4271D4CFA0032076C /* PubNubContractCucumberTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 79407BC0271D4CFA0032076C /* PubNubContractCucumberTest.m */; };
@@ -916,16 +918,18 @@
 		3D1321B529ED2DFC0049EAB0 /* EffectHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EffectHandler.swift; sourceTree = "<group>"; };
 		3D1321B629ED2DFC0049EAB0 /* EventEngine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventEngine.swift; sourceTree = "<group>"; };
 		3D1321B929ED2DFC0049EAB0 /* SubscribeState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscribeState.swift; sourceTree = "<group>"; };
-		3D1321BB29ED2DFC0049EAB0 /* EmitMessagesEffect.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmitMessagesEffect.swift; sourceTree = "<group>"; };
-		3D1321BC29ED2DFC0049EAB0 /* SubscribeEffect.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscribeEffect.swift; sourceTree = "<group>"; };
-		3D1321BD29ED2DFC0049EAB0 /* EmitStatusEffect.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmitStatusEffect.swift; sourceTree = "<group>"; };
-		3D1321BE29ED2DFC0049EAB0 /* SubscribeRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscribeRequest.swift; sourceTree = "<group>"; };
 		3D1321BF29ED2DFC0049EAB0 /* SubscribeEffectFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscribeEffectFactory.swift; sourceTree = "<group>"; };
 		3D1321C029ED2DFC0049EAB0 /* Subscribe.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Subscribe.swift; sourceTree = "<group>"; };
 		3D1321C129ED2DFC0049EAB0 /* SubscribeTransition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscribeTransition.swift; sourceTree = "<group>"; };
 		3D1321CF29ED2EBD0049EAB0 /* SubscribeTransitionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscribeTransitionTests.swift; sourceTree = "<group>"; };
-		3D9134932A0D0484000A5124 /* SubscribeEffectsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscribeEffectsTests.swift; sourceTree = "<group>"; };
+		3D6795302A1F88C7003BFF39 /* SubscribeRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscribeRequest.swift; sourceTree = "<group>"; };
 		3DA4848929F91133005152A4 /* DispatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatcherTests.swift; sourceTree = "<group>"; };
+		3DE20C362A1E358B0067B543 /* SubscribeEffects.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscribeEffects.swift; sourceTree = "<group>"; };
+		3DE20C3C2A1E361F0067B543 /* EmitMessagesEffect.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmitMessagesEffect.swift; sourceTree = "<group>"; };
+		3DE20C3E2A1E36650067B543 /* EmitStatusEffect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmitStatusEffect.swift; sourceTree = "<group>"; };
+		3DE20C402A1E377B0067B543 /* SubscribeEffectsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscribeEffectsTests.swift; sourceTree = "<group>"; };
+		3DE20C412A1E377B0067B543 /* EmitMessagesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmitMessagesTests.swift; sourceTree = "<group>"; };
+		3DE20C422A1E377B0067B543 /* EmitStatusTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmitStatusTests.swift; sourceTree = "<group>"; };
 		793079152667C63700F23B72 /* CODEOWNERS */ = {isa = PBXFileReference; lastKnownFileType = text; path = CODEOWNERS; sourceTree = "<group>"; };
 		793079172667C63700F23B72 /* validate-yml.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = "validate-yml.js"; sourceTree = "<group>"; };
 		793079182667C63700F23B72 /* validate-pubnub-yml.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = "validate-pubnub-yml.yml"; sourceTree = "<group>"; };
@@ -1947,10 +1951,10 @@
 		3D1321BA29ED2DFC0049EAB0 /* Effects */ = {
 			isa = PBXGroup;
 			children = (
-				3D1321BB29ED2DFC0049EAB0 /* EmitMessagesEffect.swift */,
-				3D1321BC29ED2DFC0049EAB0 /* SubscribeEffect.swift */,
-				3D1321BD29ED2DFC0049EAB0 /* EmitStatusEffect.swift */,
-				3D1321BE29ED2DFC0049EAB0 /* SubscribeRequest.swift */,
+				3D6795302A1F88C7003BFF39 /* SubscribeRequest.swift */,
+				3DE20C362A1E358B0067B543 /* SubscribeEffects.swift */,
+				3DE20C3C2A1E361F0067B543 /* EmitMessagesEffect.swift */,
+				3DE20C3E2A1E36650067B543 /* EmitStatusEffect.swift */,
 			);
 			path = Effects;
 			sourceTree = "<group>";
@@ -1958,9 +1962,11 @@
 		3D1321CE29ED2EA00049EAB0 /* EventEngine */ = {
 			isa = PBXGroup;
 			children = (
-				3D1321CF29ED2EBD0049EAB0 /* SubscribeTransitionTests.swift */,
 				3DA4848929F91133005152A4 /* DispatcherTests.swift */,
-				3D9134932A0D0484000A5124 /* SubscribeEffectsTests.swift */,
+				3D1321CF29ED2EBD0049EAB0 /* SubscribeTransitionTests.swift */,
+				3DE20C402A1E377B0067B543 /* SubscribeEffectsTests.swift */,
+				3DE20C412A1E377B0067B543 /* EmitMessagesTests.swift */,
+				3DE20C422A1E377B0067B543 /* EmitStatusTests.swift */,
 			);
 			path = EventEngine;
 			sourceTree = "<group>";
@@ -2983,12 +2989,10 @@
 			buildActionMask = 0;
 			files = (
 				3D1321C329ED2DFC0049EAB0 /* Dispatcher.swift in Sources */,
-				3D1321C929ED2DFC0049EAB0 /* EmitStatusEffect.swift in Sources */,
 				3556E37224806E33004FDC25 /* CaseAccessible.swift in Sources */,
 				35CDA4D02510068A00218137 /* XMLSerialization.swift in Sources */,
 				35481BF6252275B5004E07B5 /* PubNubFile.swift in Sources */,
 				35CDA4CC2510031E00218137 /* XMLDecoder.swift in Sources */,
-				3D1321C729ED2DFC0049EAB0 /* EmitMessagesEffect.swift in Sources */,
 				35D0615F2304830600FDB2F9 /* GenericServicePayloadResponse.swift in Sources */,
 				35A66A8E22F911DB00AC67A9 /* SubscribeSessionFactory.swift in Sources */,
 				35D8D4C522EB4600001B07D9 /* AnyJSON.swift in Sources */,
@@ -3012,6 +3016,7 @@
 				35C6B6E322F515760054F242 /* SubscribeRouter.swift in Sources */,
 				35C6B6DD22F501780054F242 /* Encodable+PubNub.swift in Sources */,
 				35580682230F3A34005CDD92 /* RequestIdOperator.swift in Sources */,
+				3D6795312A1F88C7003BFF39 /* SubscribeRequest.swift in Sources */,
 				3D1321C629ED2DFC0049EAB0 /* SubscribeState.swift in Sources */,
 				35A66A8322F861BA00AC67A9 /* PubNubMessage.swift in Sources */,
 				35A66A8022F861BA00AC67A9 /* AutomaticRetry.swift in Sources */,
@@ -3049,7 +3054,6 @@
 				358C641F238C5FCA009CE354 /* FCMWebpushPayload.swift in Sources */,
 				352DBFEA237CCB9D00A0106E /* EndpointResponse.swift in Sources */,
 				350EFBE422C95FED00FA33AA /* Atomic.swift in Sources */,
-				3D1321C829ED2DFC0049EAB0 /* SubscribeEffect.swift in Sources */,
 				35293A7A2368F9680049A71F /* MessageActionsRouter.swift in Sources */,
 				35AC162B2485B1DA00A66030 /* SubscribeMessageActionPayload.swift in Sources */,
 				35599796230B6FFA000BCFD1 /* FileManager+PubNub.swift in Sources */,
@@ -3061,7 +3065,6 @@
 				35458BAB230F369A0085B502 /* InstanceIdOperator.swift in Sources */,
 				7951954E26C955CE001E308C /* PAMToken.swift in Sources */,
 				35F0259922BBFA85007BD7D3 /* HTTPSession.swift in Sources */,
-				3D1321CA29ED2DFC0049EAB0 /* SubscribeRequest.swift in Sources */,
 				353F78C42527934500FFB72C /* InputStream+PubNub.swift in Sources */,
 				353E8CE423C68F01003FBFF5 /* Float32+PubNub.swift in Sources */,
 				352DBFE9237C937F00A0106E /* HTTPSessionDelegate.swift in Sources */,
@@ -3075,6 +3078,7 @@
 				350EFBDC22C951F700FA33AA /* Request.swift in Sources */,
 				35A66A7F22F861BA00AC67A9 /* WeakBox.swift in Sources */,
 				357CA288251D3C9100BC40D3 /* MultipartInputStream.swift in Sources */,
+				3DE20C3D2A1E361F0067B543 /* EmitMessagesEffect.swift in Sources */,
 				35CF54942489918E0099FE81 /* PubNubChannelMetadata.swift in Sources */,
 				OBJ_31 /* PubNub.swift in Sources */,
 				358C641A2388BF76009CE354 /* PubNubFCMPayload.swift in Sources */,
@@ -3093,11 +3097,13 @@
 				35089A0B22E56F1F002BCC94 /* Constants.swift in Sources */,
 				358C6421238C6787009CE354 /* PubNubPushMessage.swift in Sources */,
 				35E4604F234B8B9D005D04AE /* ErrorDescription.swift in Sources */,
+				3DE20C3F2A1E36650067B543 /* EmitStatusEffect.swift in Sources */,
 				35089A0922E3C08D002BCC94 /* Error+PubNub.swift in Sources */,
 				3534D4E422C57659008E89FA /* PublishRouter.swift in Sources */,
 				35EE358C22E26A4D00E3F081 /* HTTPURLResponse+PubNub.swift in Sources */,
 				35A66A9422F91B2A00AC67A9 /* SubscriptionSession+Presence.swift in Sources */,
 				350EFBE022C9573F00FA33AA /* NSLocking+PubNub.swift in Sources */,
+				3DE20C392A1E358B0067B543 /* SubscribeEffects.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3109,10 +3115,12 @@
 				35D973542857BBFE001A44DC /* FlatJSONCodable+Test.swift in Sources */,
 				35FE93B922EE44F70051C455 /* MockURLSession.swift in Sources */,
 				3557CDFB237F566E004BBACC /* PushRouterTests.swift in Sources */,
+				3DE20C482A1E37A00067B543 /* EmitStatusTests.swift in Sources */,
 				35CDFEAB22E762E100F3B9F2 /* String+PubNubTests.swift in Sources */,
 				35CDFEA922E75DA800F3B9F2 /* Set+PubNubTests.swift in Sources */,
 				359152AB22BAA6730048842D /* PubNubConfigurationTests.swift in Sources */,
 				35FE941B22EFE5400051C455 /* EventStreamTests.swift in Sources */,
+				3DE20C472A1E379C0067B543 /* EmitMessagesTests.swift in Sources */,
 				35FE93C322EF57FA0051C455 /* Session+URLErrorTests.swift in Sources */,
 				35FE940122EF983A0051C455 /* Session+EndpointErrorTests.swift in Sources */,
 				357AEB8422E6954600C18250 /* Collection+PubNubTests.swift in Sources */,
@@ -3136,6 +3144,7 @@
 				35CDFEA722E75BE800F3B9F2 /* OperationQueue+PubNubTests.swift in Sources */,
 				357AEB8A22E6A02F00C18250 /* Error+PubNubTests.swift in Sources */,
 				35C8FDC625000BC80069E89E /* FileManagementRouterTests.swift in Sources */,
+				3DE20C462A1E37940067B543 /* SubscribeEffectsTests.swift in Sources */,
 				35A6C7BA22FC5BFB00E97CC5 /* Data+PubNubTests.swift in Sources */,
 				35AB218D22E7D72200BD3049 /* AnyJSON+CodableTests.swift in Sources */,
 				3557CDFC237F59F6004BBACC /* PublishRouterTests.swift in Sources */,
@@ -3156,7 +3165,6 @@
 				35458BA5230D8E500085B502 /* TestLogWriter.swift in Sources */,
 				3513AB2723A967D9002D4B57 /* PAMTokenTests.swift in Sources */,
 				3580A5A822F1583900B12E5E /* MockRequestOperators.swift in Sources */,
-				3D9134942A0D0484000A5124 /* SubscribeEffectsTests.swift in Sources */,
 				35458BA7230D91BB0085B502 /* TestSetup.swift in Sources */,
 				357AEB8C22E6A12400C18250 /* HTTPURLResponse+PubNubTests.swift in Sources */,
 				3580A59422F0C74100B12E5E /* RequestMutatorTests.swift in Sources */,

--- a/Sources/PubNub/EventEngine/Subscribe/Effects/EmitMessagesEffect.swift
+++ b/Sources/PubNub/EventEngine/Subscribe/Effects/EmitMessagesEffect.swift
@@ -1,0 +1,93 @@
+//
+//  EmitMessagesEffect.swift
+//
+//  PubNub Real-time Cloud-Hosted Push API and Push Notification Client Frameworks
+//  Copyright © 2023 PubNub Inc.
+//  https://www.pubnub.com/
+//  https://www.pubnub.com/terms
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+class MessageCache {
+  private(set) var messagesArray = [SubscribeMessagePayload?].init(repeating: nil, count: 100)
+  
+  init(messagesArray: [SubscribeMessagePayload?] = .init(repeating: nil, count: 100)) {
+    self.messagesArray = messagesArray
+  }
+  
+  var isOverflowed: Bool {
+    return messagesArray.count >= 100
+  }
+  
+  func contains(_ message: SubscribeMessagePayload) -> Bool {
+    messagesArray.contains(message)
+  }
+  
+  func append(_ message: SubscribeMessagePayload) {
+    messagesArray.append(message)
+  }
+  
+  func dropTheOldest() {
+    messagesArray.remove(at: 0)
+  }
+}
+
+struct EmitMessagesEffect: EffectHandler {
+  let messages: [SubscribeMessagePayload]
+  let cursor: SubscribeCursor
+  let listeners: [BaseSubscriptionListener]
+  let messageCache: MessageCache
+  
+  func performTask(completionBlock: @escaping ([Subscribe.Event]) -> Void) {
+    // Attempt to detect missed messages due to queue overflow
+    if messages.count >= 100 {
+      listeners.forEach {
+        $0.emit(subscribe: .errorReceived(
+          PubNubError(
+            .messageCountExceededMaximum,
+            router: nil,
+            affected: [.subscribe(cursor)]
+          ))
+        )
+      }
+    }
+    
+    let filteredMessages = messages.filter { message in // Dedupe the message
+      // Update cache and notify if not a duplicate message
+      if !messageCache.contains(message) {
+        messageCache.append(message)
+        // Remove the oldest value if we're at max capacity
+        if messageCache.isOverflowed {
+          messageCache.dropTheOldest()
+        }
+        return true
+      }
+      return false
+    }
+    
+    listeners.forEach {
+      $0.emit(batch: filteredMessages)
+    }
+    
+    completionBlock([])
+  }
+}

--- a/Sources/PubNub/EventEngine/Subscribe/Effects/EmitStatusEffect.swift
+++ b/Sources/PubNub/EventEngine/Subscribe/Effects/EmitStatusEffect.swift
@@ -1,0 +1,45 @@
+//
+//  EmitStatusEffect.swift
+//
+//  PubNub Real-time Cloud-Hosted Push API and Push Notification Client Frameworks
+//  Copyright © 2023 PubNub Inc.
+//  https://www.pubnub.com/
+//  https://www.pubnub.com/terms
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+struct EmitStatusEffect: EffectHandler {
+  let currentStatus: ConnectionStatus
+  let newStatus: ConnectionStatus
+  let listeners: [BaseSubscriptionListener]
+  
+  func performTask(completionBlock: @escaping ([Subscribe.Event]) -> Void) {
+    if currentStatus != newStatus, currentStatus.canTransition(to: newStatus) {
+      listeners.forEach {
+        $0.emit(subscribe: .connectionChanged(newStatus))
+      }
+      completionBlock([])
+    } else {
+      completionBlock([])
+    }
+  }
+}

--- a/Sources/PubNub/EventEngine/Subscribe/Effects/SubscribeEffects.swift
+++ b/Sources/PubNub/EventEngine/Subscribe/Effects/SubscribeEffects.swift
@@ -1,0 +1,156 @@
+//
+//  SubscribeEffect.swift
+//
+//  PubNub Real-time Cloud-Hosted Push API and Push Notification Client Frameworks
+//  Copyright © 2023 PubNub Inc.
+//  https://www.pubnub.com/
+//  https://www.pubnub.com/terms
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+// MARK: - SubscribeEffect (Common)
+
+protocol SubscribeEffect: EffectHandler {
+  var request: SubscribeRequest { get }
+  
+  func onCompletion(with response: SubscribeResponse) -> Subscribe.Event
+  func onFailure(dueTo error: SubscribeError) -> Subscribe.Event
+}
+
+extension SubscribeEffect {
+  func performTask(completionBlock: @escaping ([Subscribe.Event]) -> Void) {
+    request.execute(onCompletion: {
+      switch $0 {
+      case .success(let response):
+        completionBlock([onCompletion(with: response)])
+      case .failure(let error):
+        completionBlock([onFailure(dueTo: error)])
+      }
+    })
+  }
+  
+  func cancelTask() {
+    request.cancel()
+  }
+}
+
+// MARK: - Subscribe Reconnect Effect (Common)
+
+protocol SubscribeReconnectEffect: SubscribeEffect {
+  var currentAttempt: Int { get }
+  var error: SubscribeError? { get }
+  
+  func onGivingUp(dueTo error: SubscribeError) -> Subscribe.Event
+}
+
+extension SubscribeReconnectEffect {
+  func performTask(completionBlock: @escaping ([Subscribe.Event]) -> Void) {
+    if let reconnectionDelay = request.computeReconnectionDelay(dueTo: error, with: currentAttempt) {
+      DispatchQueue.global(qos: .default).asyncAfter(deadline: .now() + reconnectionDelay) {
+        if !request.isCancelled {
+          request.execute(onCompletion: {
+            switch $0 {
+            case .success(let response):
+              completionBlock([onCompletion(with: response)])
+            case .failure(let e):
+              if currentAttempt + 1 >= request.retryLimit {
+                completionBlock([onGivingUp(dueTo: e)])
+              } else {
+                completionBlock([onFailure(dueTo: e)])
+              }
+            }
+          })
+        }
+      }
+    } else {
+      completionBlock([onGivingUp(dueTo: error!)])
+    }
+  }
+}
+
+// MARK: - HandshakingEffect
+
+struct HandshakingEffect: SubscribeEffect {
+  let request: SubscribeRequest
+
+  func onCompletion(with response: SubscribeResponse) -> Subscribe.Event {
+    .handshakeSucceess(cursor: response.cursor)
+  }
+  
+  func onFailure(dueTo error: SubscribeError) -> Subscribe.Event {
+    .handshakeFailure(error: error)
+  }
+}
+
+// MARK: - ReceivingEffect
+
+struct ReceivingEffect: SubscribeEffect {
+  let request: SubscribeRequest
+  
+  func onCompletion(with response: SubscribeResponse) -> Subscribe.Event {
+    .receiveSuccess(cursor: response.cursor, messages: response.messages)
+  }
+  
+  func onFailure(dueTo error: SubscribeError) -> Subscribe.Event {
+    .receiveFailure(error: error)
+  }  
+}
+
+// MARK: - HandshakeReconnectEffect
+
+struct HandshakeReconnectEffect: SubscribeReconnectEffect {
+  let request: SubscribeRequest
+  let error: SubscribeError?
+  let currentAttempt: Int
+  
+  func onCompletion(with response: SubscribeResponse) -> Subscribe.Event {
+    .handshakeReconnectSuccess(cursor: response.cursor)
+  }
+  
+  func onFailure(dueTo error: SubscribeError) -> Subscribe.Event {
+    .handshakeReconnectFailure(error: error)
+  }
+  
+  func onGivingUp(dueTo error: SubscribeError) -> Subscribe.Event {
+    .handshakeReconnectGiveUp(error: error)
+  }
+}
+
+// MARK: - ReceiveReconnectEffect
+
+struct ReceiveReconnectEffect: SubscribeReconnectEffect {
+  let request: SubscribeRequest
+  let error: SubscribeError?
+  let currentAttempt: Int
+  
+  func onCompletion(with response: SubscribeResponse) -> Subscribe.Event {
+    .receiveReconnectSuccess(cursor: response.cursor, messages: response.messages)
+  }
+  
+  func onFailure(dueTo error: SubscribeError) -> Subscribe.Event {
+    .receiveReconnectFailure(error: error)
+  }
+  
+  func onGivingUp(dueTo error: SubscribeError) -> Subscribe.Event {
+    .receiveReconnectGiveUp(error: error)
+  }
+}

--- a/Sources/PubNub/EventEngine/Subscribe/Effects/SubscribeRequest.swift
+++ b/Sources/PubNub/EventEngine/Subscribe/Effects/SubscribeRequest.swift
@@ -1,0 +1,127 @@
+//
+//  SubscribeRequest.swift
+//
+//  PubNub Real-time Cloud-Hosted Push API and Push Notification Client Frameworks
+//  Copyright © 2023 PubNub Inc.
+//  https://www.pubnub.com/
+//  https://www.pubnub.com/terms
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+class SubscribeRequest {
+  let channels: [String]
+  let groups: [String]
+  let timetoken: Timetoken?
+  let region: Int?
+  
+  private let configuration: SubscriptionConfiguration
+  private let session: SessionReplaceable
+  private let sessionResponseQueue: DispatchQueue
+  private var request: RequestReplaceable?
+  
+  var isCancelled: Bool {
+    request?.isCancelled ?? false
+  }
+  var retryLimit: UInt {
+    configuration.automaticRetry?.retryLimit ?? 0
+  }
+  
+  init(
+    configuration: SubscriptionConfiguration,
+    channels: [String],
+    groups: [String],
+    timetoken: Timetoken? = nil,
+    region: Int? = nil,
+    session: SessionReplaceable,
+    sessionResponseQueue: DispatchQueue
+  ) {
+    self.configuration = configuration
+    self.channels = channels
+    self.groups = groups
+    self.timetoken = timetoken
+    self.region = region
+    self.session = session
+    self.sessionResponseQueue = sessionResponseQueue
+  }
+  
+  func computeReconnectionDelay(
+    dueTo error: SubscribeError?,
+    with currentAttempt: Int
+  ) -> TimeInterval? {
+    guard let error = error else {
+      return 0
+    }
+    guard let automaticRetry = configuration.automaticRetry else {
+      return nil
+    }
+    guard let underlyingError = error.underlying.underlying else {
+      return nil
+    }
+    
+    let shouldRetry = automaticRetry.shouldRetry(response: error.urlResponse, error: underlyingError)
+    let hasEnoughAttempts = automaticRetry.retryLimit > currentAttempt
+    
+    if (shouldRetry && hasEnoughAttempts) {
+      return automaticRetry.policy.delay(for: currentAttempt)
+    } else {
+      return nil
+    }
+  }
+        
+  func execute(onCompletion: @escaping (Result<SubscribeResponse, SubscribeError>) -> Void) {
+    request = session.request(
+      with: SubscribeRouter(
+        .subscribe(
+          channels: channels,
+          groups: groups,
+          timetoken: timetoken,
+          region: region?.description ?? nil,
+          heartbeat: configuration.durationUntilTimeout,
+          filter: configuration.filterExpression
+        ), configuration: configuration
+      ), requestOperator: nil
+    )
+    request?.validate().response(
+      on: sessionResponseQueue,
+      decoder: SubscribeDecoder(),
+      completion: { [weak self] result in
+        switch result {
+        case .success(let response):
+          onCompletion(.success(response.payload))
+        case .failure(let error):
+          onCompletion(.failure(SubscribeError(
+            underlying: error as? PubNubError ?? PubNubError(.unknown, underlying: error),
+            urlResponse: self?.request?.urlResponse
+          )))
+        }
+      }
+    )
+  }
+  
+  func cancel() {
+    request?.cancel(PubNubError(.clientCancelled, router: nil))
+  }
+  
+  deinit {
+    cancel()
+  }
+}

--- a/Sources/PubNub/EventEngine/Subscribe/SubscribeTransition.swift
+++ b/Sources/PubNub/EventEngine/Subscribe/SubscribeTransition.swift
@@ -212,7 +212,9 @@ fileprivate extension SubscribeTransition {
       state: Subscribe.HandshakeFailedState(
         input: state.input,
         error: error
-      )
+      ), invocations: [
+        .managed(invocation: .emitStatus(status: .disconnected))
+      ]
     )
   }
 }
@@ -292,7 +294,9 @@ fileprivate extension SubscribeTransition {
         input: state.input,
         cursor: state.cursor,
         error: error
-      )
+      ), invocations: [
+        .managed(invocation: .emitStatus(status: .disconnected))
+      ]
     )
   }
 }
@@ -303,7 +307,8 @@ fileprivate extension SubscribeTransition {
       .cancel(id: Invocation.ID.HandshakeRequest),
       .cancel(id: Invocation.ID.HandshakeReconnect),
       .cancel(id: Invocation.ID.ReceiveMessages),
-      .cancel(id: Invocation.ID.ReceiveReconnect)
+      .cancel(id: Invocation.ID.ReceiveReconnect),
+      .managed(invocation: .emitStatus(status: .disconnected))
     ]
     if let state = state as? (any CursorState) {
       return TransitionResult(

--- a/Tests/PubNubTests/EventEngine/EmitMessagesTests.swift
+++ b/Tests/PubNubTests/EventEngine/EmitMessagesTests.swift
@@ -1,0 +1,297 @@
+//
+//  EmitMessagesTests.swift
+//
+//  PubNub Real-time Cloud-Hosted Push API and Push Notification Client Frameworks
+//  Copyright © 2023 PubNub Inc.
+//  https://www.pubnub.com/
+//  https://www.pubnub.com/terms
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+import XCTest
+
+@testable import PubNub
+
+fileprivate class MockListener: BaseSubscriptionListener {
+  var onEmitMessagesCalled: ([SubscribeMessagePayload]) -> Void = { _ in }
+  var onEmitSubscribeEventCalled: ((PubNubSubscribeEvent) -> Void) = { _ in }
+  
+  override func emit(batch: [SubscribeMessagePayload]) {
+    onEmitMessagesCalled(batch)
+  }
+  override func emit(subscribe: PubNubSubscribeEvent) {
+    onEmitSubscribeEventCalled(subscribe)
+  }
+}
+
+class EmitMessagesTests: XCTestCase {
+  private var listeners: [MockListener] = []
+  
+  override func setUp() {
+    listeners = (0...2).map { _ in MockListener() }
+    super.setUp()
+  }
+  
+  override func tearDown() {
+    listeners = []
+    super.tearDown()
+  }
+  
+  func testListener_WithMessage() {
+    let expectation = XCTestExpectation(description: "Emit Messages")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = listeners.count
+    
+    let messages = [
+      testMessage,
+      testSignal,
+      testObject,
+      testMessageAction,
+      testFile,
+      testPresenceChange
+    ]
+    let effect = EmitMessagesEffect(
+      messages: messages,
+      cursor: SubscribeCursor(timetoken: 12345, region: 11),
+      listeners: listeners,
+      messageCache: MessageCache()
+    )
+    
+    listeners.forEach {
+      $0.onEmitMessagesCalled = { receivedMessages in
+        XCTAssertTrue(receivedMessages.elementsEqual(messages))
+        expectation.fulfill()
+      }
+    }
+    
+    effect.performTask(completionBlock: { _ in
+      PubNub.log.debug("Did finish performing EmitMessages effect")
+    })
+    
+    wait(for: [expectation], timeout: 0.15)
+  }
+  
+  func testListener_MessageCountExceededMaximum() {
+    let expectation = XCTestExpectation(description: "Emit Messages")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = listeners.count
+    
+    let effect = EmitMessagesEffect(
+      messages: (1...100).map {
+        generateMessage(
+          with: .message,
+          payload: AnyJSON("Hello, it's message number \($0)")
+        )
+      },
+      cursor: SubscribeCursor(timetoken: 12345, region: 11),
+      listeners: listeners,
+      messageCache: MessageCache()
+    )
+    
+    listeners.forEach() {
+      $0.onEmitSubscribeEventCalled = { event in
+        if case let .errorReceived(error) = event {
+          XCTAssertTrue(error.reason == .messageCountExceededMaximum)
+          expectation.fulfill()
+        }
+      }
+    }
+    
+    effect.performTask(completionBlock: { _ in
+      PubNub.log.debug("Did finish performing EmitMessages effect")
+    })
+    
+    wait(for: [expectation], timeout: 0.1)
+  }
+  
+  func testEffect_SkipsDuplicatedMessages() {
+    let expectation = XCTestExpectation(description: "Emit Messages")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = listeners.count
+    
+    let effect = EmitMessagesEffect(
+      messages: (1...50).map { _ in
+        generateMessage(
+          with: .message,
+          payload: AnyJSON("Hello, it's a message")
+        )
+      },
+      cursor: SubscribeCursor(timetoken: 12345, region: 11),
+      listeners: listeners,
+      messageCache: MessageCache()
+    )
+    
+    listeners.forEach {
+      $0.onEmitMessagesCalled = { messages in
+        XCTAssertTrue(messages.count == 1)
+        XCTAssertTrue(messages[0].payload == "Hello, it's a message")
+        expectation.fulfill()
+      }
+    }
+    
+    effect.performTask(completionBlock: { _ in
+      PubNub.log.debug("Did finish performing EmitMessages effect")
+    })
+    
+    wait(for: [expectation], timeout: 0.1)
+  }
+  
+  func testEffect_MessageCacheDropsTheOldestMessages() {
+    let initialMessages = (1...99).map { idx in
+      generateMessage(
+        with: .message,
+        payload: AnyJSON("Hello, it's a message \(idx)")
+      )
+    }
+    let newMessages = (1...10).map { idx in
+      generateMessage(
+        with: .message,
+        payload: AnyJSON("Hello again, it's a message \(idx)")
+      )
+    }
+    let cache = MessageCache(
+      messagesArray: initialMessages
+    )
+    let effect = EmitMessagesEffect(
+      messages: newMessages,
+      cursor: SubscribeCursor(timetoken: 12345, region: 11),
+      listeners: listeners,
+      messageCache: cache
+    )
+    
+    effect.performTask(completionBlock: { _ in
+      PubNub.log.debug("Did finish performing EmitMessages effect")
+    })
+    
+    let allCachedMessages = cache.messagesArray.compactMap { $0 }
+    let expectedDroppedMssgs = Array(initialMessages[0...9])
+        
+    for droppedMssg in expectedDroppedMssgs {
+      XCTAssertFalse(allCachedMessages.contains(droppedMssg))
+    }
+    for newMessage in allCachedMessages {
+      XCTAssertTrue(allCachedMessages.contains(newMessage))
+    }
+  }
+}
+
+fileprivate extension EmitMessagesTests {
+  var testMessage: SubscribeMessagePayload {
+    generateMessage(
+      with: .message,
+      payload: "Hello, this is a message"
+    )
+  }
+  
+  var testSignal: SubscribeMessagePayload {
+    generateMessage(
+      with: .signal,
+      payload: "Hello, this is a signal"
+    )
+  }
+  
+  var testObject: SubscribeMessagePayload {
+    generateMessage(
+      with: .object,
+      payload: AnyJSON(
+        SubscribeObjectMetadataPayload(
+          source: "123",
+          version: "456",
+          event: .delete,
+          type: .uuid,
+          subscribeEvent: .uuidMetadataRemoved(metadataId: "12345")
+        )
+      )
+    )
+  }
+  
+  var testMessageAction: SubscribeMessagePayload {
+    generateMessage(
+      with: .messageAction,
+      payload: AnyJSON(
+        [
+          "event": "added",
+          "source": "actions",
+          "version": "1.0",
+          "data": [
+            "messageTimetoken": "16844114408637596",
+            "type": "receipt",
+            "actionTimetoken": "16844114409339370",
+            "value": "read"
+          ]
+        ]
+      )
+    )
+  }
+  
+  var testFile: SubscribeMessagePayload {
+    generateMessage(
+      with: .file,
+      payload: AnyJSON(FilePublishPayload(
+        channel: "",
+        fileId: "",
+        filename: "",
+        size: 54556,
+        contentType: "image/jpeg",
+        createdDate: nil,
+        additionalDetails: nil
+      ))
+    )
+  }
+  
+  var testPresenceChange: SubscribeMessagePayload {
+    generateMessage(
+      with: .presence,
+      payload: AnyJSON(
+        SubscribePresencePayload(
+          actionEvent: .join,
+          occupancy: 15,
+          uuid: nil,
+          timestamp: 123123,
+          refreshHereNow: false,
+          state: nil,
+          join: ["dsadf", "fdsa"],
+          leave: [],
+          timeout: []
+        )
+      )
+    )
+  }
+  
+  func generateMessage(
+    with type: SubscribeMessagePayload.Action,
+    payload: AnyJSON
+  ) -> SubscribeMessagePayload {
+    SubscribeMessagePayload(
+      shard: "shard",
+      subscription: nil,
+      channel: "test-channel",
+      messageType: type,
+      payload: payload,
+      flags: 123,
+      publisher: "publisher",
+      subscribeKey: "FakeKey",
+      originTimetoken: nil,
+      publishTimetoken: SubscribeCursor(timetoken: 12312412412, region: 12),
+      meta: nil
+    )
+  }
+}

--- a/Tests/PubNubTests/EventEngine/EmitStatusTests.swift
+++ b/Tests/PubNubTests/EventEngine/EmitStatusTests.swift
@@ -1,0 +1,140 @@
+//
+//  EmitStatusTests.swift
+//
+//  PubNub Real-time Cloud-Hosted Push API and Push Notification Client Frameworks
+//  Copyright © 2023 PubNub Inc.
+//  https://www.pubnub.com/
+//  https://www.pubnub.com/terms
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+import XCTest
+
+@testable import PubNub
+
+fileprivate class MockListener: BaseSubscriptionListener {
+  var onEmitSubscribeEventCalled: ((PubNubSubscribeEvent) -> Void) = { _ in }
+  
+  override func emit(subscribe: PubNubSubscribeEvent) {
+    onEmitSubscribeEventCalled(subscribe)
+  }
+}
+
+class EmitStatusTests: XCTestCase {
+  private var listeners: [MockListener] = []
+  
+  override func setUp() {
+    listeners = (0...2).map { _ in MockListener() }
+    super.setUp()
+  }
+  
+  override func tearDown() {
+    listeners = []
+    super.tearDown()
+  }
+    
+  func testEmitStatus_FromDisconnectedToConnecting() {
+    testEffect(from: .disconnected, to: .connecting) { result in
+      XCTAssertTrue(result == .connecting)
+    }
+  }
+  
+  func testEmitStatus_FromConnectingToConnected() {
+    testEffect(from: .connecting, to: .connected) { result in
+      XCTAssertTrue(result == .connected)
+    }
+  }
+  
+  func testEmitStatus_FromConnectingToDisconnected() {
+    testEffect(from: .connecting, to: .disconnected) { result in
+      XCTAssertTrue(result == .disconnected)
+    }
+  }
+  
+  func testEmitStatus_FromConnectedToReconnecting() {
+    testEffect(from: .connected, to: .reconnecting) { result in
+      XCTAssertTrue(result == .reconnecting)
+    }
+  }
+  
+  func testEmitStatus_FromConnectedToDisconnected() {
+    testEffect(from: .connected, to: .disconnected) { result in
+      XCTAssertTrue(result == .disconnected)
+    }
+  }
+  
+  func testEmitStatus_FromReconnectingToDisconnected() {
+    testEffect(from: .reconnecting, to: .disconnected) { result in
+      XCTAssertTrue(result == .disconnected)
+    }
+  }
+  
+  func testEmitStatus_FromConnectingToDisconnectedUnexpectedly() {
+    testEffect(from: .connecting, to: .disconnectedUnexpectedly) { result in
+      XCTAssertTrue(result == .disconnectedUnexpectedly)
+    }
+  }
+  
+  func testEmitStatus_FromConnectedToDisconnectedUnexpectedly() {
+    testEffect(from: .connected, to: .disconnectedUnexpectedly) { result in
+      XCTAssertTrue(result == .disconnectedUnexpectedly)
+    }
+  }
+  
+  func testEmitStatus_FromReconnectingToDisconnectedUnexpectedly() {
+    testEffect(from: .reconnecting, to: .disconnectedUnexpectedly) { result in
+      XCTAssertTrue(result == .disconnectedUnexpectedly)
+    }
+  }
+  
+  private func testEffect(
+    from currentStatus: ConnectionStatus,
+    to newStatus: ConnectionStatus,
+    verifyResult: @escaping (ConnectionStatus) -> Void
+  ) {
+    let expectation = XCTestExpectation(description: "Emit Status Effect")
+    expectation.expectedFulfillmentCount = listeners.count
+    expectation.assertForOverFulfill = true
+    
+    let effect = EmitStatusEffect(
+      currentStatus: currentStatus,
+      newStatus: newStatus,
+      listeners: listeners
+    )
+    
+    listeners.forEach {
+      $0.onEmitSubscribeEventCalled = { event in
+        if case let .connectionChanged(status) = event {
+          verifyResult(status)
+          expectation.fulfill()
+        } else {
+          XCTFail("Unexpected event")
+        }
+      }
+    }
+    
+    effect.performTask(completionBlock: { _ in
+      PubNub.log.debug("Did finish performing EmitStatus effect")
+    })
+    
+    wait(for: [expectation], timeout: 0.1)
+  }
+}

--- a/Tests/PubNubTests/EventEngine/SubscribeEffectsTests.swift
+++ b/Tests/PubNubTests/EventEngine/SubscribeEffectsTests.swift
@@ -1,0 +1,377 @@
+//
+//  File.swift
+//
+//  PubNub Real-time Cloud-Hosted Push API and Push Notification Client Frameworks
+//  Copyright © 2023 PubNub Inc.
+//  https://www.pubnub.com/
+//  https://www.pubnub.com/terms
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+import XCTest
+
+@testable import PubNub
+
+class SubscribeEffectsTests: XCTestCase {
+  private var mockUrlSession: MockURLSession!
+  private var httpSession: HTTPSession!
+  private var delegate: HTTPSessionDelegate!
+  
+  private lazy var factory = SubscribeEffectFactory(
+    configuration: PubNubConfiguration(
+      publishKey: "pubKey",
+      subscribeKey: "subKey",
+      userId: "userId",
+      automaticRetry: AutomaticRetry(
+        retryLimit: 3,
+        policy: AutomaticRetry.ReconnectionPolicy.immediately
+      )
+    ),
+    session: httpSession
+  )
+  
+  override func setUp() {
+    delegate = HTTPSessionDelegate()
+    mockUrlSession = MockURLSession(delegate: delegate)
+    httpSession = HTTPSession(session: mockUrlSession, delegate: delegate, sessionQueue: .main)
+    super.setUp()
+  }
+  
+  override func tearDown() {
+    mockUrlSession = nil
+    delegate = nil
+    httpSession = nil
+    super.tearDown()
+  }
+  
+  func test_HandshakingEffectWithSuccessResponse() {
+    let effect = factory.effect(
+      for: .handshakeRequest(channels: ["test-channel"], groups: [])
+    )
+    testEffect(effect: effect, mockResponse: {
+      mockResponse(subscribeResponse: SubscribeResponse(
+        cursor: SubscribeCursor(timetoken: 12345, region: 1),
+        messages: []
+      ))
+    }, verifyResults: { results in
+      if case let .handshakeSucceess(cursor) = results[0] {
+        XCTAssertTrue(results.count == 1)
+        XCTAssertTrue(cursor == SubscribeCursor(timetoken: 12345, region: 1))
+      } else {
+        XCTFail("Unexpected condition")
+      }
+    })
+  }
+  
+  func test_HandshakingEffectWithFailedResponse() {
+    let effect = factory.effect(
+      for: .handshakeRequest(channels: ["test-channel"], groups: [])
+    )
+    testEffect(effect: effect, mockResponse: {
+      mockResponse(
+        errorIfAny: URLError(.cannotFindHost),
+        httpResponse: HTTPURLResponse(statusCode: 404)!
+      )
+    }, verifyResults: { results in
+      if case let .handshakeFailure(error) = results[0] {
+        XCTAssertTrue(results.count == 1)
+        XCTAssertTrue(error.underlying == PubNubError(.nameResolutionFailure, underlying: URLError(.cannotFindHost)))
+      } else {
+        XCTFail("Unexpected condition")
+      }
+    })
+  }
+  
+  func test_ReceivingEffectWithSuccessResponse() {
+    let effect = factory.effect(
+      for: .receiveMessages(
+        channels: ["test-channel"],
+        groups: [],
+        cursor: SubscribeCursor(timetoken: 111, region: 1)
+      )
+    )
+    testEffect(effect: effect, mockResponse: {
+      mockResponse(subscribeResponse: SubscribeResponse(
+        cursor: SubscribeCursor(timetoken: 12345, region: 1),
+        messages: [firstMessage, secondMessage]
+      ))
+    }, verifyResults: { results in
+      if case let .receiveSuccess(cursor, messages) = results[0] {
+        XCTAssertTrue(results.count == 1)
+        XCTAssertTrue(cursor == SubscribeCursor(timetoken: 12345, region: 1))
+        XCTAssertTrue(messages == [firstMessage, secondMessage])
+      } else {
+        XCTFail("Unexpected condition")
+      }
+    })
+  }
+  
+  func test_ReceivingEffectWithFailedResponse() {
+    let effect = factory.effect(
+      for: .receiveMessages(
+        channels: ["test-channel"],
+        groups: [],
+        cursor: SubscribeCursor(timetoken: 111, region: 1)
+      )
+    )
+    testEffect(effect: effect, mockResponse: {
+      mockResponse(
+        errorIfAny: URLError(.cannotFindHost),
+        httpResponse: HTTPURLResponse(statusCode: 404)!
+      )
+    }, verifyResults: { results in
+      if case let .receiveFailure(error) = results[0] {
+        XCTAssertTrue(results.count == 1)
+        XCTAssertTrue(error.underlying == PubNubError(.nameResolutionFailure, underlying: URLError(.cannotFindHost)))
+      } else {
+        XCTFail("Unexpected condition")
+      }
+    })
+  }
+  
+  func test_HandshakeReconnectingSuccess() {
+    let error = SubscribeError(
+      underlying: PubNubError(.badServerResponse, underlying: URLError(.badServerResponse))
+    )
+    let effect = factory.effect(
+      for: .handshakeReconnect(
+        channels: ["test-channel"],
+        groups: [],
+        currentAttempt: 1,
+        reason: error
+      )
+    )
+    testEffect(effect: effect, mockResponse: {
+      mockResponse(subscribeResponse: SubscribeResponse(
+        cursor: SubscribeCursor(timetoken: 12345, region: 1),
+        messages: []
+      ))
+    }, verifyResults: { results in
+      if case let .handshakeReconnectSuccess(cursor) = results[0] {
+        XCTAssertTrue(results.count == 1)
+        XCTAssertTrue(cursor == SubscribeCursor(timetoken: 12345, region: 1))
+      } else {
+        XCTFail("Unexpected condition")
+      }
+    })
+  }
+  
+  func test_HandshakeReconnectingFailed() {
+    let error = SubscribeError(
+      underlying: PubNubError(.badServerResponse, underlying: URLError(.badServerResponse))
+    )
+    let effect = factory.effect(
+      for: .handshakeReconnect(
+        channels: ["test-channel"],
+        groups: [],
+        currentAttempt: 1,
+        reason: error
+      )
+    )
+    testEffect(effect: effect, mockResponse: {
+      mockResponse(
+        errorIfAny: URLError(.cannotFindHost),
+        httpResponse: HTTPURLResponse(statusCode: 404)!
+      )
+    }, verifyResults: { results in
+      if case let .handshakeReconnectFailure(error) = results[0] {
+        XCTAssertTrue(results.count == 1)
+        XCTAssertTrue(error.underlying == PubNubError(.nameResolutionFailure, underlying: URLError(.cannotFindHost)))
+      } else {
+        XCTFail("Unexpected condition")
+      }
+    })
+  }
+  
+  func test_HandshakeReconnectGiveUp() {
+    let error = SubscribeError(
+      underlying: PubNubError(.badServerResponse, underlying: URLError(.badServerResponse))
+    )
+    let effect = factory.effect(
+      for: .handshakeReconnect(
+        channels: ["test-channel"],
+        groups: [],
+        currentAttempt: 2,
+        reason: error
+      )
+    )
+    testEffect(effect: effect, mockResponse: {
+      mockResponse(
+        errorIfAny: URLError(.cannotFindHost),
+        httpResponse: HTTPURLResponse(statusCode: 404)!
+      )
+    }, verifyResults: { results in
+      if case let .handshakeReconnectGiveUp(error) = results[0] {
+        XCTAssertTrue(results.count == 1)
+        XCTAssertTrue(error.underlying == PubNubError(.nameResolutionFailure, underlying: URLError(.cannotFindHost)))
+      } else {
+        XCTFail("Unexpected condition")
+      }
+    })
+  }
+  
+  func test_ReceiveReconnectingSuccess() {
+    let error = SubscribeError(
+      underlying: PubNubError(.badServerResponse, underlying: URLError(.badServerResponse))
+    )
+    let effect = factory.effect(
+      for: .receiveReconnect(
+        channels: ["test-channel"],
+        group: [],
+        cursor: SubscribeCursor(timetoken: 1111, region: 1),
+        currentAttempt: 1,
+        reason: error
+      )
+    )
+    testEffect(effect: effect, mockResponse: {
+      mockResponse(subscribeResponse: SubscribeResponse(
+        cursor: SubscribeCursor(timetoken: 12345, region: 1),
+        messages: [firstMessage, secondMessage]
+      ))
+    }, verifyResults: { results in
+      if case let .receiveReconnectSuccess(cursor, messages) = results[0] {
+        XCTAssertTrue(results.count == 1)
+        XCTAssertTrue(cursor == SubscribeCursor(timetoken: 12345, region: 1))
+        XCTAssertTrue(messages == [firstMessage, secondMessage])
+      } else {
+        XCTFail("Unexpected condition")
+      }
+    })
+  }
+  
+  func test_ReceiveReconnectingFailure() {
+    let error = SubscribeError(
+      underlying: PubNubError(.badServerResponse, underlying: URLError(.badServerResponse))
+    )
+    let effect = factory.effect(
+      for: .receiveReconnect(
+        channels: ["test-channel"],
+        group: [],
+        cursor: SubscribeCursor(timetoken: 1111, region: 1),
+        currentAttempt: 1,
+        reason: error
+      )
+    )
+    testEffect(effect: effect, mockResponse: {
+      mockResponse(
+        errorIfAny: URLError(.cannotFindHost),
+        httpResponse: HTTPURLResponse(statusCode: 404)!
+      )
+    }, verifyResults: { results in
+      if case let .receiveReconnectFailure(error) = results[0] {
+        XCTAssertTrue(results.count == 1)
+        XCTAssertTrue(error.underlying == PubNubError(.nameResolutionFailure, underlying: URLError(.cannotFindHost)))
+      } else {
+        XCTFail("Unexpected condition")
+      }
+    })
+  }
+  
+  func test_ReceiveReconnectGiveUp() {
+    let error = SubscribeError(
+      underlying: PubNubError(.badServerResponse, underlying: URLError(.badServerResponse))
+    )
+    let effect = factory.effect(
+      for: .receiveReconnect(
+        channels: ["test-channel"],
+        group: [],
+        cursor: SubscribeCursor(timetoken: 1111, region: 1),
+        currentAttempt: 2,
+        reason: error
+      )
+    )
+    testEffect(effect: effect, mockResponse: {
+      mockResponse(
+        errorIfAny: URLError(.cannotFindHost),
+        httpResponse: HTTPURLResponse(statusCode: 404)!
+      )
+    }, verifyResults: { results in
+      if case let .receiveReconnectGiveUp(error) = results[0] {
+        XCTAssertTrue(results.count == 1)
+        XCTAssertTrue(error.underlying == PubNubError(.nameResolutionFailure, underlying: URLError(.cannotFindHost)))
+      } else {
+        XCTFail("Unexpected condition")
+      }
+    })
+  }
+}
+
+fileprivate extension SubscribeEffectsTests {
+  func mockResponse(
+    subscribeResponse: SubscribeResponse? = nil,
+    errorIfAny: Error? = nil,
+    httpResponse: HTTPURLResponse = HTTPURLResponse(statusCode: 200)!
+  ) {
+    mockUrlSession.responseForDataTask = { task, id in
+      task.mockError = errorIfAny
+      task.mockData = try? Constant.jsonEncoder.encode(subscribeResponse)
+      task.mockResponse = httpResponse
+      return task
+    }
+  }
+  
+  func testEffect(
+    effect: some EffectHandler<Subscribe.Event>,
+    mockResponse: () -> Void,
+    verifyResults: @escaping ([Subscribe.Event]) -> Void
+  ) {
+    mockResponse()
+    
+    let expectation = XCTestExpectation()
+    expectation.expectationDescription = "Effect Completion Expectation"
+    expectation.assertForOverFulfill = true
+    
+    effect.performTask(completionBlock: { events in
+      verifyResults(events)
+      expectation.fulfill()
+    })
+    
+    wait(for: [expectation], timeout: 0.5)
+  }
+}
+
+fileprivate let firstMessage = SubscribeMessagePayload(
+  shard: "",
+  subscription: nil,
+  channel: "test-channel",
+  messageType: .message,
+  payload: ["message": "hello!"],
+  flags: 123,
+  publisher: "publisher",
+  subscribeKey: "FakeKey",
+  originTimetoken: nil,
+  publishTimetoken: SubscribeCursor(timetoken: 12312412412, region: 12),
+  meta: nil
+)
+
+fileprivate let secondMessage = SubscribeMessagePayload(
+  shard: "",
+  subscription: nil,
+  channel: "test-channel",
+  messageType: .messageAction,
+  payload: ["reaction": "👍"],
+  flags: 456,
+  publisher: "second-publisher",
+  subscribeKey: "FakeKey",
+  originTimetoken: nil,
+  publishTimetoken: SubscribeCursor(timetoken: 12312412555, region: 12),
+  meta: nil
+)

--- a/Tests/PubNubTests/EventEngine/SubscribeTransitionTests.swift
+++ b/Tests/PubNubTests/EventEngine/SubscribeTransitionTests.swift
@@ -469,14 +469,18 @@ class SubscribeTransitionTests: XCTestCase {
       from: Subscribe.HandshakeReconnectingState(input: input, currentAttempt: 3),
       event: .handshakeReconnectGiveUp(error: SubscribeError(underlying: PubNubError(.unknown)))
     )
+    let expEmitStatusInvocation = Subscribe.Invocation.emitStatus(
+      status: .disconnected
+    )
     let expState = Subscribe.HandshakeFailedState(
       input: input,
       error: SubscribeError(underlying: PubNubError(.unknown))
     )
     
     XCTAssertTrue(try XCTUnwrap(results.state as? Subscribe.HandshakeFailedState) == expState)
-    XCTAssertTrue(results.invocations.count == 1)
+    XCTAssertTrue(results.invocations.count == 2)
     XCTAssertTrue(results.invocations.contains(.cancel(id: Subscribe.Invocation.ID.HandshakeReconnect)))
+    XCTAssertTrue(results.invocations.contains(.managed(invocation: expEmitStatusInvocation)))
   }
   
   // MARK: - Receive Give Up
@@ -489,6 +493,9 @@ class SubscribeTransitionTests: XCTestCase {
       ),
       event: .receiveReconnectGiveUp(error: SubscribeError(underlying: PubNubError(.unknown)))
     )
+    let expEmitStatusInvocation = Subscribe.Invocation.emitStatus(
+      status: .disconnected
+    )
     let expState = Subscribe.ReceiveFailedState(
       input: input,
       cursor: SubscribeCursor(timetoken: 18001000, region: 123),
@@ -496,8 +503,9 @@ class SubscribeTransitionTests: XCTestCase {
     )
     
     XCTAssertTrue(try XCTUnwrap(results.state as? Subscribe.ReceiveFailedState) == expState)
-    XCTAssertTrue(results.invocations.count == 1)
+    XCTAssertTrue(results.invocations.count == 2)
     XCTAssertTrue(results.invocations.contains(.cancel(id: Subscribe.Invocation.ID.ReceiveReconnect)))
+    XCTAssertTrue(results.invocations.contains(.managed(invocation: expEmitStatusInvocation)))
   }
   
   // MARK: - Receiving With Messages


### PR DESCRIPTION
* Added a new class called `SubscribeRequest` to encapsulate calling the `subscribe` method from our REST API
  * This should make `HandshakingEffect`, `ReceivingEffect`, etc network-agnostic. Those effects shouldn't have any knowledge about classes we use for networking like `SessionReplaceable`, `HTTPRouter`, etc. Objects of those classes are hidden in `SubscribeRequest` as private members 
* Removed code duplication from `HandshakingEffect`, `ReceivingEffect`, and their reconnection counterparts
* Implemented new `EmitStatus` and `EmitMessages` effects
* Unit tests for current Effects