### PR TITLE
Fix global status handler to emit 'disconnected' when PubNub instance is deallocated

### DIFF
--- a/Sources/PubNub/Subscription/Strategy/EventEngineSubscriptionSessionStrategy.swift
+++ b/Sources/PubNub/Subscription/Strategy/EventEngineSubscriptionSessionStrategy.swift
@@ -60,10 +60,6 @@ class EventEngineSubscriptionSessionStrategy: SubscriptionSessionStrategy {
     subscribeEngine.state.connectionStatus
   }
 
-  deinit {
-    PubNub.log.debug("SubscriptionSession Destroyed")
-  }
-
   private func listenForStateUpdates() {
     subscribeEngine.onStateUpdated = { [weak self] state in
       if state is Subscribe.ReceivingState && state.hasTimetoken {

--- a/Sources/PubNub/Subscription/SubscriptionSession.swift
+++ b/Sources/PubNub/Subscription/SubscriptionSession.swift
@@ -209,6 +209,20 @@ class SubscriptionSession: EventListenerInterface, StatusListenerInterface {
   func unsubscribeAll() {
     strategy.unsubscribeAll()
   }
+
+  // MARK: - Deinit
+
+  deinit {
+    if connectionStatus.isActive {
+      // Calling disconnect() will trigger status notifications to user-added listeners
+      disconnect()
+      // Ensures the status notification is also dispatched for the global status listener.
+      // We don't rely on disconnect() to complete because this object may not exist when it finishes.
+      globalStatusListener.queue.async { [onConnectionStateChange] in
+        onConnectionStateChange?(.disconnected)
+      }
+    }
+  }
 }
 
 extension SubscriptionSession {

--- a/Tests/PubNubTests/Integration/SubscriptionIntegrationTests.swift
+++ b/Tests/PubNubTests/Integration/SubscriptionIntegrationTests.swift
@@ -242,7 +242,11 @@ class SubscriptionIntegrationTests: XCTestCase {
     
     pubnub.subscribe(to: [testChannelName])
     
-    defer { pubnub.disconnect() }
+    defer {
+      pubnub.onConnectionStateChange = nil
+      pubnub.disconnect()
+    }
+    
     wait(for: [statusExpect, messageExpect], timeout: 30.0)
   }
 
@@ -313,6 +317,12 @@ class SubscriptionIntegrationTests: XCTestCase {
     pubnub.subscribe(to: [testChannelName])
     
     XCTAssertEqual(pubnub.subscribedChannels, [testChannelName])
+    
+    defer {
+      pubnub.onConnectionStateChange = nil
+      pubnub.disconnect()
+    }
+    
     wait(for: [expectation], timeout: 5.0)
   }
   
@@ -343,6 +353,11 @@ class SubscriptionIntegrationTests: XCTestCase {
     pubnub.add(listener)
     pubnub.subscribe(to: [testChannelName])
     
+    defer {
+      pubnub.onConnectionStateChange = nil
+      pubnub.disconnect()
+    }
+    
     wait(for: [expectation], timeout: 10.0)
   }
   
@@ -372,6 +387,11 @@ class SubscriptionIntegrationTests: XCTestCase {
     }
     
     firstSubscription.subscribe()
+    
+    defer {
+      pubnub.onConnectionStateChange = nil
+      pubnub.disconnect()
+    }
     
     wait(for: [expectation], timeout: 5.0)
   }


### PR DESCRIPTION
fix(pubnub): fix global status handler to emit `disconnected` when PubNub instance is deallocated