### PR TITLE
Fix APM library crash (when present) by centralizing HTTPSession cleanup

### DIFF
--- a/Sources/PubNub/EventEngine/Presence/Effects/PresenceEffectFactory.swift
+++ b/Sources/PubNub/EventEngine/Presence/Effects/PresenceEffectFactory.swift
@@ -55,8 +55,4 @@ class PresenceEffectFactory: EffectHandlerFactory {
       return WaitEffect(configuration: dependencies.value.configuration)
     }
   }
-
-  deinit {
-    session.invalidateAndCancel()
-  }
 }

--- a/Sources/PubNub/EventEngine/Subscribe/Effects/SubscribeEffectFactory.swift
+++ b/Sources/PubNub/EventEngine/Subscribe/Effects/SubscribeEffectFactory.swift
@@ -72,8 +72,4 @@ class SubscribeEffectFactory: EffectHandlerFactory {
       )
     }
   }
-
-  deinit {
-    session.invalidateAndCancel()
-  }
 }


### PR DESCRIPTION
fix(presence): fix APM library crash (when present) by centralizing `HTTPSession` cleanup

APM Libraries Crash Fix: Removed explicit deinit methods from `PresenceEffectFactory` and `SubscribeEffectFactory` to prevent race conditions with Application Performance Monitoring libraries. These factories now rely entirely on `HTTPSession.deinit` for proper cleanup, which ensures the correct sequence: (1) cancel all active requests, (2) invalidate session. This prevents crashes occurring inside APM libraries when they intercept network operations during session invalidation