### PR TITLE
fix(crypto): Renaming CryptorModule with CryptoModule

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,9 +1,14 @@
 ---
 name: swift
 scm: github.com/pubnub/swift
-version: "6.2.0"
+version: "6.2.1"
 schema: 1
 changelog:
+  - date: 2023-10-23
+    version: 6.2.1
+    changes:
+      - type: bug
+        text: "Align on namings across all supported platforms."
   - date: 2023-10-16
     version: v6.2.0
     changes:
@@ -497,7 +502,7 @@ sdks:
           - distribution-type: source
             distribution-repository: GitHub release
             package-name: PubNub
-            location: https://github.com/pubnub/swift/archive/refs/tags/6.2.0.zip
+            location: https://github.com/pubnub/swift/archive/refs/tags/6.2.1.zip
             supported-platforms:
               supported-operating-systems:
                 macOS:

--- a/Examples/Sources/ConfigDetailTableViewController.swift
+++ b/Examples/Sources/ConfigDetailTableViewController.swift
@@ -90,7 +90,7 @@ class ConfigDetailTableViewController: UITableViewController {
       case .subscribeKey:
         return config.subscribeKey
       case .cipherKey:
-        return config.cryptorModule?.description ?? "CryptorModule Not Found"
+        return config.cryptoModule?.description ?? "CryptoModule Not Found"
       case .authKey:
         return config.authKey
       case .uuid:

--- a/PubNub.xcodeproj/project.pbxproj
+++ b/PubNub.xcodeproj/project.pbxproj
@@ -3436,7 +3436,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.2.0;
+				MARKETING_VERSION = 6.2.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnub.swift.PubNubUser;
@@ -3483,7 +3483,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.2.0;
+				MARKETING_VERSION = 6.2.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnub.swift.PubNubUser;
@@ -3583,7 +3583,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.2.0;
+				MARKETING_VERSION = 6.2.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnub.swift.PubNubSpace;
@@ -3632,7 +3632,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.2.0;
+				MARKETING_VERSION = 6.2.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnub.swift.PubNubSpace;
@@ -3745,7 +3745,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.2.0;
+				MARKETING_VERSION = 6.2.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnub.swift.PubNubMembership;
@@ -3793,7 +3793,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.2.0;
+				MARKETING_VERSION = 6.2.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnub.swift.PubNubMembership;
@@ -4253,7 +4253,7 @@
 					"$(inherited)",
 					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
 				);
-				MARKETING_VERSION = 6.2.0;
+				MARKETING_VERSION = 6.2.1;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -4292,7 +4292,7 @@
 					"$(inherited)",
 					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
 				);
-				MARKETING_VERSION = 6.2.0;
+				MARKETING_VERSION = 6.2.1;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";

--- a/PubNub.xcodeproj/project.pbxproj
+++ b/PubNub.xcodeproj/project.pbxproj
@@ -376,7 +376,7 @@
 		35FE941B22EFE5400051C455 /* EventStreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35FE941A22EFE5400051C455 /* EventStreamTests.swift */; };
 		35FE941F22F0929A0051C455 /* RequestRetrierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35FE941E22F0929A0051C455 /* RequestRetrierTests.swift */; };
 		3D6265D72ABCA79100FDD5E6 /* CryptorUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D6265D62ABCA79100FDD5E6 /* CryptorUtils.swift */; };
-		3D758DBF2AAA1C49005D2B36 /* CryptorModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D758DBE2AAA1C49005D2B36 /* CryptorModule.swift */; };
+		3D758DBF2AAA1C49005D2B36 /* CryptoModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D758DBE2AAA1C49005D2B36 /* CryptoModule.swift */; };
 		3D758DC82AB06A12005D2B36 /* CryptoInputStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D758DC62AB06A12005D2B36 /* CryptoInputStream.swift */; };
 		3D758DC92AB06A12005D2B36 /* CryptoStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D758DC72AB06A12005D2B36 /* CryptoStream.swift */; };
 		3D758DCB2AB06A2D005D2B36 /* Cryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D758DCA2AB06A2D005D2B36 /* Cryptor.swift */; };
@@ -911,7 +911,7 @@
 		35FE941A22EFE5400051C455 /* EventStreamTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventStreamTests.swift; sourceTree = "<group>"; };
 		35FE941E22F0929A0051C455 /* RequestRetrierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestRetrierTests.swift; sourceTree = "<group>"; };
 		3D6265D62ABCA79100FDD5E6 /* CryptorUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptorUtils.swift; sourceTree = "<group>"; };
-		3D758DBE2AAA1C49005D2B36 /* CryptorModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptorModule.swift; sourceTree = "<group>"; };
+		3D758DBE2AAA1C49005D2B36 /* CryptoModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoModule.swift; sourceTree = "<group>"; };
 		3D758DC62AB06A12005D2B36 /* CryptoInputStream.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CryptoInputStream.swift; sourceTree = "<group>"; };
 		3D758DC72AB06A12005D2B36 /* CryptoStream.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CryptoStream.swift; sourceTree = "<group>"; };
 		3D758DCA2AB06A2D005D2B36 /* Cryptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cryptor.swift; sourceTree = "<group>"; };
@@ -1091,7 +1091,7 @@
 			isa = PBXGroup;
 			children = (
 				3595120F2301DCAB00C9D3AE /* Crypto.swift */,
-				3D758DBE2AAA1C49005D2B36 /* CryptorModule.swift */,
+				3D758DBE2AAA1C49005D2B36 /* CryptoModule.swift */,
 				3D758DCC2AB06B98005D2B36 /* Header */,
 				3D758DC52AB06983005D2B36 /* Cryptors */,
 				3D758DC42AB06977005D2B36 /* Miscellaneous */,
@@ -3078,7 +3078,7 @@
 				35D0615F2304830600FDB2F9 /* GenericServicePayloadResponse.swift in Sources */,
 				3D758DD62AB48A6A005D2B36 /* CryptorHeaderWithinStreamFinder.swift in Sources */,
 				35A66A8E22F911DB00AC67A9 /* SubscribeSessionFactory.swift in Sources */,
-				3D758DBF2AAA1C49005D2B36 /* CryptorModule.swift in Sources */,
+				3D758DBF2AAA1C49005D2B36 /* CryptoModule.swift in Sources */,
 				3D758DD02AB0A8C6005D2B36 /* CryptorVector.swift in Sources */,
 				3D6265D72ABCA79100FDD5E6 /* CryptorUtils.swift in Sources */,
 				35D8D4C522EB4600001B07D9 /* AnyJSON.swift in Sources */,

--- a/PubNubSwift.podspec
+++ b/PubNubSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'PubNubSwift'
-  s.version  = '6.2.0'
+  s.version  = '6.2.1'
   s.homepage = 'https://github.com/pubnub/swift'
   s.documentation_url = 'https://www.pubnub.com/docs/swift-native/pubnub-swift-sdk'
   s.authors = { 'PubNub, Inc.' => 'support@pubnub.com' }

--- a/Sources/PubNub/APIs/File+PubNub.swift
+++ b/Sources/PubNub/APIs/File+PubNub.swift
@@ -160,9 +160,9 @@ public extension PubNub {
       switch result {
       case let .success(response):
         do {
-          let cryptorModule = requestConfig.customConfiguration?.cryptorModule ?? configuration.cryptorModule
+          let cryptoModule = requestConfig.customConfiguration?.cryptoModule ?? configuration.cryptoModule
           completion?(.success((
-            try URLRequest(from: response.payload, uploading: content, cryptorModule: cryptorModule),
+            try URLRequest(from: response.payload, uploading: content, cryptoModule: cryptoModule),
             response.payload.fileId,
             response.payload.filename
           )))
@@ -450,7 +450,7 @@ public extension PubNub {
   ///   - downloadTo: The async `Result` of the method call
   /// - Returns: The new file download task. The `urlSessionTask` property can be used to access the underlying `URLSessionDownloadTask`
   func createFileURLSessionDownloadTask(
-    _ taskType: FileDownloadTaskType, session: URLSessionReplaceable, downloadTo url: URL, decrypt: CryptorModule? = nil
+    _ taskType: FileDownloadTaskType, session: URLSessionReplaceable, downloadTo url: URL, decrypt: CryptoModule? = nil
   ) -> HTTPFileDownloadTask {
     let downloadTask: URLSessionDownloadTask
     switch taskType {
@@ -464,7 +464,7 @@ public extension PubNub {
       task: downloadTask,
       session: session.configuration.identifier,
       downloadTo: url,
-      cryptorModule: decrypt ?? configuration.cryptorModule
+      cryptoModule: decrypt ?? configuration.cryptoModule
     )
 
     // Create task map inside Delegate

--- a/Sources/PubNub/Extensions/URLRequest+PubNub.swift
+++ b/Sources/PubNub/Extensions/URLRequest+PubNub.swift
@@ -46,7 +46,7 @@ public extension URLRequest {
   internal init(
     from response: GenerateUploadURLResponse,
     uploading content: PubNub.FileUploadContent,
-    cryptorModule: CryptorModule? = nil
+    cryptoModule: CryptoModule? = nil
   ) throws {
     self.init(url: response.uploadRequestURL)
     method = response.uploadMethod
@@ -73,8 +73,8 @@ public extension URLRequest {
     let contentLength: Int
     
     // If we were given a Crypto module we should convert the stream to a secure stream
-    if let cryptorModule = cryptorModule {
-      switch cryptorModule.encrypt(stream: contentStream, contentLength: content.contentLength) {
+    if let cryptoModule = cryptoModule {
+      switch cryptoModule.encrypt(stream: contentStream, contentLength: content.contentLength) {
       case .success(let encryptingResult):
         finalStream = encryptingResult
         contentLength = prefixData.count + ((encryptingResult as? MultipartInputStream)?.length ?? 0) + postfixData.count

--- a/Sources/PubNub/Helpers/Constants.swift
+++ b/Sources/PubNub/Helpers/Constants.swift
@@ -57,7 +57,7 @@ public enum Constant {
 
   static let pubnubSwiftSDKName: String = "PubNubSwift"
 
-  static let pubnubSwiftSDKVersion: String = "6.2.0"
+  static let pubnubSwiftSDKVersion: String = "6.2.1"
 
   static let appBundleId: String = {
     if let info = Bundle.main.infoDictionary,

--- a/Sources/PubNub/Helpers/Crypto/Crypto.swift
+++ b/Sources/PubNub/Helpers/Crypto/Crypto.swift
@@ -30,7 +30,7 @@ import Foundation
 
 /// Object capable of encryption/decryption
 ///
-/// - Warning: This struct is deprecated. Use ``CryptorModule`` instead.
+/// - Warning: This struct is deprecated. Use ``CryptoModule`` instead.
 public struct Crypto: Hashable {
   /// Key initially provided by the user
   let key: String

--- a/Sources/PubNub/Helpers/Crypto/CryptoModule.swift
+++ b/Sources/PubNub/Helpers/Crypto/CryptoModule.swift
@@ -1,5 +1,5 @@
 //
-//  CryptorModule.swift
+//  CryptoModule.swift
 //
 //  PubNub Real-time Cloud-Hosted Push API and Push Notification Client Frameworks
 //  Copyright © 2023 PubNub Inc.
@@ -27,19 +27,29 @@
 
 import Foundation
 
+@available(*, unavailable, renamed: "CryptoModule")
+public class CryptorModule {
+  public static func aesCbcCryptoModule(with key: String, withRandomIV: Bool = true) -> CryptoModule {
+    preconditionFailure("This method is no longer available")
+  }
+  public static func legacyCryptoModule(with key: String, withRandomIV: Bool = true) -> CryptoModule {
+    preconditionFailure("This method is no longer available")
+  }
+}
+
 /// Object capable of encryption/decryption
-public struct CryptorModule {
+public struct CryptoModule {
   private let defaultCryptor: Cryptor
   private let cryptors: [Cryptor]
   private let legacyCryptorId: CryptorId = []
   
   typealias Base64EncodedString = String
   
-  /// Initializes `CryptorModule` with custom ``Cryptor`` objects capable of encryption and decryption
+  /// Initializes `CryptoModule` with custom ``Cryptor`` objects capable of encryption and decryption
   ///
   /// Use this constructor if you would like to provide **custom** objects for decryption and encryption and don't want to use PubNub's built-in `Cryptors`.
   /// Otherwise, refer to convenience static factory methods such as ``aesCbcCryptoModule(with:withRandomIV:)``
-  /// and ``legacyCryptoModule(with:withRandomIV:)`` that return `CryptorModule` configured for you.
+  /// and ``legacyCryptoModule(with:withRandomIV:)`` that return `CryptoModule` configured for you.
   ///
   /// - Parameters:
   ///   - default: Primary ``Cryptor`` instance used for encryption and decryption
@@ -251,10 +261,10 @@ public struct CryptorModule {
   }
 }
 
-/// Convenience methods for creating `CryptorModule`
-public extension CryptorModule {
+/// Convenience methods for creating `CryptoModule`
+public extension CryptoModule {
   
-  /// Returns **recommended** `CryptorModule` for encryption/decryption
+  /// Returns **recommended** `CryptoModule` for encryption/decryption
   ///
   /// - Parameters:
   ///   - key: Key used for encryption/decryption
@@ -263,40 +273,40 @@ public extension CryptorModule {
   /// This method sets ``AESCBCCryptor`` as the primary object for decryption and encryption. It also
   /// instantiates ``LegacyCryptor``under the hood with `withRandomIV`. This way, you can interact with historical
   /// messages or messages sent from older clients
-  static func aesCbcCryptoModule(with key: String, withRandomIV: Bool = true) -> CryptorModule {
-    CryptorModule(default: AESCBCCryptor(key: key), cryptors: [LegacyCryptor(key: key, withRandomIV: withRandomIV)])
+  static func aesCbcCryptoModule(with key: String, withRandomIV: Bool = true) -> CryptoModule {
+    CryptoModule(default: AESCBCCryptor(key: key), cryptors: [LegacyCryptor(key: key, withRandomIV: withRandomIV)])
   }
   
-  /// Returns legacy `CryptorModule` for encryption/decryption
+  /// Returns legacy `CryptoModule` for encryption/decryption
   ///
   /// - Parameters:
   ///   - key: Key used for encryption/decryption
   ///   - withRandomIV: A flag describing whether random initialization vector should be used
   /// - Warning: It's highly recommended to always use ``aesCbcCryptoModule(with:withRandomIV:)``
-  static func legacyCryptoModule(with key: String, withRandomIV: Bool = true) -> CryptorModule {
-    CryptorModule(default: LegacyCryptor(key: key, withRandomIV: withRandomIV), cryptors: [AESCBCCryptor(key: key)])
+  static func legacyCryptoModule(with key: String, withRandomIV: Bool = true) -> CryptoModule {
+    CryptoModule(default: LegacyCryptor(key: key, withRandomIV: withRandomIV), cryptors: [AESCBCCryptor(key: key)])
   }
 }
 
-extension CryptorModule: Equatable {
-  public static func ==(lhs: CryptorModule, rhs: CryptorModule) -> Bool {
+extension CryptoModule: Equatable {
+  public static func ==(lhs: CryptoModule, rhs: CryptoModule) -> Bool {
     lhs.cryptors.map { $0.id } == rhs.cryptors.map { $0.id }
   }
 }
 
-extension CryptorModule: Hashable {
+extension CryptoModule: Hashable {
   public func hash(into hasher: inout Hasher) {
     hasher.combine(cryptors.map { $0.id })
   }
 }
 
-extension CryptorModule: CustomStringConvertible {
+extension CryptoModule: CustomStringConvertible {
   public var description: String {
     "Default cryptor: \(defaultCryptor.id), others: \(cryptors.map { $0.id })"
   }
 }
 
-internal extension CryptorModule {
+internal extension CryptoModule {
   func encrypt(string: String) -> Result<Base64EncodedString, PubNubError> {
     guard let data = string.data(using: .utf8) else {
       return .failure(PubNubError(

--- a/Sources/PubNub/Networking/HTTPFileTask.swift
+++ b/Sources/PubNub/Networking/HTTPFileTask.swift
@@ -236,7 +236,7 @@ public class HTTPFileDownloadTask: HTTPFileTask {
   /// The  block that is called when the task completes
   public var completionBlock: ((Result<URL, Error>) -> Void)?
   /// The crypto object that will attempt to decrypt the file
-  public var cryptorModule: CryptorModule?
+  public var cryptoModule: CryptoModule?
 
   /// The location where the temporary downloaded file should be copied
   public private(set) var destinationURL: URL
@@ -250,21 +250,21 @@ public class HTTPFileDownloadTask: HTTPFileTask {
     (urlSessionTask as? URLSessionDownloadTask)?.cancel(byProducingResumeData: byProducingResumeData)
   }
 
-  init(task: URLSessionDownloadTask, session identifier: String?, downloadTo url: URL, cryptorModule: CryptorModule?) {
+  init(task: URLSessionDownloadTask, session identifier: String?, downloadTo url: URL, cryptoModule: CryptoModule?) {
     self.destinationURL = url
-    self.cryptorModule = cryptorModule
+    self.cryptoModule = cryptoModule
 
     super.init(task: task, session: identifier)
   }
 
-  func decrypt(_ encryptedURL: URL, to outpuURL: URL, using cryptorModule: CryptorModule) throws {
+  func decrypt(_ encryptedURL: URL, to outpuURL: URL, using cryptoModule: CryptoModule) throws {
     // If we were provided a Crypto object we should try and decrypt the file
     
     guard let inputStream = InputStream(url: encryptedURL) else {
       throw PubNubError(.streamCouldNotBeInitialized, additional: [encryptedURL.absoluteString])
     }
     
-    cryptorModule.decrypt(
+    cryptoModule.decrypt(
       stream: inputStream,
       contentLength: encryptedURL.sizeOf,
       to: outpuURL
@@ -324,7 +324,7 @@ public class HTTPFileDownloadTask: HTTPFileTask {
       // Update destination to be a unique file
       destinationURL = fileManager.makeUniqueFilename(destinationURL)
 
-      if let cryptorModule = cryptorModule {
+      if let cryptoModule = cryptoModule {
         // Set the encrypted in case something goes wrong
         encryptedURL = url
         
@@ -332,7 +332,7 @@ public class HTTPFileDownloadTask: HTTPFileTask {
           throw PubNubError(.streamCouldNotBeInitialized, additional: [url.absoluteString])
         }
                 
-        cryptorModule.decrypt(
+        cryptoModule.decrypt(
           stream: stream,
           contentLength: url.sizeOf,
           to: destinationURL

--- a/Sources/PubNub/Networking/HTTPRouter.swift
+++ b/Sources/PubNub/Networking/HTTPRouter.swift
@@ -44,7 +44,7 @@ public protocol RouterConfiguration {
   /// If Access Manager (PAM) is enabled, client will use  `authToken` instead of `authKey` on all requests
   var authToken: String? { get }
   /// If set, all communication will be encrypted with this module
-  var cryptorModule: CryptorModule? { get }
+  var cryptoModule: CryptoModule? { get }
   /// Whether a request identifier should be included on outgoing requests
   var useRequestId: Bool { get }
   /// Ordered list of key-value pairs which identify various consumers.

--- a/Sources/PubNub/Networking/Routers/HistoryRouter.swift
+++ b/Sources/PubNub/Networking/Routers/HistoryRouter.swift
@@ -188,7 +188,7 @@ struct MessageHistoryResponseDecoder: ResponseDecoder {
     response: EndpointResponse<MessageHistoryResponse>
   ) -> Result<EndpointResponse<MessageHistoryResponse>, Error> {
     // End early if we don't have a cipher key
-    guard let cryptorModule = response.router.configuration.cryptorModule else {
+    guard let cryptoModule = response.router.configuration.cryptoModule else {
       return .success(response)
     }
 
@@ -200,7 +200,7 @@ struct MessageHistoryResponseDecoder: ResponseDecoder {
         // Convert base64 string into Data
         if let messageData = message.message.dataOptional {
           // If a message fails we just return the original and move on
-          switch cryptorModule.decryptedString(from: messageData) {
+          switch cryptoModule.decryptedString(from: messageData) {
           case .success(let decodedString):
             messages[index] = MessageHistoryMessagePayload(
               message: AnyJSON(reverse: decodedString),

--- a/Sources/PubNub/Networking/Routers/PublishRouter.swift
+++ b/Sources/PubNub/Networking/Routers/PublishRouter.swift
@@ -92,9 +92,9 @@ struct PublishRouter: HTTPRouter {
   }
 
   func append(message: JSONCodable, to partialPath: String) -> Result<String, Error> {
-    if let cryptorModule = configuration.cryptorModule {
+    if let cryptoModule = configuration.cryptoModule {
       return message.jsonDataResult.flatMap { jsonData in
-        cryptorModule.encrypt(data: jsonData).mapError { $0 as Error }
+        cryptoModule.encrypt(data: jsonData).mapError { $0 as Error }
           .flatMap { .success("\(partialPath)\($0.base64EncodedString().urlEncodeSlash.jsonDescription)") }
       }
     }
@@ -145,9 +145,9 @@ struct PublishRouter: HTTPRouter {
   var body: Result<Data?, Error> {
     switch endpoint {
     case let .compressedPublish(message, _, _, _, _):
-      if let cryptorModule = configuration.cryptorModule {
+      if let cryptoModule = configuration.cryptoModule {
         return message.jsonStringifyResult.flatMap {
-          cryptorModule.encrypt(string: $0)
+          cryptoModule.encrypt(string: $0)
             .map { $0.jsonDescription.data(using: .utf8) }
             .mapError { $0 as Error }
         }

--- a/Sources/PubNub/Networking/Routers/SubscribeRouter.swift
+++ b/Sources/PubNub/Networking/Routers/SubscribeRouter.swift
@@ -136,11 +136,11 @@ struct SubscribeDecoder: ResponseDecoder {
     }
   }
 
-  func decrypt(_ cryptorModule: CryptorModule, message: SubscribeMessagePayload) -> SubscribeMessagePayload {
+  func decrypt(_ cryptoModule: CryptoModule, message: SubscribeMessagePayload) -> SubscribeMessagePayload {
     // Convert base64 string into Data
     if let messageData = message.payload.dataOptional {
       // If a message fails we just return the original and move on
-      switch cryptorModule.decryptedString(from: messageData) {
+      switch cryptoModule.decryptedString(from: messageData) {
       case .success(let decodedString):
         // Create mutable copy of payload
         var message = message
@@ -157,7 +157,7 @@ struct SubscribeDecoder: ResponseDecoder {
 
   func decrypt(response: SubscribeEndpointResponse) -> Result<SubscribeEndpointResponse, Error> {
     // End early if we don't have a cipher key
-    guard let cryptorModule = response.router.configuration.cryptorModule else {
+    guard let cryptoModule = response.router.configuration.cryptoModule else {
       return .success(response)
     }
 
@@ -165,11 +165,11 @@ struct SubscribeDecoder: ResponseDecoder {
     for (index, message) in messages.enumerated() {
       switch message.messageType {
       case .message:
-        messages[index] = decrypt(cryptorModule, message: message)
+        messages[index] = decrypt(cryptoModule, message: message)
       case .signal:
-        messages[index] = decrypt(cryptorModule, message: message)
+        messages[index] = decrypt(cryptoModule, message: message)
       case .file:
-        messages[index] = decrypt(cryptorModule, message: message)
+        messages[index] = decrypt(cryptoModule, message: message)
       default:
         messages[index] = message
       }

--- a/Sources/PubNub/PubNub.swift
+++ b/Sources/PubNub/PubNub.swift
@@ -1247,11 +1247,11 @@ public extension PubNub {
 // MARK: - Crypto
 
 extension PubNub {
-  /// Encrypt some `Data` using the configuration `CryptorModule` value
+  /// Encrypt some `Data` using the configuration `CryptoModule` value
   /// - Parameter message: The plain text message to be encrypted
   /// - Returns: A `Result` containing either the encryped Data (mapped to Base64-encoded  data) or the Crypto Error
   public func encrypt(message: String) -> Result<Data, Error> {
-    guard let cryptorModule = configuration.cryptorModule else {
+    guard let cryptoModule = configuration.cryptoModule else {
       PubNub.log.error(ErrorDescription.missingCryptoKey)
       return .failure(CryptoError.invalidKey)
     }
@@ -1259,18 +1259,18 @@ extension PubNub {
       return .failure(CryptoError.decodeError)
     }
     
-    return cryptorModule.encrypt(data: dataMessage).map {
+    return cryptoModule.encrypt(data: dataMessage).map {
       $0.base64EncodedData()
     }.mapError {
       $0 as Error
     }
   }
 
-  /// Decrypt some `Data` using the configuration CryptorModule value
+  /// Decrypt some `Data` using the configuration CryptoModule value
   /// - Parameter message: The encrypted `Data` to decrypt
   /// - Returns: A `Result` containing either the decrypted plain text message  or the Crypto Error
   public func decrypt(data: Data) -> Result<String, Error> {
-    guard let cryptorModule = configuration.cryptorModule else {
+    guard let cryptoModule = configuration.cryptoModule else {
       PubNub.log.error(ErrorDescription.missingCryptoKey)
       return .failure(CryptoError.invalidKey)
     }
@@ -1279,7 +1279,7 @@ extension PubNub {
       return .failure(CryptoError.decodeError)
     }
     
-    return cryptorModule.decrypt(data: base64EncodedData)
+    return cryptoModule.decrypt(data: base64EncodedData)
       .flatMap {
         guard let string = String(data: $0, encoding: .utf8) else {
           return .failure(PubNubError(.decryptionFailure, additional: ["Cannot create String from received bytes"]))

--- a/Sources/PubNub/PubNubConfiguration.swift
+++ b/Sources/PubNub/PubNubConfiguration.swift
@@ -74,7 +74,7 @@ public struct PubNubConfiguration: Hashable {
   ///   - subscribeKey: The PubNub Subscribe Key to be used when getting data from a channel
   ///   - userId: The unique identifier to be used as a device identifier
   ///   - cipherKey: ~~If set, all communication will be encrypted with this key~~
-  ///   - cryptorModule: If set, all communication will be encrypted with this module
+  ///   - cryptoModule: If set, all communication will be encrypted with this module
   ///   - authKey: If Access Manager (PAM) is enabled, client will use  `authToken` instead of `authKey` on all requests
   ///   - authToken: If Access Manager (PAM) is enabled, client will use  `authToken` instead of `authKey` on all requests
   ///   - useSecureConnections: The PubNub Publish Key to be used when publishing data to a channel
@@ -93,7 +93,7 @@ public struct PubNubConfiguration: Hashable {
     subscribeKey: String,
     userId: String,
     cipherKey: Crypto? = nil,
-    cryptorModule: CryptorModule? = nil,
+    cryptoModule: CryptoModule? = nil,
     authKey: String? = nil,
     authToken: String? = nil,
     useSecureConnections: Bool = true,
@@ -111,11 +111,11 @@ public struct PubNubConfiguration: Hashable {
     guard userId.trimmingCharacters(in: .whitespacesAndNewlines).count > 0 else {
       preconditionFailure("UserId should not be empty.")
     }
-    if let cryptorModule = cryptorModule {
-      self.cryptorModule = cryptorModule
+    if let cryptoModule = cryptoModule {
+      self.cryptoModule = cryptoModule
     } else {
       if let cipherKey = cipherKey {
-        self.cryptorModule = CryptorModule.legacyCryptoModule(with: cipherKey.key, withRandomIV: cipherKey.randomizeIV)
+        self.cryptoModule = CryptoModule.legacyCryptoModule(with: cipherKey.key, withRandomIV: cipherKey.randomizeIV)
         // Preserves cipherKey for backward compatibility if anyone has already accessed it before
         self.cipherKey = cipherKey
       }
@@ -199,9 +199,9 @@ public struct PubNubConfiguration: Hashable {
   /// Specifies the PubNub Subscribe Key to be used when subscribing to a channel
   public var subscribeKey: String
   /// If set, all communication will be encrypted with this key
-  public var cryptorModule: CryptorModule?
+  public var cryptoModule: CryptoModule?
   /// If set, all communication will be encrypted with this key
-  @available(*, deprecated, message: "Use 'cryptorModule' instead")
+  @available(*, deprecated, message: "Use 'cryptoModule' instead")
   public var cipherKey: Crypto?
   /// If Access Manager (PAM) is enabled, client will use `authKey` on all requests
   public var authKey: String?

--- a/Sources/PubNub/Subscription/SubscribeSessionFactory.swift
+++ b/Sources/PubNub/Subscription/SubscribeSessionFactory.swift
@@ -134,7 +134,7 @@ extension SubscriptionConfiguration {
     hasher.combine(useSecureConnections.hashValue)
     hasher.combine(origin.hashValue)
     hasher.combine(authKey.hashValue)
-    hasher.combine(cryptorModule.hashValue)
+    hasher.combine(cryptoModule.hashValue)
     return hasher.finalize()
   }
 }

--- a/Tests/PubNubContractTest/Steps/CryptorModule/PubNubCryptoModuleContractTestSteps.swift
+++ b/Tests/PubNubContractTest/Steps/CryptorModule/PubNubCryptoModuleContractTestSteps.swift
@@ -37,7 +37,7 @@ public class PubNubCryptoModuleContractTestSteps: PubNubContractTestCase {
   var cipherKey: String!
   var randomIV: Bool = true
   var otherCryptors: [String] = []
-  var cryptorModule: CryptorModule!
+  var cryptoModule: CryptoModule!
   
   var encryptDataRes: Result<Data, PubNubError>!
   var decryptDataRes: Result<Data, PubNubError>!
@@ -54,7 +54,7 @@ public class PubNubCryptoModuleContractTestSteps: PubNubContractTestCase {
     cipherKey = ""
     randomIV = true
     otherCryptors = []
-    cryptorModule = nil
+    cryptoModule = nil
     
     encryptDataRes = nil
     decryptDataRes = nil
@@ -92,10 +92,10 @@ public class PubNubCryptoModuleContractTestSteps: PubNubContractTestCase {
     When("I decrypt '(.*)' file") { args, userInfo in
       self.outputPath = self.generateTestOutputUrl()
       self.givenFileUrl = self.localUrl(for: args?.first ?? "")
-      self.cryptorModule = self.createCryptorModule()
+      self.cryptoModule = self.createCryptorModule()
       self.decryptAsBinary = false
       
-      self.decryptStreamRes = self.cryptorModule.decrypt(
+      self.decryptStreamRes = self.cryptoModule.decrypt(
         stream: InputStream(url: self.givenFileUrl)!,
         contentLength: self.givenFileUrl.sizeOf,
         to: self.outputPath
@@ -105,14 +105,14 @@ public class PubNubCryptoModuleContractTestSteps: PubNubContractTestCase {
     When("I decrypt '(.*)' file as '(.*)'") { args, _ in
       self.givenFileUrl = self.localUrl(for: args?.first ?? "")
       self.outputPath = self.generateTestOutputUrl()
-      self.cryptorModule = self.createCryptorModule()
+      self.cryptoModule = self.createCryptorModule()
       self.decryptAsBinary = args?.last == "binary"
 
       if self.decryptAsBinary {
         let dataToDecrypt = try! Data(contentsOf: self.givenFileUrl)
-        self.decryptDataRes = self.cryptorModule.decrypt(data: dataToDecrypt)
+        self.decryptDataRes = self.cryptoModule.decrypt(data: dataToDecrypt)
       } else {
-        self.decryptStreamRes = self.cryptorModule.decrypt(
+        self.decryptStreamRes = self.cryptoModule.decrypt(
           stream: InputStream(url: self.givenFileUrl)!,
           contentLength: self.givenFileUrl.sizeOf,
           to: self.outputPath
@@ -124,15 +124,15 @@ public class PubNubCryptoModuleContractTestSteps: PubNubContractTestCase {
       self.givenFileUrl = self.localUrl(for: args?.first ?? "")
       self.encryptAsBinary = args?.last == "binary"
       self.outputPath = self.generateTestOutputUrl()
-      self.cryptorModule = self.createCryptorModule()
+      self.cryptoModule = self.createCryptorModule()
       
       if self.encryptAsBinary {
         let dataToEncrypt = try! Data(contentsOf: self.givenFileUrl)
-        self.encryptDataRes = self.cryptorModule.encrypt(data: dataToEncrypt)
+        self.encryptDataRes = self.cryptoModule.encrypt(data: dataToEncrypt)
       } else {
         let streamToEncrypt = InputStream(url: self.givenFileUrl)!
         let contentLength = self.givenFileUrl.sizeOf
-        self.encryptStreamRes = self.cryptorModule.encrypt(stream: streamToEncrypt, contentLength: contentLength)
+        self.encryptStreamRes = self.cryptoModule.encrypt(stream: streamToEncrypt, contentLength: contentLength)
       }
     }
     
@@ -164,12 +164,12 @@ public class PubNubCryptoModuleContractTestSteps: PubNubContractTestCase {
       
       if self.encryptAsBinary {
         let encryptedData = try! self.encryptDataRes.get()
-        let decryptedData = try! self.cryptorModule.decrypt(data: encryptedData).get()
+        let decryptedData = try! self.cryptoModule.decrypt(data: encryptedData).get()
         XCTAssertEqual(expectedData, decryptedData)
       } else {
         let encryptedStream = try! self.encryptStreamRes.get()
         let length = (encryptedStream as! MultipartInputStream).length
-        self.cryptorModule.decrypt(stream: encryptedStream, contentLength: length, to: self.outputPath)
+        self.cryptoModule.decrypt(stream: encryptedStream, contentLength: length, to: self.outputPath)
         let decryptedData = try! Data(contentsOf: self.outputPath)
         XCTAssertEqual(expectedData, decryptedData)
       }
@@ -196,8 +196,8 @@ fileprivate extension PubNubCryptoModuleContractTestSteps {
     return URL(fileURLWithPath: finalPath)
   }
   
-  func createCryptorModule() -> CryptorModule {
-    CryptorModule(
+  func createCryptorModule() -> CryptoModule {
+    CryptoModule(
       default: self.createCryptor(for: self.cryptorKind),
       cryptors: self.otherCryptors.map { self.createCryptor(for: $0) }
     )

--- a/Tests/PubNubContractTest/Steps/Subscribe/PubNubSubscribeContractTestSteps.swift
+++ b/Tests/PubNubContractTest/Steps/Subscribe/PubNubSubscribeContractTestSteps.swift
@@ -30,11 +30,11 @@ import Foundation
 import PubNub
 
 public class PubNubSubscribeContractTestSteps: PubNubContractTestCase {
-  fileprivate var cryptorModule: CryptorModule?
+  fileprivate var cryptoModule: CryptoModule?
 
   override public var configuration: PubNubConfiguration {
     var config = super.configuration
-    config.cryptorModule = cryptorModule
+    config.cryptoModule = cryptoModule
 
     if let scenario = self.currentScenario, scenario.name.contains("auto-retry") {
       config.automaticRetry = AutomaticRetry(retryLimit: 10, policy: .linear(delay: 0.1))
@@ -52,7 +52,7 @@ public class PubNubSubscribeContractTestSteps: PubNubContractTestCase {
   }
 
   override public func handleBeforeHook() {
-    cryptorModule = nil
+    cryptoModule = nil
     super.handleBeforeHook()
   }
 
@@ -64,11 +64,11 @@ public class PubNubSubscribeContractTestSteps: PubNubContractTestCase {
     startCucumberHookEventsListening()
 
     Given("the crypto keyset") { _, _ in
-      self.cryptorModule = CryptorModule.legacyCryptoModule(with: "enigma")
+      self.cryptoModule = CryptoModule.legacyCryptoModule(with: "enigma")
     }
 
     Given("the invalid-crypto keyset") { _, _ in
-      self.cryptorModule = CryptorModule.legacyCryptoModule(with: "secret")
+      self.cryptoModule = CryptoModule.legacyCryptoModule(with: "secret")
     }
 
     When("I subscribe") { _, _ in

--- a/Tests/PubNubTests/Helpers/CryptoTests.swift
+++ b/Tests/PubNubTests/Helpers/CryptoTests.swift
@@ -31,16 +31,16 @@ import XCTest
 
 class CryptoTests: XCTestCase {
   func testEncryptDecrypt_Data() {
-    let cryptorModule = CryptorModule.legacyCryptoModule(with: "SomeTestString")
+    let cryptoModule = CryptoModule.legacyCryptoModule(with: "SomeTestString")
     let testMessage = "Test Message To Be Encrypted"
     
     guard let testData = testMessage.data(using: .utf16) else {
       return XCTFail("Could not create Data from test string")
     }
-    guard let encryptedData = try? cryptorModule.encrypt(data: testData).get() else {
+    guard let encryptedData = try? cryptoModule.encrypt(data: testData).get() else {
       return XCTFail("Encrypted Data should not be nil")
     }
-    guard let decryptedData = try? cryptorModule.decrypt(data: encryptedData).get() else {
+    guard let decryptedData = try? cryptoModule.decrypt(data: encryptedData).get() else {
       return XCTFail("Decrypted Data should not be nil")
     }
     let decryptedString = String(
@@ -51,15 +51,15 @@ class CryptoTests: XCTestCase {
   }
 
   func testEncryptDecrypt_String() {
-    let cryptorModule = CryptorModule.legacyCryptoModule(with: "SomeTestString")
+    let cryptoModule = CryptoModule.legacyCryptoModule(with: "SomeTestString")
     let testMessage = true.description
     
-    guard let encryptedString = try? cryptorModule.encrypt(string: testMessage).get() else {
+    guard let encryptedString = try? cryptoModule.encrypt(string: testMessage).get() else {
       return XCTFail("Encrypted Data should not be nil")
     }
     guard
       let encryptedStringAsData = Data(base64Encoded: encryptedString),
-      let decryptedString = try? cryptorModule.decryptedString(from: encryptedStringAsData).get()
+      let decryptedString = try? cryptoModule.decryptedString(from: encryptedStringAsData).get()
     else {
       return XCTFail("Decrypted Data should not be nil")
     }
@@ -67,17 +67,17 @@ class CryptoTests: XCTestCase {
   }
 
   func testEncryptDecrypt_JSONString() {
-    let cryptorModule = CryptorModule.legacyCryptoModule(with: "SomeTestString")
+    let cryptoModule = CryptoModule.legacyCryptoModule(with: "SomeTestString")
     let testMessage = "Test Message To Be Encrypted"
     let jsonMessage = testMessage.jsonDescription
     
     guard let testData = jsonMessage.data(using: .utf8) else {
       return XCTFail("Could not create Data from test string")
     }
-    guard let encryptedData = try? cryptorModule.encrypt(data: testData).get() else {
+    guard let encryptedData = try? cryptoModule.encrypt(data: testData).get() else {
       return XCTFail("Encrypted Data should not be nil")
     }
-    guard let decryptedData = try? cryptorModule.decrypt(data: encryptedData).get() else {
+    guard let decryptedData = try? cryptoModule.decrypt(data: encryptedData).get() else {
       return XCTFail("Decrypted Data should not be nil")
     }
     let decryptedString = String(
@@ -90,24 +90,24 @@ class CryptoTests: XCTestCase {
 
   func testDefaultRandomizedIVEncryptDecrypt() {
     let testMessage = "Test Message To Be Encrypted"
-    let cryptorModule = CryptorModule.legacyCryptoModule(with: "MyCoolCipherKey")
+    let cryptoModule = CryptoModule.legacyCryptoModule(with: "MyCoolCipherKey")
     
-    guard let encryptedString1 = try? cryptorModule.encrypt(string: testMessage).get() else {
+    guard let encryptedString1 = try? cryptoModule.encrypt(string: testMessage).get() else {
       return XCTFail("Encrypted Data should not be nil")
     }
-    guard let encryptedString2 = try? cryptorModule.encrypt(string: testMessage).get() else {
+    guard let encryptedString2 = try? cryptoModule.encrypt(string: testMessage).get() else {
       return XCTFail("Encrypted Data should not be nil")
     }
     guard let encryptedString1Data = Data(base64Encoded: encryptedString1) else {
       return XCTFail("Cannot create Data from Base-64 encoded \(encryptedString1)")
     }
-    guard let decryptedString1 = try? cryptorModule.decryptedString(from: encryptedString1Data).get() else {
+    guard let decryptedString1 = try? cryptoModule.decryptedString(from: encryptedString1Data).get() else {
       return XCTFail("Decrypted Data should not be nil")
     }
     guard let encryptedString2Data = Data(base64Encoded: encryptedString2) else {
       return XCTFail("Cannot create Data from Base-64 encoded \(encryptedString2)")
     }
-    guard let decryptedString2 = try? cryptorModule.decryptedString(from: encryptedString2Data).get() else {
+    guard let decryptedString2 = try? cryptoModule.decryptedString(from: encryptedString2Data).get() else {
       return XCTFail("Decrypted Data should not be nil")
     }
     
@@ -117,7 +117,7 @@ class CryptoTests: XCTestCase {
   }
 
   func testOtherSDKContractTest() {
-    let cryptorModule = CryptorModule.legacyCryptoModule(with: "MyCoolCipherKey", withRandomIV: false)
+    let cryptoModule = CryptoModule.legacyCryptoModule(with: "MyCoolCipherKey", withRandomIV: false)
     let message = "\"Hello there!\""
     
     guard let messageData = message.data(using: .utf8) else {
@@ -125,8 +125,8 @@ class CryptoTests: XCTestCase {
     }
 
     do {
-      let encryptedMessage = try cryptorModule.encrypt(data: messageData).get()
-      let decrypted = try cryptorModule.decrypt(data: encryptedMessage).get()
+      let encryptedMessage = try cryptoModule.encrypt(data: messageData).get()
+      let decrypted = try cryptoModule.decrypt(data: encryptedMessage).get()
       XCTAssertEqual(message, String(bytes: decrypted, encoding: .utf8))
     } catch {
       XCTFail("Crypto failed due to \(error)")
@@ -134,21 +134,21 @@ class CryptoTests: XCTestCase {
   }
 
   func testOtherSDK_RandomIV() {
-    let cryptorModule = CryptorModule.legacyCryptoModule(with: "enigma", withRandomIV: true)
+    let cryptoModule = CryptoModule.legacyCryptoModule(with: "enigma", withRandomIV: true)
     let plainText = "yay!"
     let otherSDKBase64 = "MTIzNDU2Nzg5MDEyMzQ1NjdnONoCgo0wbuMGGMmfMX0="
 
     do {
-      let swiftEncryptedString = try cryptorModule.encrypt(string: plainText).get()
+      let swiftEncryptedString = try cryptoModule.encrypt(string: plainText).get()
       let swiftEncryptedStringAsData = Data(base64Encoded: swiftEncryptedString)!
-      let swiftDecryptedString = try cryptorModule.decryptedString(from: swiftEncryptedStringAsData).get()
+      let swiftDecryptedString = try cryptoModule.decryptedString(from: swiftEncryptedStringAsData).get()
 
       XCTAssertEqual(plainText, swiftDecryptedString)
 
       guard let otherData = Data(base64Encoded: otherSDKBase64) else {
         return XCTFail("Could not create data from Base64")
       }
-      let otherDecrypted = try cryptorModule.decrypt(data: otherData).get()
+      let otherDecrypted = try cryptoModule.decrypt(data: otherData).get()
       XCTAssertEqual(plainText, String(data: otherDecrypted, encoding: .utf8))
     } catch {
       XCTFail("Crypto failed due to \(error)")
@@ -156,7 +156,7 @@ class CryptoTests: XCTestCase {
   }
 
   func testStreamOtherSDK() {
-    let cryptorModule = CryptorModule.legacyCryptoModule(
+    let cryptoModule = CryptoModule.legacyCryptoModule(
       with: "enigma",
       withRandomIV: true
     )
@@ -171,7 +171,7 @@ class CryptoTests: XCTestCase {
       // Purges existing item (if any)
       try? FileManager.default.removeItem(at: outputPath)
 
-      cryptorModule.decrypt(
+      cryptoModule.decrypt(
         stream: InputStream(data: ecrypted),
         contentLength: ecrypted.count,
         to: outputPath
@@ -186,7 +186,7 @@ class CryptoTests: XCTestCase {
   }
 
   func testStreamEncryptDecrypt() {
-    let cryptorModule = CryptorModule.legacyCryptoModule(
+    let cryptoModule = CryptoModule.legacyCryptoModule(
       with: "enigma",
       withRandomIV: true
     )
@@ -205,7 +205,7 @@ class CryptoTests: XCTestCase {
       let data = try Data(contentsOf: plainTextURL)
       let inputStream = InputStream(data: data)
       
-      let encryptedStreamResult = try cryptorModule.encrypt(
+      let encryptedStreamResult = try cryptoModule.encrypt(
         stream: inputStream,
         contentLength: data.count
       ).get() as! MultipartInputStream
@@ -213,7 +213,7 @@ class CryptoTests: XCTestCase {
       let decryptedURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("decryptedStream")
       try? FileManager.default.removeItem(at: decryptedURL)
       
-      cryptorModule.decrypt(
+      cryptoModule.decrypt(
         stream: encryptedStreamResult,
         contentLength: encryptedStreamResult.length,
         to: decryptedURL

--- a/Tests/PubNubTests/Networking/Routers/HistoryRouterTests.swift
+++ b/Tests/PubNubTests/Networking/Routers/HistoryRouterTests.swift
@@ -176,7 +176,7 @@ extension HistoryRouterTests {
     }
 
     var configWithCipher = config
-    configWithCipher.cryptorModule = CryptorModule.legacyCryptoModule(with: "SomeTestString", withRandomIV: false)
+    configWithCipher.cryptoModule = CryptoModule.legacyCryptoModule(with: "SomeTestString", withRandomIV: false)
 
     let pubnub = PubNub(configuration: configWithCipher, session: sessions.session)
     pubnub.fetchMessageHistory(for: testMultiChannels) { result in
@@ -203,7 +203,7 @@ extension HistoryRouterTests {
     }
 
     var configWithCipher = config
-    configWithCipher.cryptorModule = CryptorModule.legacyCryptoModule(with: "NotTheRightKey", withRandomIV: false)
+    configWithCipher.cryptoModule = CryptoModule.legacyCryptoModule(with: "NotTheRightKey", withRandomIV: false)
 
     let pubnub = PubNub(configuration: config, session: sessions.session)
     pubnub.fetchMessageHistory(for: testMultiChannels) { result in
@@ -231,7 +231,7 @@ extension HistoryRouterTests {
     }
 
     var configWithCipher = config
-    configWithCipher.cryptorModule = CryptorModule.legacyCryptoModule(with: "SomeTestString", withRandomIV: false)
+    configWithCipher.cryptoModule = CryptoModule.legacyCryptoModule(with: "SomeTestString", withRandomIV: false)
 
     let pubnub = PubNub(configuration: configWithCipher, session: sessions.session)
     pubnub.fetchMessageHistory(for: testMultiChannels) { result in

--- a/Tests/PubNubTests/PubNubConfigurationTests.swift
+++ b/Tests/PubNubTests/PubNubConfigurationTests.swift
@@ -46,7 +46,7 @@ class PubNubConfigurationTests: XCTestCase {
 
     XCTAssertNil(config.publishKey)
     XCTAssertEqual(config.subscribeKey, plistSubscribeKeyValue)
-    XCTAssertNil(config.cryptorModule)
+    XCTAssertNil(config.cryptoModule)
     XCTAssertNil(config.authKey)
     XCTAssertNotNil(config.uuid)
     XCTAssertEqual(config.useSecureConnections, true)


### PR DESCRIPTION
fix(crypto): Renaming `CryptorModule` with `CryptoModule`

Align on namings across all supported platforms