### PR TITLE
Test PR

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,116 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: en
+early_access: false
+
+reviews:
+  request_changes_workflow: true
+  poem: false
+  high_level_summary_in_walkthrough: true
+  estimate_code_review_effort: false
+  sequence_diagrams: false
+  changed_files_summary: false
+  path_filters:
+    - '!**/.build/**'
+    - '!**/xcuserdata/**'
+    - '!**/*.xcuserstate'
+    - '!**/*.xcworkspacedata'
+    - '!Tests/PubNubUnitTests/Support/Responses/**/*.json'
+    - '!Tests/PubNubUnitTests/Support/Responses/**/*.txt'
+    - '!Examples/**/*.storyboard'
+    - '!Examples/**/*.plist'
+    - '!Examples/**/*.xcworkspacedata'
+    - '!Examples/**/Package.resolved'
+  path_instructions:
+    - path: 'Sources/**/*.swift'
+      instructions: |
+        Review this as production Swift library code.
+
+        Swift best practices to check:
+        - Prefer value semantics and immutability where practical; use `let` instead of `var` unless mutation is required.
+        - Avoid force unwraps and other crash-prone patterns unless they are provably safe and justified.
+        - Prefer `if let` / `guard let` shorthand when unwrapping and shadowing the same optional, unless the explicit form is clearer.
+        - Preserve clear ownership and lifecycle behavior; flag likely retain cycles, leaked observers, and long-lived captured references.
+        - Watch for race conditions and shared mutable state, especially around callbacks, queues, async work, and listener management.
+        - Prefer clear, idiomatic Swift naming and small focused types/functions over overly clever abstractions.
+        - Flag duplicated logic, dead code, and abstractions that add complexity without a real boundary or testability benefit.
+        - Preserve useful error information; do not ignore failures or replace specific errors with vague ones.
+        - Watch for hot-path inefficiencies such as repeated allocations, avoidable copying, and unnecessary collection transformations.
+
+    - path: 'Sources/PubNub/PubNub.swift'
+      instructions: |
+        Review this as public SDK API surface exposed through `PubNub`.
+
+        Focus on:
+        - Consistency with existing `PubNub` API patterns, naming, parameter semantics, and overload design.
+        - Completion and callback behavior, especially around async results, threading expectations, and error delivery.
+        - Access control: avoid exposing APIs, types, members, or initializers wider than needed.
+        - Public-facing doc comments should stay accurate and aligned with current behavior, parameters, defaults, and callback semantics.
+        - Breaking changes to public API or behavior should be explicit, justified, and reflected in tests, snippets, and documentation.
+
+    - path: 'Sources/PubNub/APIs/**/*.swift'
+      instructions: |
+        Review this as public SDK API surface exposed through `PubNub`.
+
+        Focus on:
+        - Consistency with existing `PubNub` API patterns, naming, parameter semantics, and overload design.
+        - Completion and callback behavior, especially around async results, threading expectations, and error delivery.
+        - Access control: avoid exposing APIs, types, members, or initializers wider than needed.
+        - Public-facing doc comments should stay accurate and aligned with current behavior, parameters, defaults, and callback semantics.
+        - Breaking changes to public API or behavior should be explicit, justified, and reflected in tests, snippets, and documentation.
+
+    - path: 'Tests/**/*.swift'
+      instructions: |
+        Review this as Swift SDK test code.
+
+        Focus on:
+        - Test names should clearly describe the scenario and expected outcome.
+        - Prefer a clear Arrange-Act-Assert structure when practical.
+        - Cover edge cases and failure paths introduced by the change.
+        - Keep tests deterministic and isolated; avoid hidden shared state, order dependence, and timing-sensitive assertions.
+        - Prefer focused tests over broad tests that verify many behaviors at once.
+
+    - path: 'Tests/PubNubUnitTests/**/*.swift'
+      instructions: |
+        Review this as Swift unit test code.
+
+        Focus on:
+        - Unit tests should stay fast, deterministic, and isolated.
+        - Mock external interactions instead of relying on real network behavior.
+        - Prefer tests that verify behavior without depending on incidental implementation details.
+        - Use assertions that clearly validate the intended behavior and failure mode.
+
+    - path: 'Tests/PubNubIntegrationTests/**/*.swift'
+      instructions: |
+        Review this as Swift integration test code.
+
+        Focus on:
+        - Validate real end-to-end SDK behavior against PubNub services.
+        - Use the same module imports that SDK customers would use; do not rely on `@testable import`.
+        - Avoid making integration coverage redundant with unit tests when behavior can be validated more cheaply in unit tests.
+        - Watch for flaky behavior, missing cleanup, and hidden environment dependencies.
+
+    - path: 'Package.swift'
+      instructions: |
+        Review this as customer-facing Swift Package Manager integration metadata.
+
+        Focus on:
+        - Keep platform versions, products, targets, and source layout aligned with the actual project.
+        - Flag package metadata that drifts from the SDK's real supported platforms or public package surface.
+
+    - path: 'Snippets/**/*.swift'
+      instructions: |
+        Review this as documentation snippet code intended for SDK users.
+
+        Focus on:
+        - Snippets should use current public SDK APIs and recommended usage patterns.
+        - Keep examples clear, minimal, and easy for users to adapt.
+        - Public-facing comments should stay accurate and aligned with current released behavior.
+        - Do not introduce internal-only, unreleased, or misleading usage patterns.
+        - Preserve `// snippet.<id>` and `// snippet.end` markers required by documentation tooling.
+
+  tools:
+    languagetool:
+      enabled: true
+    swiftlint:
+      enabled: true
+      config_file: '.swiftlint.yml'

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,8 +3,9 @@ language: en
 early_access: false
 
 reviews:
-  request_changes_workflow: true
+  in_progress_fortune: false
   poem: false
+  request_changes_workflow: true
   high_level_summary: true
   high_level_summary_in_walkthrough: false
   high_level_summary_instructions: |
@@ -131,9 +132,16 @@ reviews:
         - Do not introduce internal-only, unreleased, or misleading usage patterns.
         - Preserve `// snippet.<id>` and `// snippet.end` markers required by documentation tooling.
 
+  pre_merge_checks:
+    docstrings:
+      mode: off
+
   tools:
     languagetool:
       enabled: true
     swiftlint:
       enabled: true
       config_file: '.swiftlint.yml'
+
+chat:
+  art: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -5,7 +5,30 @@ early_access: false
 reviews:
   request_changes_workflow: true
   poem: false
-  high_level_summary_in_walkthrough: true
+  high_level_summary: true
+  high_level_summary_in_walkthrough: false
+  high_level_summary_instructions: |
+    Structure the summary into three sections: Context, Changes, and Notes.
+
+    ## Context
+    A short paragraph (no more than 3-4 sentences) explaining what the PR
+    accomplishes, why the change was made, and any relevant context a reviewer
+    should know upfront. Do not simply restate the PR title — infer the
+    purpose from the actual changes.
+
+    ## Changes
+    Release-notes-style bullets grouped by category. One line per bullet.
+    Group related changes into a single bullet describing the logical change,
+    not one bullet per file. For user-facing changes, frame bullets in terms
+    of impact on the user or caller. For internal changes, describe what was
+    technically modified.
+
+    ## Notes
+    - State whether the change is user-facing or purely internal.
+    - If user-facing, flag whether the change is breaking.
+    - Omit this line for additive or non-breaking changes.
+
+    Do not include file paths. Do not restate the file-level walkthrough.
   estimate_code_review_effort: false
   sequence_diagrams: false
   changed_files_summary: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,18 +2,24 @@
 language: en
 early_access: false
 
+knowledge_base:
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - '**/CODING_STANDARDS.md'
+
 reviews:
   in_progress_fortune: false
   poem: false
   request_changes_workflow: true
   high_level_summary: true
-  high_level_summary_in_walkthrough: false
+  high_level_summary_in_walkthrough: true
   high_level_summary_instructions: |
     Structure the summary into three sections: Context, Changes, and Notes.
 
     ## Context
     A short paragraph (no more than 3-4 sentences) explaining what the PR
-    accomplishes, why the change was made, and any relevant context a reviewer
+    accomplishes, why the change was made, and any relevant context a maintainer
     should know upfront. Do not simply restate the PR title — infer the
     purpose from the actual changes.
 
@@ -45,60 +51,23 @@ reviews:
     - '!Examples/**/*.xcworkspacedata'
     - '!Examples/**/Package.resolved'
   path_instructions:
-    - path: 'Sources/**/*.swift'
-      instructions: |
-        Review this as production Swift library code.
-
-        Swift best practices to check:
-        - Prefer value semantics and immutability where practical; use `let` instead of `var` unless mutation is required.
-        - Avoid force unwraps and other crash-prone patterns unless they are provably safe and justified.
-        - Prefer `if let` / `guard let` shorthand when unwrapping and shadowing the same optional, unless the explicit form is clearer.
-        - Preserve clear ownership and lifecycle behavior; flag likely retain cycles, leaked observers, and long-lived captured references.
-        - Watch for race conditions and shared mutable state, especially around callbacks, queues, async work, and listener management.
-        - Prefer clear, idiomatic Swift naming and small focused types/functions over overly clever abstractions.
-        - Flag duplicated logic, dead code, and abstractions that add complexity without a real boundary or testability benefit.
-        - Preserve useful error information; do not ignore failures or replace specific errors with vague ones.
-        - Watch for hot-path inefficiencies such as repeated allocations, avoidable copying, and unnecessary collection transformations.
-
-    - path: 'Sources/PubNub/PubNub.swift'
+    - path: 'Sources/PubNub/{PubNub.swift,APIs/**/*.swift}'
       instructions: |
         Review this as public SDK API surface exposed through `PubNub`.
 
         Focus on:
-        - Consistency with existing `PubNub` API patterns, naming, parameter semantics, and overload design.
-        - Completion and callback behavior, especially around async results, threading expectations, and error delivery.
-        - Access control: avoid exposing APIs, types, members, or initializers wider than needed.
-        - Public-facing doc comments should stay accurate and aligned with current behavior, parameters, defaults, and callback semantics.
-        - Breaking changes to public API or behavior should be explicit, justified, and reflected in tests, snippets, and documentation.
-
-    - path: 'Sources/PubNub/APIs/**/*.swift'
-      instructions: |
-        Review this as public SDK API surface exposed through `PubNub`.
-
-        Focus on:
-        - Consistency with existing `PubNub` API patterns, naming, parameter semantics, and overload design.
-        - Completion and callback behavior, especially around async results, threading expectations, and error delivery.
-        - Access control: avoid exposing APIs, types, members, or initializers wider than needed.
-        - Public-facing doc comments should stay accurate and aligned with current behavior, parameters, defaults, and callback semantics.
-        - Breaking changes to public API or behavior should be explicit, justified, and reflected in tests, snippets, and documentation.
-
-    - path: 'Tests/**/*.swift'
-      instructions: |
-        Review this as Swift SDK test code.
-
-        Focus on:
-        - Test names should clearly describe the scenario and expected outcome.
-        - Prefer a clear Arrange-Act-Assert structure when practical.
-        - Cover edge cases and failure paths introduced by the change.
-        - Keep tests deterministic and isolated; avoid hidden shared state, order dependence, and timing-sensitive assertions.
-        - Prefer focused tests over broad tests that verify many behaviors at once.
+        - Keep API patterns, naming, parameter semantics, and overload design consistent with the existing `PubNub` surface.
+        - Check completion and callback behavior, especially around async results, threading expectations, and error delivery.
+        - Avoid exposing APIs, types, members, or initializers wider than needed.
+        - Keep public-facing doc comments accurate and aligned with current behavior, parameters, defaults, and callback semantics.
+        - Make breaking changes to public API or behavior explicit, justified, and reflected in tests, snippets, and documentation.
 
     - path: 'Tests/PubNubUnitTests/**/*.swift'
       instructions: |
         Review this as Swift unit test code.
 
         Focus on:
-        - Unit tests should stay fast, deterministic, and isolated.
+        - Keep unit tests fast, deterministic, and isolated.
         - Mock external interactions instead of relying on real network behavior.
         - Prefer tests that verify behavior without depending on incidental implementation details.
         - Use assertions that clearly validate the intended behavior and failure mode.
@@ -126,9 +95,9 @@ reviews:
         Review this as documentation snippet code intended for SDK users.
 
         Focus on:
-        - Snippets should use current public SDK APIs and recommended usage patterns.
+        - Use current public SDK APIs and recommended usage patterns.
         - Keep examples clear, minimal, and easy for users to adapt.
-        - Public-facing comments should stay accurate and aligned with current released behavior.
+        - Keep public-facing comments accurate and aligned with current released behavior.
         - Do not introduce internal-only, unreleased, or misleading usage patterns.
         - Preserve `// snippet.<id>` and `// snippet.end` markers required by documentation tooling.
 
@@ -141,7 +110,7 @@ reviews:
       enabled: true
     swiftlint:
       enabled: true
-      config_file: '.swiftlint.yml'
+      config_file: ".swiftlint.yml"
 
 chat:
   art: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -11,7 +11,7 @@ knowledge_base:
 reviews:
   in_progress_fortune: false
   poem: false
-  request_changes_workflow: true
+  request_changes_workflow: false
   high_level_summary: true
   high_level_summary_in_walkthrough: true
   high_level_summary_instructions: |

--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -1,0 +1,27 @@
+# CODING_STANDARDS.md
+
+This document contains shared Swift standards for this repository.
+
+## Production Swift Library Code
+
+Apply these standards to production Swift library code:
+
+- Prefer value semantics and immutability where practical; use `let` instead of `var` unless mutation is required.
+- Avoid force unwraps and other crash-prone patterns unless they are provably safe and justified.
+- Prefer `if let` / `guard let` shorthand when unwrapping and shadowing the same optional, unless the explicit form is clearer.
+- Preserve clear ownership and lifecycle behavior; flag likely retain cycles, leaked observers, and long-lived captured references.
+- Watch for race conditions and shared mutable state, especially around callbacks, queues, async work, and listener management.
+- Prefer clear, idiomatic Swift naming and small focused types/functions over overly clever abstractions.
+- Flag duplicated logic, dead code, and abstractions that add complexity without a real boundary or testability benefit.
+- Preserve useful error information; do not ignore failures or replace specific errors with vague ones.
+- Watch for hot-path inefficiencies such as repeated allocations, avoidable copying, and unnecessary collection transformations.
+
+## Swift SDK Test Code
+
+Apply these standards to Swift SDK test code:
+
+- Test names should clearly describe the scenario and expected outcome.
+- Prefer a clear Arrange-Act-Assert structure when practical.
+- Cover edge cases and failure paths introduced by the change.
+- Keep tests deterministic and isolated; avoid hidden shared state, order dependence, and timing-sensitive assertions.
+- Prefer focused tests over broad tests that verify many behaviors at once.

--- a/Snippets/Configuration/configuration.swift
+++ b/Snippets/Configuration/configuration.swift
@@ -32,7 +32,7 @@ func basicConfigExample() {
 
 func aesCbcCryptoModuleExample() {
   // snippet.crypto-module
-  // Uses 256-bit AES-CBC encryption (recommended) with backward compatibility for legacy encryption
+  // Uses encryption.
   let pubnub = PubNub(
     configuration: PubNubConfiguration(
       publishKey: "demo",

--- a/Sources/PubNub/APIs/Objects+PubNub.swift
+++ b/Sources/PubNub/APIs/Objects+PubNub.swift
@@ -1592,19 +1592,17 @@ public extension PubNub {
       ), category: .pubNub
     )
 
-    let router = ObjectsMembershipsRouter(.setMembers(
-      channelMetadataId: metadataId, customFields: include.includeFields, totalCount: include.totalCount,
-      changes: .init(
-        set: userMembershipSets.map {
-          .init(metadataId: $0.userMetadataId, status: $0.status, type: $0.type, custom: $0.custom)
-        },
-        delete: userMembershipDeletes.map {
-          .init(metadataId: $0.userMetadataId, status: $0.status, type: $0.type, custom: $0.custom)
-        }
+    let router = ObjectsMembershipsRouter(
+      .setMembers(
+        channelMetadataId: metadataId, customFields: include.includeFields, totalCount: include.totalCount,
+        changes: .init(
+          set: userMembershipSets.map { .init(metadataId: $0.userMetadataId, status: $0.status, type: $0.type, custom: $0.custom) },
+          delete: userMembershipDeletes.map { .init(metadataId: $0.userMetadataId, status: $0.status, type: $0.type, custom: $0.custom) }
+        ),
+        filter: filter, sort: sort.memberURLValue, limit: limit, start: page?.start, end: page?.end
       ),
-      filter: filter, sort: sort.memberURLValue,
-      limit: limit, start: page?.start, end: page?.end
-    ), configuration: requestConfig.customConfiguration ?? configuration)
+      configuration: requestConfig.customConfiguration ?? configuration
+    )
 
     route(
       router,
@@ -1619,5 +1617,4 @@ public extension PubNub {
       })
     }
   }
-  // swiftlint:disable:next file_length
 }

--- a/Sources/PubNub/PubNub.swift
+++ b/Sources/PubNub/PubNub.swift
@@ -216,7 +216,7 @@ public extension PubNub {
   ///   - to: List of channels to subscribe on
   ///   - and: List of channel groups to subscribe on
   ///   - at: The initial timetoken to subscribe with
-  ///   - withPresence: If true it also subscribes to presence events on the specified channels.
+  ///   - withPresence: Enables extra events.
   func subscribe(
     to channels: [String],
     and channelGroups: [String] = [],

--- a/Sources/PubNub/PubNubConfiguration.swift
+++ b/Sources/PubNub/PubNubConfiguration.swift
@@ -190,7 +190,7 @@ public struct PubNubConfiguration: Hashable {
     enableEventEngine: Bool = true,
     maintainPresenceState: Bool = true
   ) {
-    let cryptoModule: CryptoModule? = if let cipherKey {
+    let cryptoModule: CryptoModule? = if let cipherKey = cipherKey {
       CryptoModule.legacyCryptoModule(with: cipherKey.key, withRandomIV: cipherKey.randomizeIV)
     } else {
       nil

--- a/Tests/PubNubUnitTests/Helpers/ValidatedTests.swift
+++ b/Tests/PubNubUnitTests/Helpers/ValidatedTests.swift
@@ -31,7 +31,7 @@ class ValidatedTests: XCTestCase {
     XCTAssertFalse(invalidTest.isValid)
   }
 
-  func testValidResult() {
+  func testResult() {
     let validTest = TestValidated()
     XCTAssertNil(validTest.validationError)
     XCTAssertNoThrow(try validTest.validResult.get())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Context

Adds a CodeRabbit configuration for automated review and makes several small internal cleanups across the Swift library: documentation tweaks, a minor initializer refactor, formatting changes for readability, and a test name change. The PR is aimed at improving review automation, code consistency, and maintainability without altering public API behavior.

## Changes

- Added CodeRabbit configuration that controls review workflow, disables early-access fortune/poem components, sets path filters to exclude build/workspace/test fixtures, enables request-changes flow, and configures path-specific review checklists and static tools (languagetool, swiftlint using project .swiftlint.yml)
- Rewrote deprecated initializer logic to explicitly bind cipherKey when deriving legacy cryptoModule
- Updated subscribe(withPresence:) documentation to use more general wording about enabling extra events
- Reformatted manageMembers router construction for improved readability
- Simplified crypto-module example comment to a concise “Uses encryption.” description
- Renamed a unit test from testValidResult to testResult (test logic unchanged)

## Notes

This change is internal only and does not modify public APIs or introduce breaking changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->