### PR TITLE
feat: add static_framework flag to podspec for react native

### DIFF
--- a/PubNubSwift.podspec
+++ b/PubNubSwift.podspec
@@ -25,4 +25,11 @@ The PubNub Real-Time Network. Build real-time apps quickly and scale them global
 
   s.module_name = 'PubNub'
   s.source_files = 'Sources/**/*.swift'
+
+  if defined?($PubNubAsStaticFramework)
+    Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$PubNubAsStaticFramework}'"
+    s.static_framework = $PubNubAsStaticFramework
+  else
+    s.static_framework = false
+  end
 end


### PR DESCRIPTION
By adding this to the podspec, react-native builds can opt-out of `use_framework!` in order to be able to keep compatibility with Flipper, and other not yet updated pods. For other popular pod implementing this, see [rnfirebase](https://github.com/invertase/react-native-firebase/commit/530f8bbb51f89f106854dbf1df5ec80211e2cf8b)