### PR TITLE
Subscribing to the same channel via PubNub class causes disconnecting

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Swift Package Manager compatible](https://img.shields.io/badge/Swift%20Package%20Manager-compatible-brightgreen.svg)](https://github.com/apple/swift-package-manager)
 [![Carthage Compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![Build Status](https://travis-ci.org/pubnub/swift.svg?branch=master)](https://travis-ci.org/pubnub/swift)
-[![Codacy Coverage Grade Badge](https://api.codacy.com/project/badge/Grade/d6dbd8cad97d42bbb72c47137e94d6f5)](https://www.codacy.com?utm_source=github.com&utm_medium=referral&utm_content=pubnub/swift&utm_campaign=Badge_Grade)
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/ea96a32a311944eaa09b4c452db4d397)](https://app.codacy.com?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 
 This is the official PubNub Swift SDK repository.
 
@@ -59,7 +59,7 @@ end
 
 > Note: Replace `YOUR_TARGET_NAME` with your target's name.
 
-In the directory containing your `Podfile`. execute the following:
+In the directory containing your `Podfile` execute the following:
 
 ```bash
 pod install

--- a/Tests/PubNubTests/Events/New/SubscriptionTests.swift
+++ b/Tests/PubNubTests/Events/New/SubscriptionTests.swift
@@ -8,8 +8,8 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 @testable import PubNub
+import XCTest
 
 class SubscriptionTests: XCTestCase {
   private let pubnub = PubNub(
@@ -24,27 +24,27 @@ class SubscriptionTests: XCTestCase {
     let messagesExpectation = XCTestExpectation(description: "Message")
     messagesExpectation.assertForOverFulfill = true
     messagesExpectation.expectedFulfillmentCount = 1
-
+    
     let signalExpectation = XCTestExpectation(description: "Signal")
     signalExpectation.assertForOverFulfill = true
     signalExpectation.expectedFulfillmentCount = 1
-
+    
     let messageAction = XCTestExpectation(description: "Message Action")
     messageAction.assertForOverFulfill = true
     messageAction.expectedFulfillmentCount = 1
-
+    
     let presenceChangeExpectation = XCTestExpectation(description: "Presence")
     presenceChangeExpectation.assertForOverFulfill = true
     presenceChangeExpectation.expectedFulfillmentCount = 1
-
+    
     let appContextExpectation = XCTestExpectation(description: "App Context")
     appContextExpectation.assertForOverFulfill = true
     appContextExpectation.expectedFulfillmentCount = 1
-
+    
     let fileExpectation = XCTestExpectation(description: "File")
     fileExpectation.assertForOverFulfill = true
     fileExpectation.expectedFulfillmentCount = 1
-
+    
     let allEventsExpectation = XCTestExpectation(description: "All Events")
     allEventsExpectation.assertForOverFulfill = true
     allEventsExpectation.expectedFulfillmentCount = 1
@@ -102,28 +102,28 @@ class SubscriptionTests: XCTestCase {
     let messagesExpectation = XCTestExpectation(description: "Message")
     messagesExpectation.isInverted = true
     messagesExpectation.assertForOverFulfill = true
-
+    
     let signalExpectation = XCTestExpectation(description: "Signal")
     signalExpectation.isInverted = true
     signalExpectation.assertForOverFulfill = true
-
+    
     let messageAction = XCTestExpectation(description: "Message Action")
     messageAction.isInverted = true
     messageAction.assertForOverFulfill = true
-
+    
     let presenceChangeExpectation = XCTestExpectation(description: "Presence")
     presenceChangeExpectation.isInverted = true
     presenceChangeExpectation.assertForOverFulfill = true
     presenceChangeExpectation.expectedFulfillmentCount = 1
-
+    
     let appContextExpectation = XCTestExpectation(description: "App Context")
     appContextExpectation.isInverted = true
     appContextExpectation.assertForOverFulfill = true
-
+    
     let fileExpectation = XCTestExpectation(description: "File")
     fileExpectation.isInverted = true
     fileExpectation.assertForOverFulfill = true
-
+    
     let allEventsExpectation = XCTestExpectation(description: "All Events")
     allEventsExpectation.isInverted = true
     allEventsExpectation.assertForOverFulfill = true
@@ -185,7 +185,7 @@ class SubscriptionTests: XCTestCase {
     let channel = pubnub.channel("channel.item.*")
     let subscription = channel.subscription()
     
-    subscription.onMessage = { message in
+    subscription.onMessage = { _ in
       expectation.fulfill()
     }
     subscription.onPayloadsReceived(


### PR DESCRIPTION
fix(subscribe): prevent from disconnecting while subscribing to the channel that was already subscribed