### PR TITLE
Make `static_framework` flag configurable

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,9 +1,14 @@
 ---
 name: swift
 scm: github.com/pubnub/swift
-version: "6.0.5"
+version: "6.1.0"
 schema: 1
 changelog:
+  - date: 2023-08-30
+    version: 6.1.0
+    changes:
+      - type: feature
+        text: "To make client integration more flexible for different projects setup, the `$PubNubAsStaticFramework` flag has been added to `PubNubSwift.podspec`.  With `$PubNubAsStaticFramework = true` in `Podfile` SDK will be integrated as a static library."
   - date: 2023-05-18
     version: 6.0.5
     changes:
@@ -485,7 +490,7 @@ sdks:
           - distribution-type: source
             distribution-repository: GitHub release
             package-name: PubNub
-            location: https://github.com/pubnub/swift/archive/refs/tags/6.0.5.zip
+            location: https://github.com/pubnub/swift/archive/refs/tags/6.1.0.zip
             supported-platforms:
               supported-operating-systems:
                 macOS:

--- a/PubNub.xcodeproj/project.pbxproj
+++ b/PubNub.xcodeproj/project.pbxproj
@@ -3256,7 +3256,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.0.5;
+				MARKETING_VERSION = 6.1.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnub.swift.PubNubUser;
@@ -3303,7 +3303,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.0.5;
+				MARKETING_VERSION = 6.1.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnub.swift.PubNubUser;
@@ -3403,7 +3403,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.0.5;
+				MARKETING_VERSION = 6.1.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnub.swift.PubNubSpace;
@@ -3452,7 +3452,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.0.5;
+				MARKETING_VERSION = 6.1.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnub.swift.PubNubSpace;
@@ -3565,7 +3565,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.0.5;
+				MARKETING_VERSION = 6.1.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnub.swift.PubNubMembership;
@@ -3613,7 +3613,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.0.5;
+				MARKETING_VERSION = 6.1.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnub.swift.PubNubMembership;
@@ -4069,7 +4069,7 @@
 					"$(inherited)",
 					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
 				);
-				MARKETING_VERSION = 6.0.5;
+				MARKETING_VERSION = 6.1.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -4108,7 +4108,7 @@
 					"$(inherited)",
 					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
 				);
-				MARKETING_VERSION = 6.0.5;
+				MARKETING_VERSION = 6.1.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";

--- a/PubNubSwift.podspec
+++ b/PubNubSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'PubNubSwift'
-  s.version  = '6.0.5'
+  s.version  = '6.0.6'
   s.homepage = 'https://github.com/pubnub/swift'
   s.documentation_url = 'https://www.pubnub.com/docs/swift-native/pubnub-swift-sdk'
   s.authors = { 'PubNub, Inc.' => 'support@pubnub.com' }
@@ -16,13 +16,20 @@ The PubNub Real-Time Network. Build real-time apps quickly and scale them global
 
                   DESC
 
-  s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = '11.0'
   s.osx.deployment_target = '10.11'
-  s.tvos.deployment_target = '9.0'
-  s.watchos.deployment_target = '4.0'
+  s.tvos.deployment_target = '11.0'
+  s.watchos.deployment_target = '6.0'
 
   s.swift_version = '5.0'
 
   s.module_name = 'PubNub'
   s.source_files = 'Sources/**/*.swift'
+
+  if defined?($PubNubAsStaticFramework)
+    Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$PubNubAsStaticFramework}'"
+    s.static_framework = $PubNubAsStaticFramework
+  else
+    s.static_framework = false
+  end
 end

--- a/PubNubSwift.podspec
+++ b/PubNubSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'PubNubSwift'
-  s.version  = '6.0.6'
+  s.version  = '6.1.0'
   s.homepage = 'https://github.com/pubnub/swift'
   s.documentation_url = 'https://www.pubnub.com/docs/swift-native/pubnub-swift-sdk'
   s.authors = { 'PubNub, Inc.' => 'support@pubnub.com' }

--- a/Sources/PubNub/Helpers/Constants.swift
+++ b/Sources/PubNub/Helpers/Constants.swift
@@ -57,7 +57,7 @@ public enum Constant {
 
   static let pubnubSwiftSDKName: String = "PubNubSwift"
 
-  static let pubnubSwiftSDKVersion: String = "6.0.5"
+  static let pubnubSwiftSDKVersion: String = "6.1.0"
 
   static let appBundleId: String = {
     if let info = Bundle.main.infoDictionary,


### PR DESCRIPTION
feat(cocoapods): make `static_framework` configurable in the spec file

To make client integration more flexible for different projects setup, the `$PubNubAsStaticFramework` flag has been added to `PubNubSwift.podspec`. 
With `$PubNubAsStaticFramework = true` in `Podfile` SDK will be integrated as a static library.

Closes #142 