### PR TITLE
Add DataSync networking routers and endpoints

### DIFF
--- a/PubNub.xcodeproj/project.pbxproj
+++ b/PubNub.xcodeproj/project.pbxproj
@@ -281,6 +281,13 @@
 		35CDFEBC22E789B200F3B9F2 /* ConstantsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35CDFEBB22E789B200F3B9F2 /* ConstantsTests.swift */; };
 		35CDFEC022E7B48000F3B9F2 /* ImportTestResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35CDFEBF22E7B48000F3B9F2 /* ImportTestResource.swift */; };
 		35CF548C248971BF0099FE81 /* ObjectsUserRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35CF548B248971BF0099FE81 /* ObjectsUserRouter.swift */; };
+		4E45EAB7E4CAE5C43AA4C598 /* DataSyncChannelRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203376E7E6C9C1B39DCEAD9B /* DataSyncChannelRouter.swift */; };
+		A9FE40B4D29F21CC0143667E /* DataSyncEntityRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A657F0570CF9A9B2BD9E4719 /* DataSyncEntityRouter.swift */; };
+		862A4507613A1E76D0C7798A /* DataSyncMembershipRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01BFE10F1FA3723DE2556979 /* DataSyncMembershipRouter.swift */; };
+		997DBBB71508808142C40D57 /* DataSyncRelationshipRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B214609A615104BE8A597B9 /* DataSyncRelationshipRouter.swift */; };
+		61EF9E0B1C8606520E009F04 /* DataSyncRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33212E96A038DB6A4F03D7BE /* DataSyncRouter.swift */; };
+		3B606B5ABA0D7EEACD6457C1 /* DataSyncUserRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B2B4CA4F68262547E20A6DA /* DataSyncUserRouter.swift */; };
+		7E421DECD8867FA8742DEB06 /* DataSyncRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C499F67A4CCAA9E47D1B542 /* DataSyncRouterTests.swift */; };
 		35CF548E248971CD0099FE81 /* ObjectsChannelRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35CF548D248971CD0099FE81 /* ObjectsChannelRouter.swift */; };
 		35CF5490248971DD0099FE81 /* ObjectsMembershipsRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35CF548F248971DD0099FE81 /* ObjectsMembershipsRouter.swift */; };
 		35CF54922489912F0099FE81 /* PubNubUserMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35CF54912489912F0099FE81 /* PubNubUserMetadata.swift */; };
@@ -936,6 +943,12 @@
 		35CDFEBB22E789B200F3B9F2 /* ConstantsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstantsTests.swift; sourceTree = "<group>"; };
 		35CDFEBF22E7B48000F3B9F2 /* ImportTestResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportTestResource.swift; sourceTree = "<group>"; };
 		35CF548B248971BF0099FE81 /* ObjectsUserRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectsUserRouter.swift; sourceTree = "<group>"; };
+		203376E7E6C9C1B39DCEAD9B /* DataSyncChannelRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataSyncChannelRouter.swift; sourceTree = "<group>"; };
+		A657F0570CF9A9B2BD9E4719 /* DataSyncEntityRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataSyncEntityRouter.swift; sourceTree = "<group>"; };
+		01BFE10F1FA3723DE2556979 /* DataSyncMembershipRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataSyncMembershipRouter.swift; sourceTree = "<group>"; };
+		1B214609A615104BE8A597B9 /* DataSyncRelationshipRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataSyncRelationshipRouter.swift; sourceTree = "<group>"; };
+		33212E96A038DB6A4F03D7BE /* DataSyncRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataSyncRouter.swift; sourceTree = "<group>"; };
+		3B2B4CA4F68262547E20A6DA /* DataSyncUserRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataSyncUserRouter.swift; sourceTree = "<group>"; };
 		35CF548D248971CD0099FE81 /* ObjectsChannelRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectsChannelRouter.swift; sourceTree = "<group>"; };
 		35CF548F248971DD0099FE81 /* ObjectsMembershipsRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectsMembershipsRouter.swift; sourceTree = "<group>"; };
 		35CF54912489912F0099FE81 /* PubNubUserMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PubNubUserMetadata.swift; sourceTree = "<group>"; };
@@ -959,6 +972,7 @@
 		35DA9AB02334479800867989 /* objects_uuid_all_success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = objects_uuid_all_success.json; path = Tests/PubNubUnitTests/Support/Responses/Objects/objects_uuid_all_success.json; sourceTree = SOURCE_ROOT; };
 		35DA9AB2233447F200867989 /* objects_uuid_fetch_success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = objects_uuid_fetch_success.json; sourceTree = "<group>"; };
 		35DA9AB42335491F00867989 /* ObjectsUserRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectsUserRouterTests.swift; sourceTree = "<group>"; };
+		3C499F67A4CCAA9E47D1B542 /* DataSyncRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataSyncRouterTests.swift; sourceTree = "<group>"; };
 		35DB0C4A2874768C001E1F76 /* FlatJSONCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlatJSONCodable.swift; sourceTree = "<group>"; };
 		35DB0C4C287476BF001E1F76 /* OptionalChange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalChange.swift; sourceTree = "<group>"; };
 		35E381FC23149BA900A17549 /* AutomaticRetryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutomaticRetryTests.swift; sourceTree = "<group>"; };
@@ -1390,6 +1404,12 @@
 			isa = PBXGroup;
 			children = (
 				35A6C78E22FB4F0500E97CC5 /* ChannelGroupsRouter.swift */,
+				203376E7E6C9C1B39DCEAD9B /* DataSyncChannelRouter.swift */,
+				A657F0570CF9A9B2BD9E4719 /* DataSyncEntityRouter.swift */,
+				01BFE10F1FA3723DE2556979 /* DataSyncMembershipRouter.swift */,
+				1B214609A615104BE8A597B9 /* DataSyncRelationshipRouter.swift */,
+				33212E96A038DB6A4F03D7BE /* DataSyncRouter.swift */,
+				3B2B4CA4F68262547E20A6DA /* DataSyncUserRouter.swift */,
 				35AE6A3124FD6CEE00BBFA37 /* FileManagementRouter.swift */,
 				35A6C7BD22FCCBF900E97CC5 /* HistoryRouter.swift */,
 				35293A792368F9680049A71F /* MessageActionsRouter.swift */,
@@ -1782,6 +1802,7 @@
 			isa = PBXGroup;
 			children = (
 				35A6C79222FB93FD00E97CC5 /* ChannelGroupEndpointTests.swift */,
+				3C499F67A4CCAA9E47D1B542 /* DataSyncRouterTests.swift */,
 				35AE6A3525000AC700BBFA37 /* FileManagementRouterTests.swift */,
 				35304F9122FF7073006A02CA /* HistoryRouterTests.swift */,
 				35293A942369F31B0049A71F /* MessageActionsRouterTests.swift */,
@@ -3989,6 +4010,12 @@
 				35A66A8022F861BA00AC67A9 /* AutomaticRetry.swift in Sources */,
 				357D1C1B22CB04C4003625BA /* Bool+PubNub.swift in Sources */,
 				35CF548C248971BF0099FE81 /* ObjectsUserRouter.swift in Sources */,
+				4E45EAB7E4CAE5C43AA4C598 /* DataSyncChannelRouter.swift in Sources */,
+				A9FE40B4D29F21CC0143667E /* DataSyncEntityRouter.swift in Sources */,
+				862A4507613A1E76D0C7798A /* DataSyncMembershipRouter.swift in Sources */,
+				997DBBB71508808142C40D57 /* DataSyncRelationshipRouter.swift in Sources */,
+				61EF9E0B1C8606520E009F04 /* DataSyncRouter.swift in Sources */,
+				3B606B5ABA0D7EEACD6457C1 /* DataSyncUserRouter.swift in Sources */,
 				3585033222CD138300A11D9A /* Set+PubNub.swift in Sources */,
 				358C641C238C5232009CE354 /* FCMAndroidPayload.swift in Sources */,
 				35FAC1E72357C2AE0096E418 /* PubNubError.swift in Sources */,
@@ -4186,6 +4213,7 @@
 				3D38A0142B35AF6B006928E7 /* PresenceTransitionTests.swift in Sources */,
 				OBJ_49 /* PubNubTests.swift in Sources */,
 				35CF549E248D913A0099FE81 /* ObjectsUserRouterTests.swift in Sources */,
+				7E421DECD8867FA8742DEB06 /* DataSyncRouterTests.swift in Sources */,
 				3DB925642B7A2BF5001B7E90 /* SubscriptionSetTests.swift in Sources */,
 				35458BA3230CB3570085B502 /* SubscribeSessionFactoryTests.swift in Sources */,
 				3580A5A222F13C6500B12E5E /* SessionStreamAwait.swift in Sources */,

--- a/Sources/PubNub/Errors/ErrorDescription.swift
+++ b/Sources/PubNub/Errors/ErrorDescription.swift
@@ -81,6 +81,10 @@ extension ErrorDescription {
   static let emptyMembershipChannelId: String = "The required `channelId` `String` cannot be empty"
 
   static let emptyMembershipUserId: String = "The required `userId` `String` cannot be empty"
+
+  static let emptyRelationshipEntityAId: String = "The required `entityAId` `String` cannot be empty"
+
+  static let emptyRelationshipEntityBId: String = "The required `entityBId` `String` cannot be empty"
 }
 
 extension PubNubError: LocalizedError, CustomStringConvertible {

--- a/Sources/PubNub/Errors/ErrorDescription.swift
+++ b/Sources/PubNub/Errors/ErrorDescription.swift
@@ -77,6 +77,10 @@ extension ErrorDescription {
   static let emptyRelationshipClass: String = "The required `relationship_class` `String` cannot be empty"
 
   static let emptyPatchOperations: String = "The JSON Patch operations `Array` cannot be empty"
+
+  static let emptyMembershipChannelId: String = "The required `channelId` `String` cannot be empty"
+
+  static let emptyMembershipUserId: String = "The required `userId` `String` cannot be empty"
 }
 
 extension PubNubError: LocalizedError, CustomStringConvertible {

--- a/Sources/PubNub/Errors/ErrorDescription.swift
+++ b/Sources/PubNub/Errors/ErrorDescription.swift
@@ -69,6 +69,14 @@ extension ErrorDescription {
   static let emptyFilenameString: String = "The required Filename `String` is empty"
 
   static let emptyFileIdString: String = "The required FileId `String` is empty"
+
+  static let emptyDataSyncId: String = "The DataSync resource id `String` cannot be empty"
+
+  static let emptyEntityClass: String = "The required `entity_class` `String` cannot be empty"
+
+  static let emptyRelationshipClass: String = "The required `relationship_class` `String` cannot be empty"
+
+  static let emptyPatchOperations: String = "The JSON Patch operations `Array` cannot be empty"
 }
 
 extension PubNubError: LocalizedError, CustomStringConvertible {

--- a/Sources/PubNub/Networking/HTTPRouter.swift
+++ b/Sources/PubNub/Networking/HTTPRouter.swift
@@ -81,6 +81,7 @@ public enum HTTPMethod: String, Codable {
 
 public enum PubNubService: String {
   case channelGroup = "Channel Group"
+  case dataSync = "Data Sync"
   case fileManagement = "File Management"
   case history = "History"
   case messageActions = "Message Actions"
@@ -130,6 +131,16 @@ enum QueryKey: String {
   case descending = "desc"
   case eventEngine = "ee"
   case next = "next"
+  case cursor
+  case filterAdvanced = "filter_advanced"
+  case entityClass = "entity_class"
+  case entityClassVersion = "entity_class_version"
+  case relationshipClass = "relationship_class"
+  case relationshipClassVersion = "relationship_class_version"
+  case userId = "user_id"
+  case channelId = "channel_id"
+  case entityAId = "entity_a_id"
+  case entityBId = "entity_b_id"
 }
 
 /// The PubNub Key requirement for a given Endpoint
@@ -315,7 +326,10 @@ public extension HTTPRouter {
         request.httpMethod = method.rawValue
         request.httpBody = data
 
-        if data != nil, [.post, .patch, .put, .delete, .options].contains(method) {
+        let hasContentType = additionalHeaders.keys.contains {
+          $0.caseInsensitiveCompare(Constant.contentTypeHeaderKey) == .orderedSame
+        }
+        if data != nil, !hasContentType, [.post, .patch, .put, .delete, .options].contains(method) {
           request.setValue(Constant.defaultContentTypeHeader, forHTTPHeaderField: Constant.contentTypeHeaderKey)
         }
 

--- a/Sources/PubNub/Networking/Routers/DataSyncChannelRouter.swift
+++ b/Sources/PubNub/Networking/Routers/DataSyncChannelRouter.swift
@@ -1,0 +1,185 @@
+//
+//  DataSyncChannelRouter.swift
+//
+//  Copyright (c) PubNub Inc.
+//  All rights reserved.
+//
+//  This source code is licensed under the license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+
+struct DataSyncChannelRouter: HTTPRouter {
+  enum Endpoint: CustomStringConvertible {
+    case all(entityClassVersion: Int?, cursor: String?, limit: Int?, filter: String?, filterAdvanced: String?, sort: String?)
+    case fetch(id: String)
+    case create(body: CreateBody)
+    case replace(id: String, body: ReplaceBody, ifMatch: String?)
+    case patch(id: String, operations: [JSONPatchOperation], ifMatch: String?)
+    case remove(id: String, ifMatch: String?)
+
+    var description: String {
+      switch self {
+      case .all:
+        return "List DataSync Channels"
+      case .fetch:
+        return "Fetch DataSync Channel"
+      case .create:
+        return "Create DataSync Channel"
+      case .replace:
+        return "Replace DataSync Channel"
+      case .patch:
+        return "Patch DataSync Channel"
+      case .remove:
+        return "Remove DataSync Channel"
+      }
+    }
+  }
+
+  struct CreateBody: JSONCodable, Equatable {
+    let id: String?
+    let status: String?
+    let entityClassVersion: Int
+    let payload: AnyJSON?
+
+    init(id: String? = nil, status: String? = nil, entityClassVersion: Int, payload: AnyJSON? = nil) {
+      self.id = id
+      self.status = status
+      self.entityClassVersion = entityClassVersion
+      self.payload = payload
+    }
+  }
+
+  struct ReplaceBody: JSONCodable, Equatable {
+    let status: String?
+    let entityClassVersion: Int
+    let payload: AnyJSON?
+
+    init(status: String? = nil, entityClassVersion: Int, payload: AnyJSON? = nil) {
+      self.status = status
+      self.entityClassVersion = entityClassVersion
+      self.payload = payload
+    }
+  }
+
+  init(_ endpoint: Endpoint, configuration: RouterConfiguration, customHeaders: [String: String] = [:]) {
+    self.endpoint = endpoint
+    self.configuration = configuration
+    self.customHeaders = customHeaders
+  }
+
+  var endpoint: Endpoint
+  var configuration: RouterConfiguration
+  var customHeaders: [String: String]
+
+  var service: PubNubService {
+    .dataSync
+  }
+
+  var category: String {
+    endpoint.description
+  }
+
+  var pamVersion: PAMVersionRequirement {
+    .version3
+  }
+
+  var path: Result<String, Error> {
+    let base = "/v1/datasync/subkeys/\(subscribeKey)/channels"
+
+    switch endpoint {
+    case .all, .create:
+      return .success(base)
+    case let .fetch(id):
+      return .success("\(base)/\(id.urlEncodeSlash)")
+    case let .replace(id, _, _):
+      return .success("\(base)/\(id.urlEncodeSlash)")
+    case let .patch(id, _, _):
+      return .success("\(base)/\(id.urlEncodeSlash)")
+    case let .remove(id, _):
+      return .success("\(base)/\(id.urlEncodeSlash)")
+    }
+  }
+
+  var queryItems: Result<[URLQueryItem], Error> {
+    var query = defaultQueryItems
+
+    switch endpoint {
+    case let .all(entityClassVersion, cursor, limit, filter, filterAdvanced, sort):
+      query.appendIfPresent(key: .entityClassVersion, value: entityClassVersion?.description)
+      query.appendIfPresent(key: .cursor, value: cursor)
+      query.appendIfPresent(key: .limit, value: limit?.description)
+      query.appendIfPresent(key: .filter, value: filter)
+      query.appendIfPresent(key: .filterAdvanced, value: filterAdvanced)
+      query.appendIfPresent(key: .sort, value: sort)
+    default:
+      break
+    }
+
+    return .success(query)
+  }
+
+  var method: HTTPMethod {
+    switch endpoint {
+    case .all: return .get
+    case .fetch: return .get
+    case .create: return .post
+    case .replace: return .put
+    case .patch: return .patch
+    case .remove: return .delete
+    }
+  }
+
+  var body: Result<Data?, Error> {
+    switch endpoint {
+    case let .create(body):
+      return body.jsonDataResult.map { .some($0) }
+    case let .replace(_, body, _):
+      return body.jsonDataResult.map { .some($0) }
+    case let .patch(_, operations, _):
+      return operations.encodableJSONData.map { .some($0) }
+    default:
+      return .success(nil)
+    }
+  }
+
+  var additionalHeaders: [String: String] {
+    var headers = customHeaders
+
+    switch endpoint {
+    case .create:
+      headers[Constant.contentTypeHeaderKey] = DataSyncHeader.contentType(resource: "channel")
+    case let .replace(_, _, ifMatch):
+      headers[Constant.contentTypeHeaderKey] = DataSyncHeader.contentType(resource: "channel")
+      headers[DataSyncHeader.ifMatch] = ifMatch
+    case let .patch(_, _, ifMatch):
+      headers[Constant.contentTypeHeaderKey] = DataSyncHeader.jsonPatchContentType
+      headers[DataSyncHeader.ifMatch] = ifMatch
+    case let .remove(_, ifMatch):
+      headers[DataSyncHeader.ifMatch] = ifMatch
+    default:
+      break
+    }
+
+    return headers.compactMapValues { $0 }
+  }
+
+  var validationErrorDetail: String? {
+    switch endpoint {
+    case .all, .create:
+      return nil
+    case let .fetch(id):
+      return isInvalidForReason((id.isEmpty, ErrorDescription.emptyDataSyncId))
+    case let .replace(id, _, _):
+      return isInvalidForReason((id.isEmpty, ErrorDescription.emptyDataSyncId))
+    case let .patch(id, operations, _):
+      return isInvalidForReason(
+        (id.isEmpty, ErrorDescription.emptyDataSyncId),
+        (operations.isEmpty, ErrorDescription.emptyPatchOperations)
+      )
+    case let .remove(id, _):
+      return isInvalidForReason((id.isEmpty, ErrorDescription.emptyDataSyncId))
+    }
+  }
+}

--- a/Sources/PubNub/Networking/Routers/DataSyncEntityRouter.swift
+++ b/Sources/PubNub/Networking/Routers/DataSyncEntityRouter.swift
@@ -179,8 +179,8 @@ struct DataSyncEntityRouter: HTTPRouter {
     switch endpoint {
     case let .all(entityClass, _, _, _, _, _, _):
       return isInvalidForReason((entityClass.isEmpty, ErrorDescription.emptyEntityClass))
-    case .create:
-      return nil
+    case let .create(body):
+      return isInvalidForReason((body.entityClass.isEmpty, ErrorDescription.emptyEntityClass))
     case let .fetch(id):
       return isInvalidForReason((id.isEmpty, ErrorDescription.emptyDataSyncId))
     case let .replace(id, _, _):

--- a/Sources/PubNub/Networking/Routers/DataSyncEntityRouter.swift
+++ b/Sources/PubNub/Networking/Routers/DataSyncEntityRouter.swift
@@ -1,0 +1,197 @@
+//
+//  DataSyncEntityRouter.swift
+//
+//  Copyright (c) PubNub Inc.
+//  All rights reserved.
+//
+//  This source code is licensed under the license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+
+struct DataSyncEntityRouter: HTTPRouter {
+  enum Endpoint: CustomStringConvertible {
+    case all(
+      entityClass: String, entityClassVersion: Int?, cursor: String?, limit: Int?,
+      filter: String?, filterAdvanced: String?, sort: String?
+    )
+    case fetch(id: String)
+    case create(body: CreateBody)
+    case replace(id: String, body: ReplaceBody, ifMatch: String?)
+    case patch(id: String, operations: [JSONPatchOperation], ifMatch: String?)
+    case remove(id: String, ifMatch: String?)
+
+    var description: String {
+      switch self {
+      case .all:
+        return "List DataSync Entities"
+      case .fetch:
+        return "Fetch DataSync Entity"
+      case .create:
+        return "Create DataSync Entity"
+      case .replace:
+        return "Replace DataSync Entity"
+      case .patch:
+        return "Patch DataSync Entity"
+      case .remove:
+        return "Remove DataSync Entity"
+      }
+    }
+  }
+
+  struct CreateBody: JSONCodable, Equatable {
+    let id: String?
+    let entityClass: String
+    let entityClassVersion: Int
+    let status: String?
+    let payload: AnyJSON?
+
+    init(
+      id: String? = nil, entityClass: String, entityClassVersion: Int,
+      status: String? = nil, payload: AnyJSON? = nil
+    ) {
+      self.id = id
+      self.entityClass = entityClass
+      self.entityClassVersion = entityClassVersion
+      self.status = status
+      self.payload = payload
+    }
+  }
+
+  struct ReplaceBody: JSONCodable, Equatable {
+    let status: String?
+    let entityClassVersion: Int
+    let payload: AnyJSON?
+
+    init(status: String? = nil, entityClassVersion: Int, payload: AnyJSON? = nil) {
+      self.status = status
+      self.entityClassVersion = entityClassVersion
+      self.payload = payload
+    }
+  }
+
+  init(_ endpoint: Endpoint, configuration: RouterConfiguration, customHeaders: [String: String] = [:]) {
+    self.endpoint = endpoint
+    self.configuration = configuration
+    self.customHeaders = customHeaders
+  }
+
+  var endpoint: Endpoint
+  var configuration: RouterConfiguration
+  var customHeaders: [String: String]
+
+  var service: PubNubService {
+    .dataSync
+  }
+
+  var category: String {
+    endpoint.description
+  }
+
+  var pamVersion: PAMVersionRequirement {
+    .version3
+  }
+
+  var path: Result<String, Error> {
+    let base = "/v1/datasync/subkeys/\(subscribeKey)/entities"
+
+    switch endpoint {
+    case .all, .create:
+      return .success(base)
+    case let .fetch(id):
+      return .success("\(base)/\(id.urlEncodeSlash)")
+    case let .replace(id, _, _):
+      return .success("\(base)/\(id.urlEncodeSlash)")
+    case let .patch(id, _, _):
+      return .success("\(base)/\(id.urlEncodeSlash)")
+    case let .remove(id, _):
+      return .success("\(base)/\(id.urlEncodeSlash)")
+    }
+  }
+
+  var queryItems: Result<[URLQueryItem], Error> {
+    var query = defaultQueryItems
+
+    switch endpoint {
+    case let .all(entityClass, entityClassVersion, cursor, limit, filter, filterAdvanced, sort):
+      query.appendIfPresent(key: .entityClass, value: entityClass)
+      query.appendIfPresent(key: .entityClassVersion, value: entityClassVersion?.description)
+      query.appendIfPresent(key: .cursor, value: cursor)
+      query.appendIfPresent(key: .limit, value: limit?.description)
+      query.appendIfPresent(key: .filter, value: filter)
+      query.appendIfPresent(key: .filterAdvanced, value: filterAdvanced)
+      query.appendIfPresent(key: .sort, value: sort)
+    default:
+      break
+    }
+
+    return .success(query)
+  }
+
+  var method: HTTPMethod {
+    switch endpoint {
+    case .all: return .get
+    case .fetch: return .get
+    case .create: return .post
+    case .replace: return .put
+    case .patch: return .patch
+    case .remove: return .delete
+    }
+  }
+
+  var body: Result<Data?, Error> {
+    switch endpoint {
+    case let .create(body):
+      return body.jsonDataResult.map { .some($0) }
+    case let .replace(_, body, _):
+      return body.jsonDataResult.map { .some($0) }
+    case let .patch(_, operations, _):
+      return operations.encodableJSONData.map { .some($0) }
+    default:
+      return .success(nil)
+    }
+  }
+
+  var additionalHeaders: [String: String] {
+    var headers = customHeaders
+
+    switch endpoint {
+    case .create:
+      headers[Constant.contentTypeHeaderKey] = DataSyncHeader.contentType(resource: "entity")
+    case let .replace(_, _, ifMatch):
+      headers[Constant.contentTypeHeaderKey] = DataSyncHeader.contentType(resource: "entity")
+      headers[DataSyncHeader.ifMatch] = ifMatch
+    case let .patch(_, _, ifMatch):
+      headers[Constant.contentTypeHeaderKey] = DataSyncHeader.jsonPatchContentType
+      headers[DataSyncHeader.ifMatch] = ifMatch
+    case let .remove(_, ifMatch):
+      headers[DataSyncHeader.ifMatch] = ifMatch
+    default:
+      break
+    }
+
+    return headers.compactMapValues { $0 }
+  }
+
+  // Validated
+  var validationErrorDetail: String? {
+    switch endpoint {
+    case let .all(entityClass, _, _, _, _, _, _):
+      return isInvalidForReason((entityClass.isEmpty, ErrorDescription.emptyEntityClass))
+    case .create:
+      return nil
+    case let .fetch(id):
+      return isInvalidForReason((id.isEmpty, ErrorDescription.emptyDataSyncId))
+    case let .replace(id, _, _):
+      return isInvalidForReason((id.isEmpty, ErrorDescription.emptyDataSyncId))
+    case let .patch(id, operations, _):
+      return isInvalidForReason(
+        (id.isEmpty, ErrorDescription.emptyDataSyncId),
+        (operations.isEmpty, ErrorDescription.emptyPatchOperations)
+      )
+    case let .remove(id, _):
+      return isInvalidForReason((id.isEmpty, ErrorDescription.emptyDataSyncId))
+    }
+  }
+}

--- a/Sources/PubNub/Networking/Routers/DataSyncMembershipRouter.swift
+++ b/Sources/PubNub/Networking/Routers/DataSyncMembershipRouter.swift
@@ -1,0 +1,197 @@
+//
+//  DataSyncMembershipRouter.swift
+//
+//  Copyright (c) PubNub Inc.
+//  All rights reserved.
+//
+//  This source code is licensed under the license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+
+struct DataSyncMembershipRouter: HTTPRouter {
+  enum Endpoint: CustomStringConvertible {
+    case all(
+      userId: String?, channelId: String?, relationshipClassVersion: Int?,
+      cursor: String?, limit: Int?, filter: String?, filterAdvanced: String?, sort: String?
+    )
+    case fetch(id: String)
+    case create(body: CreateBody)
+    case replace(id: String, body: ReplaceBody, ifMatch: String?)
+    case patch(id: String, operations: [JSONPatchOperation], ifMatch: String?)
+    case remove(id: String, ifMatch: String?)
+
+    var description: String {
+      switch self {
+      case .all:
+        return "List DataSync Memberships"
+      case .fetch:
+        return "Fetch DataSync Membership"
+      case .create:
+        return "Create DataSync Membership"
+      case .replace:
+        return "Replace DataSync Membership"
+      case .patch:
+        return "Patch DataSync Membership"
+      case .remove:
+        return "Remove DataSync Membership"
+      }
+    }
+  }
+
+  struct CreateBody: JSONCodable, Equatable {
+    let id: String?
+    let channelId: String
+    let userId: String
+    let relationshipClassVersion: Int
+    let status: String?
+    let payload: AnyJSON?
+
+    init(
+      id: String? = nil, channelId: String, userId: String,
+      relationshipClassVersion: Int, status: String? = nil, payload: AnyJSON? = nil
+    ) {
+      self.id = id
+      self.channelId = channelId
+      self.userId = userId
+      self.relationshipClassVersion = relationshipClassVersion
+      self.status = status
+      self.payload = payload
+    }
+  }
+
+  struct ReplaceBody: JSONCodable, Equatable {
+    let status: String?
+    let relationshipClassVersion: Int
+    let payload: AnyJSON?
+
+    init(status: String? = nil, relationshipClassVersion: Int, payload: AnyJSON? = nil) {
+      self.status = status
+      self.relationshipClassVersion = relationshipClassVersion
+      self.payload = payload
+    }
+  }
+
+  init(_ endpoint: Endpoint, configuration: RouterConfiguration, customHeaders: [String: String] = [:]) {
+    self.endpoint = endpoint
+    self.configuration = configuration
+    self.customHeaders = customHeaders
+  }
+
+  var endpoint: Endpoint
+  var configuration: RouterConfiguration
+  var customHeaders: [String: String]
+
+  var service: PubNubService {
+    .dataSync
+  }
+
+  var category: String {
+    endpoint.description
+  }
+
+  var pamVersion: PAMVersionRequirement {
+    .version3
+  }
+
+  var path: Result<String, Error> {
+    let base = "/v1/datasync/subkeys/\(subscribeKey)/memberships"
+
+    switch endpoint {
+    case .all, .create:
+      return .success(base)
+    case let .fetch(id):
+      return .success("\(base)/\(id.urlEncodeSlash)")
+    case let .replace(id, _, _):
+      return .success("\(base)/\(id.urlEncodeSlash)")
+    case let .patch(id, _, _):
+      return .success("\(base)/\(id.urlEncodeSlash)")
+    case let .remove(id, _):
+      return .success("\(base)/\(id.urlEncodeSlash)")
+    }
+  }
+
+  var queryItems: Result<[URLQueryItem], Error> {
+    var query = defaultQueryItems
+
+    switch endpoint {
+    case let .all(userId, channelId, relationshipClassVersion, cursor, limit, filter, filterAdvanced, sort):
+      query.appendIfPresent(key: .userId, value: userId)
+      query.appendIfPresent(key: .channelId, value: channelId)
+      query.appendIfPresent(key: .relationshipClassVersion, value: relationshipClassVersion?.description)
+      query.appendIfPresent(key: .cursor, value: cursor)
+      query.appendIfPresent(key: .limit, value: limit?.description)
+      query.appendIfPresent(key: .filter, value: filter)
+      query.appendIfPresent(key: .filterAdvanced, value: filterAdvanced)
+      query.appendIfPresent(key: .sort, value: sort)
+    default:
+      break
+    }
+
+    return .success(query)
+  }
+
+  var method: HTTPMethod {
+    switch endpoint {
+    case .all: return .get
+    case .fetch: return .get
+    case .create: return .post
+    case .replace: return .put
+    case .patch: return .patch
+    case .remove: return .delete
+    }
+  }
+
+  var body: Result<Data?, Error> {
+    switch endpoint {
+    case let .create(body):
+      return body.jsonDataResult.map { .some($0) }
+    case let .replace(_, body, _):
+      return body.jsonDataResult.map { .some($0) }
+    case let .patch(_, operations, _):
+      return operations.encodableJSONData.map { .some($0) }
+    default:
+      return .success(nil)
+    }
+  }
+
+  var additionalHeaders: [String: String] {
+    var headers = customHeaders
+
+    switch endpoint {
+    case .create:
+      headers[Constant.contentTypeHeaderKey] = DataSyncHeader.contentType(resource: "membership")
+    case let .replace(_, _, ifMatch):
+      headers[Constant.contentTypeHeaderKey] = DataSyncHeader.contentType(resource: "membership")
+      headers[DataSyncHeader.ifMatch] = ifMatch
+    case let .patch(_, _, ifMatch):
+      headers[Constant.contentTypeHeaderKey] = DataSyncHeader.jsonPatchContentType
+      headers[DataSyncHeader.ifMatch] = ifMatch
+    case let .remove(_, ifMatch):
+      headers[DataSyncHeader.ifMatch] = ifMatch
+    default:
+      break
+    }
+
+    return headers.compactMapValues { $0 }
+  }
+
+  var validationErrorDetail: String? {
+    switch endpoint {
+    case .all, .create:
+      return nil
+    case let .fetch(id):
+      return isInvalidForReason((id.isEmpty, ErrorDescription.emptyDataSyncId))
+    case let .replace(id, _, _):
+      return isInvalidForReason((id.isEmpty, ErrorDescription.emptyDataSyncId))
+    case let .patch(id, operations, _):
+      return isInvalidForReason(
+        (id.isEmpty, ErrorDescription.emptyDataSyncId),
+        (operations.isEmpty, ErrorDescription.emptyPatchOperations)
+      )
+    case let .remove(id, _):
+      return isInvalidForReason((id.isEmpty, ErrorDescription.emptyDataSyncId))
+    }
+  }
+}

--- a/Sources/PubNub/Networking/Routers/DataSyncMembershipRouter.swift
+++ b/Sources/PubNub/Networking/Routers/DataSyncMembershipRouter.swift
@@ -179,8 +179,13 @@ struct DataSyncMembershipRouter: HTTPRouter {
 
   var validationErrorDetail: String? {
     switch endpoint {
-    case .all, .create:
+    case .all:
       return nil
+    case let .create(body):
+      return isInvalidForReason(
+        (body.channelId.isEmpty, ErrorDescription.emptyMembershipChannelId),
+        (body.userId.isEmpty, ErrorDescription.emptyMembershipUserId)
+      )
     case let .fetch(id):
       return isInvalidForReason((id.isEmpty, ErrorDescription.emptyDataSyncId))
     case let .replace(id, _, _):

--- a/Sources/PubNub/Networking/Routers/DataSyncRelationshipRouter.swift
+++ b/Sources/PubNub/Networking/Routers/DataSyncRelationshipRouter.swift
@@ -189,8 +189,12 @@ struct DataSyncRelationshipRouter: HTTPRouter {
     switch endpoint {
     case let .all(relationshipClass, _, _, _, _, _, _, _, _):
       return isInvalidForReason((relationshipClass.isEmpty, ErrorDescription.emptyRelationshipClass))
-    case .create:
-      return nil
+    case let .create(body):
+      return isInvalidForReason(
+        (body.entityAId.isEmpty, ErrorDescription.emptyRelationshipEntityAId),
+        (body.entityBId.isEmpty, ErrorDescription.emptyRelationshipEntityBId),
+        (body.relationshipClass.isEmpty, ErrorDescription.emptyRelationshipClass)
+      )
     case let .fetch(id):
       return isInvalidForReason((id.isEmpty, ErrorDescription.emptyDataSyncId))
     case let .replace(id, _, _):

--- a/Sources/PubNub/Networking/Routers/DataSyncRelationshipRouter.swift
+++ b/Sources/PubNub/Networking/Routers/DataSyncRelationshipRouter.swift
@@ -1,0 +1,207 @@
+//
+//  DataSyncRelationshipRouter.swift
+//
+//  Copyright (c) PubNub Inc.
+//  All rights reserved.
+//
+//  This source code is licensed under the license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+
+struct DataSyncRelationshipRouter: HTTPRouter {
+  enum Endpoint: CustomStringConvertible {
+    case all(
+      relationshipClass: String, entityAId: String?, entityBId: String?,
+      relationshipClassVersion: Int?, cursor: String?, limit: Int?,
+      filter: String?, filterAdvanced: String?, sort: String?
+    )
+    case fetch(id: String)
+    case create(body: CreateBody)
+    case replace(id: String, body: ReplaceBody, ifMatch: String?)
+    case patch(id: String, operations: [JSONPatchOperation], ifMatch: String?)
+    case remove(id: String, ifMatch: String?)
+
+    var description: String {
+      switch self {
+      case .all:
+        return "List DataSync Relationships"
+      case .fetch:
+        return "Fetch DataSync Relationship"
+      case .create:
+        return "Create DataSync Relationship"
+      case .replace:
+        return "Replace DataSync Relationship"
+      case .patch:
+        return "Patch DataSync Relationship"
+      case .remove:
+        return "Remove DataSync Relationship"
+      }
+    }
+  }
+
+  struct CreateBody: JSONCodable, Equatable {
+    let id: String?
+    let entityAId: String
+    let entityBId: String
+    let relationshipClass: String
+    let relationshipClassVersion: Int
+    let status: String?
+    let payload: AnyJSON?
+
+    init(
+      id: String? = nil, entityAId: String, entityBId: String,
+      relationshipClass: String, relationshipClassVersion: Int,
+      status: String? = nil, payload: AnyJSON? = nil
+    ) {
+      self.id = id
+      self.entityAId = entityAId
+      self.entityBId = entityBId
+      self.relationshipClass = relationshipClass
+      self.relationshipClassVersion = relationshipClassVersion
+      self.status = status
+      self.payload = payload
+    }
+  }
+
+  struct ReplaceBody: JSONCodable, Equatable {
+    let status: String?
+    let relationshipClassVersion: Int
+    let payload: AnyJSON?
+
+    init(status: String? = nil, relationshipClassVersion: Int, payload: AnyJSON? = nil) {
+      self.status = status
+      self.relationshipClassVersion = relationshipClassVersion
+      self.payload = payload
+    }
+  }
+
+  init(_ endpoint: Endpoint, configuration: RouterConfiguration, customHeaders: [String: String] = [:]) {
+    self.endpoint = endpoint
+    self.configuration = configuration
+    self.customHeaders = customHeaders
+  }
+
+  var endpoint: Endpoint
+  var configuration: RouterConfiguration
+  var customHeaders: [String: String]
+
+  var service: PubNubService {
+    .dataSync
+  }
+
+  var category: String {
+    endpoint.description
+  }
+
+  var pamVersion: PAMVersionRequirement {
+    .version3
+  }
+
+  var path: Result<String, Error> {
+    let base = "/v1/datasync/subkeys/\(subscribeKey)/relationships"
+
+    switch endpoint {
+    case .all, .create:
+      return .success(base)
+    case let .fetch(id):
+      return .success("\(base)/\(id.urlEncodeSlash)")
+    case let .replace(id, _, _):
+      return .success("\(base)/\(id.urlEncodeSlash)")
+    case let .patch(id, _, _):
+      return .success("\(base)/\(id.urlEncodeSlash)")
+    case let .remove(id, _):
+      return .success("\(base)/\(id.urlEncodeSlash)")
+    }
+  }
+
+  var queryItems: Result<[URLQueryItem], Error> {
+    var query = defaultQueryItems
+
+    switch endpoint {
+    case let .all(
+      relationshipClass, entityAId, entityBId, relationshipClassVersion,
+      cursor, limit, filter, filterAdvanced, sort
+    ):
+      query.appendIfPresent(key: .relationshipClass, value: relationshipClass)
+      query.appendIfPresent(key: .entityAId, value: entityAId)
+      query.appendIfPresent(key: .entityBId, value: entityBId)
+      query.appendIfPresent(key: .relationshipClassVersion, value: relationshipClassVersion?.description)
+      query.appendIfPresent(key: .cursor, value: cursor)
+      query.appendIfPresent(key: .limit, value: limit?.description)
+      query.appendIfPresent(key: .filter, value: filter)
+      query.appendIfPresent(key: .filterAdvanced, value: filterAdvanced)
+      query.appendIfPresent(key: .sort, value: sort)
+    default:
+      break
+    }
+
+    return .success(query)
+  }
+
+  var method: HTTPMethod {
+    switch endpoint {
+    case .all: return .get
+    case .fetch: return .get
+    case .create: return .post
+    case .replace: return .put
+    case .patch: return .patch
+    case .remove: return .delete
+    }
+  }
+
+  var body: Result<Data?, Error> {
+    switch endpoint {
+    case let .create(body):
+      return body.jsonDataResult.map { .some($0) }
+    case let .replace(_, body, _):
+      return body.jsonDataResult.map { .some($0) }
+    case let .patch(_, operations, _):
+      return operations.encodableJSONData.map { .some($0) }
+    default:
+      return .success(nil)
+    }
+  }
+
+  var additionalHeaders: [String: String] {
+    var headers = customHeaders
+
+    switch endpoint {
+    case .create:
+      headers[Constant.contentTypeHeaderKey] = DataSyncHeader.contentType(resource: "relationship")
+    case let .replace(_, _, ifMatch):
+      headers[Constant.contentTypeHeaderKey] = DataSyncHeader.contentType(resource: "relationship")
+      headers[DataSyncHeader.ifMatch] = ifMatch
+    case let .patch(_, _, ifMatch):
+      headers[Constant.contentTypeHeaderKey] = DataSyncHeader.jsonPatchContentType
+      headers[DataSyncHeader.ifMatch] = ifMatch
+    case let .remove(_, ifMatch):
+      headers[DataSyncHeader.ifMatch] = ifMatch
+    default:
+      break
+    }
+
+    return headers.compactMapValues { $0 }
+  }
+
+  var validationErrorDetail: String? {
+    switch endpoint {
+    case let .all(relationshipClass, _, _, _, _, _, _, _, _):
+      return isInvalidForReason((relationshipClass.isEmpty, ErrorDescription.emptyRelationshipClass))
+    case .create:
+      return nil
+    case let .fetch(id):
+      return isInvalidForReason((id.isEmpty, ErrorDescription.emptyDataSyncId))
+    case let .replace(id, _, _):
+      return isInvalidForReason((id.isEmpty, ErrorDescription.emptyDataSyncId))
+    case let .patch(id, operations, _):
+      return isInvalidForReason(
+        (id.isEmpty, ErrorDescription.emptyDataSyncId),
+        (operations.isEmpty, ErrorDescription.emptyPatchOperations)
+      )
+    case let .remove(id, _):
+      return isInvalidForReason((id.isEmpty, ErrorDescription.emptyDataSyncId))
+    }
+  }
+}

--- a/Sources/PubNub/Networking/Routers/DataSyncRouter.swift
+++ b/Sources/PubNub/Networking/Routers/DataSyncRouter.swift
@@ -1,0 +1,159 @@
+//
+//  DataSyncRouter.swift
+//
+//  Copyright (c) PubNub Inc.
+//  All rights reserved.
+//
+//  This source code is licensed under the license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+
+// MARK: - Shared header helpers
+
+enum DataSyncHeader {
+  static let ifMatch = "If-Match"
+  static let jsonPatchContentType = "application/json-patch+json"
+
+  /// Vendor media type for a resource write body, e.g.
+  /// `application/vnd.pubnub.objects.user+json;version=1`.
+  static func contentType(resource: String, version: Int = 1) -> String {
+    "application/vnd.pubnub.objects.\(resource)+json;version=\(version)"
+  }
+}
+
+// MARK: - JSON Patch (RFC 6902)
+
+/// A single RFC 6902 JSON Patch operation used by DataSync `PATCH` endpoints.
+enum JSONPatchOperation: Encodable, Equatable {
+  case add(path: String, value: AnyJSON)
+  case remove(path: String)
+  case replace(path: String, value: AnyJSON)
+  case move(from: String, path: String)
+  case copy(from: String, path: String)
+  case test(path: String, value: AnyJSON)
+
+  private enum CodingKeys: String, CodingKey {
+    case op
+    case path
+    case value
+    case from
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+
+    switch self {
+    case let .add(path, value):
+      try container.encode("add", forKey: .op)
+      try container.encode(path, forKey: .path)
+      try container.encode(value, forKey: .value)
+    case let .remove(path):
+      try container.encode("remove", forKey: .op)
+      try container.encode(path, forKey: .path)
+    case let .replace(path, value):
+      try container.encode("replace", forKey: .op)
+      try container.encode(path, forKey: .path)
+      try container.encode(value, forKey: .value)
+    case let .move(from, path):
+      try container.encode("move", forKey: .op)
+      try container.encode(from, forKey: .from)
+      try container.encode(path, forKey: .path)
+    case let .copy(from, path):
+      try container.encode("copy", forKey: .op)
+      try container.encode(from, forKey: .from)
+      try container.encode(path, forKey: .path)
+    case let .test(path, value):
+      try container.encode("test", forKey: .op)
+      try container.encode(path, forKey: .path)
+      try container.encode(value, forKey: .value)
+    }
+  }
+}
+
+// MARK: - Response envelope models
+
+/// Pagination metadata returned on DataSync list responses.
+struct DataSyncPageMeta: Codable, Equatable {
+  let nextCursor: String?
+  let hasNext: Bool?
+  let limit: Int?
+
+  enum CodingKeys: String, CodingKey {
+    case nextCursor = "next_cursor"
+    case hasNext = "has_next"
+    case limit
+  }
+}
+
+/// Navigation links returned on DataSync list responses.
+struct DataSyncLinks: Codable, Equatable {
+  let `self`: String?
+  let next: String?
+}
+
+/// Envelope for a single DataSync resource read/write.
+struct DataSyncSingleResponse<Value: Codable>: Codable {
+  let data: Value
+}
+
+/// Envelope for a paginated DataSync list response.
+struct DataSyncListResponse<Value: Codable>: Codable {
+  let data: [Value]
+  let links: DataSyncLinks?
+  let meta: DataSyncPageMeta?
+}
+
+/// Envelope for a no-body success response.
+struct DataSyncStatusResponse: Codable {
+}
+
+// MARK: - Raw resource
+
+struct DataSyncResource: Codable, Equatable {
+  let id: String
+  let status: String?
+  let entityClass: String?
+  let entityClassVersion: Int?
+  let entityClassLevel: String?
+  let relationshipClass: String?
+  let relationshipClassVersion: Int?
+  let entityAId: String?
+  let entityBId: String?
+  let channelId: String?
+  let userId: String?
+  let createdAt: String?
+  let updatedAt: String?
+  let eTag: String?
+  let expiresAt: String?
+  let payload: AnyJSON?
+}
+
+// MARK: - Response decoders
+
+struct DataSyncSingleValueResponseDecoder<Value: Codable>: ResponseDecoder {
+  typealias Payload = DataSyncSingleResponse<Value>
+}
+
+struct DataSyncListValueResponseDecoder<Value: Codable>: ResponseDecoder {
+  typealias Payload = DataSyncListResponse<Value>
+}
+
+struct DataSyncStatusResponseDecoder: ResponseDecoder {
+  typealias Payload = DataSyncStatusResponse
+
+  func decode(
+    response: EndpointResponse<Data>
+  ) -> Result<EndpointResponse<Payload>, Error> {
+    .success(
+      EndpointResponse<Payload>(
+        router: response.router,
+        request: response.request,
+        response: response.response,
+        data: response.data,
+        payload: DataSyncStatusResponse()
+      )
+    )
+  }
+}

--- a/Sources/PubNub/Networking/Routers/DataSyncUserRouter.swift
+++ b/Sources/PubNub/Networking/Routers/DataSyncUserRouter.swift
@@ -1,0 +1,188 @@
+//
+//  DataSyncUserRouter.swift
+//
+//  Copyright (c) PubNub Inc.
+//  All rights reserved.
+//
+//  This source code is licensed under the license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+
+struct DataSyncUserRouter: HTTPRouter {
+  enum Endpoint: CustomStringConvertible {
+    case all(
+      entityClassVersion: Int?, cursor: String?, limit: Int?,
+      filter: String?, filterAdvanced: String?, sort: String?
+    )
+    case fetch(id: String)
+    case create(body: CreateBody)
+    case replace(id: String, body: ReplaceBody, ifMatch: String?)
+    case patch(id: String, operations: [JSONPatchOperation], ifMatch: String?)
+    case remove(id: String, ifMatch: String?)
+
+    var description: String {
+      switch self {
+      case .all:
+        return "List DataSync Users"
+      case .fetch:
+        return "Fetch DataSync User"
+      case .create:
+        return "Create DataSync User"
+      case .replace:
+        return "Replace DataSync User"
+      case .patch:
+        return "Patch DataSync User"
+      case .remove:
+        return "Remove DataSync User"
+      }
+    }
+  }
+
+  struct CreateBody: JSONCodable, Equatable {
+    let id: String?
+    let status: String?
+    let entityClassVersion: Int
+    let payload: AnyJSON?
+
+    init(id: String? = nil, status: String? = nil, entityClassVersion: Int, payload: AnyJSON? = nil) {
+      self.id = id
+      self.status = status
+      self.entityClassVersion = entityClassVersion
+      self.payload = payload
+    }
+  }
+
+  struct ReplaceBody: JSONCodable, Equatable {
+    let status: String?
+    let entityClassVersion: Int
+    let payload: AnyJSON?
+
+    init(status: String? = nil, entityClassVersion: Int, payload: AnyJSON? = nil) {
+      self.status = status
+      self.entityClassVersion = entityClassVersion
+      self.payload = payload
+    }
+  }
+
+  init(_ endpoint: Endpoint, configuration: RouterConfiguration, customHeaders: [String: String] = [:]) {
+    self.endpoint = endpoint
+    self.configuration = configuration
+    self.customHeaders = customHeaders
+  }
+
+  var endpoint: Endpoint
+  var configuration: RouterConfiguration
+  var customHeaders: [String: String]
+
+  var service: PubNubService {
+    .dataSync
+  }
+
+  var category: String {
+    endpoint.description
+  }
+
+  var pamVersion: PAMVersionRequirement {
+    .version3
+  }
+
+  var path: Result<String, Error> {
+    let base = "/v1/datasync/subkeys/\(subscribeKey)/users"
+
+    switch endpoint {
+    case .all, .create:
+      return .success(base)
+    case let .fetch(id):
+      return .success("\(base)/\(id.urlEncodeSlash)")
+    case let .replace(id, _, _):
+      return .success("\(base)/\(id.urlEncodeSlash)")
+    case let .patch(id, _, _):
+      return .success("\(base)/\(id.urlEncodeSlash)")
+    case let .remove(id, _):
+      return .success("\(base)/\(id.urlEncodeSlash)")
+    }
+  }
+
+  var queryItems: Result<[URLQueryItem], Error> {
+    var query = defaultQueryItems
+
+    switch endpoint {
+    case let .all(entityClassVersion, cursor, limit, filter, filterAdvanced, sort):
+      query.appendIfPresent(key: .entityClassVersion, value: entityClassVersion?.description)
+      query.appendIfPresent(key: .cursor, value: cursor)
+      query.appendIfPresent(key: .limit, value: limit?.description)
+      query.appendIfPresent(key: .filter, value: filter)
+      query.appendIfPresent(key: .filterAdvanced, value: filterAdvanced)
+      query.appendIfPresent(key: .sort, value: sort)
+    default:
+      break
+    }
+
+    return .success(query)
+  }
+
+  var method: HTTPMethod {
+    switch endpoint {
+    case .all: return .get
+    case .fetch: return .get
+    case .create: return .post
+    case .replace: return .put
+    case .patch: return .patch
+    case .remove: return .delete
+    }
+  }
+
+  var body: Result<Data?, Error> {
+    switch endpoint {
+    case let .create(body):
+      return body.jsonDataResult.map { .some($0) }
+    case let .replace(_, body, _):
+      return body.jsonDataResult.map { .some($0) }
+    case let .patch(_, operations, _):
+      return operations.encodableJSONData.map { .some($0) }
+    default:
+      return .success(nil)
+    }
+  }
+
+  var additionalHeaders: [String: String] {
+    var headers = customHeaders
+
+    switch endpoint {
+    case .create:
+      headers[Constant.contentTypeHeaderKey] = DataSyncHeader.contentType(resource: "user")
+    case let .replace(_, _, ifMatch):
+      headers[Constant.contentTypeHeaderKey] = DataSyncHeader.contentType(resource: "user")
+      headers[DataSyncHeader.ifMatch] = ifMatch
+    case let .patch(_, _, ifMatch):
+      headers[Constant.contentTypeHeaderKey] = DataSyncHeader.jsonPatchContentType
+      headers[DataSyncHeader.ifMatch] = ifMatch
+    case let .remove(_, ifMatch):
+      headers[DataSyncHeader.ifMatch] = ifMatch
+    default:
+      break
+    }
+
+    return headers.compactMapValues { $0 }
+  }
+
+  var validationErrorDetail: String? {
+    switch endpoint {
+    case .all, .create:
+      return nil
+    case let .fetch(id):
+      return isInvalidForReason((id.isEmpty, ErrorDescription.emptyDataSyncId))
+    case let .replace(id, _, _):
+      return isInvalidForReason((id.isEmpty, ErrorDescription.emptyDataSyncId))
+    case let .patch(id, operations, _):
+      return isInvalidForReason(
+        (id.isEmpty, ErrorDescription.emptyDataSyncId),
+        (operations.isEmpty, ErrorDescription.emptyPatchOperations)
+      )
+    case let .remove(id, _):
+      return isInvalidForReason((id.isEmpty, ErrorDescription.emptyDataSyncId))
+    }
+  }
+}

--- a/Tests/PubNubUnitTests/Networking/Routers/DataSyncRouterTests.swift
+++ b/Tests/PubNubUnitTests/Networking/Routers/DataSyncRouterTests.swift
@@ -572,6 +572,42 @@ extension DataSyncRouterTests {
     XCTAssertEqual(body["relationshipClass"]?.stringOptional, "ProductOwner")
     XCTAssertEqual(body["relationshipClassVersion"]?.intOptional, 1)
   }
+
+  func test_RelationshipCreate_EmptyEntityAIdFailsValidation() throws {
+    let router = DataSyncRelationshipRouter(
+      .create(body: .init(
+        entityAId: "", entityBId: "s456", relationshipClass: "ProductOwner", relationshipClassVersion: 1
+      )),
+      configuration: config
+    )
+
+    XCTAssertEqual(router.validationError?.pubNubError?.reason, .missingRequiredParameter)
+    XCTAssertEqual(router.validationError?.pubNubError?.details.first, ErrorDescription.emptyRelationshipEntityAId)
+  }
+
+  func test_RelationshipCreate_EmptyEntityBIdFailsValidation() throws {
+    let router = DataSyncRelationshipRouter(
+      .create(body: .init(
+        entityAId: "u123", entityBId: "", relationshipClass: "ProductOwner", relationshipClassVersion: 1
+      )),
+      configuration: config
+    )
+
+    XCTAssertEqual(router.validationError?.pubNubError?.reason, .missingRequiredParameter)
+    XCTAssertEqual(router.validationError?.pubNubError?.details.first, ErrorDescription.emptyRelationshipEntityBId)
+  }
+
+  func test_RelationshipCreate_EmptyClassFailsValidation() throws {
+    let router = DataSyncRelationshipRouter(
+      .create(body: .init(
+        entityAId: "u123", entityBId: "s456", relationshipClass: "", relationshipClassVersion: 1
+      )),
+      configuration: config
+    )
+
+    XCTAssertEqual(router.validationError?.pubNubError?.reason, .missingRequiredParameter)
+    XCTAssertEqual(router.validationError?.pubNubError?.details.first, ErrorDescription.emptyRelationshipClass)
+  }
 }
 
 // MARK: - Response Decoders

--- a/Tests/PubNubUnitTests/Networking/Routers/DataSyncRouterTests.swift
+++ b/Tests/PubNubUnitTests/Networking/Routers/DataSyncRouterTests.swift
@@ -1,0 +1,488 @@
+//
+//  DataSyncRouterTests.swift
+//
+//  Copyright (c) PubNub Inc.
+//  All rights reserved.
+//
+//  This source code is licensed under the license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import XCTest
+@testable import PubNubSDK
+
+final class DataSyncRouterTests: XCTestCase {
+  let config = TestPubNubFactory.makeConfig(subscribeKey: "demo-sub")
+
+  private func queryValue(_ router: HTTPRouter, _ key: String) throws -> String? {
+    try router.queryItems.get().first { $0.name == key }?.value
+  }
+}
+
+// MARK: - Users: List
+
+extension DataSyncRouterTests {
+  func test_UserList_AllQueryItems() throws {
+    let endpoint = DataSyncUserRouter.Endpoint.all(
+      entityClassVersion: 2, cursor: "TjIw", limit: 25,
+      filter: "status=='active'", filterAdvanced: "a AND b", sort: "+name"
+    )
+    let router = DataSyncUserRouter(
+      endpoint,
+      configuration: config
+    )
+
+    XCTAssertEqual(router.method, .get)
+    XCTAssertEqual(try router.path.get(), "/v1/datasync/subkeys/demo-sub/users")
+    XCTAssertEqual(try queryValue(router, "entity_class_version"), "2")
+    XCTAssertEqual(try queryValue(router, "cursor"), "TjIw")
+    XCTAssertEqual(try queryValue(router, "limit"), "25")
+    XCTAssertEqual(try queryValue(router, "filter"), "status=='active'")
+    XCTAssertEqual(try queryValue(router, "filter_advanced"), "a AND b")
+    XCTAssertEqual(try queryValue(router, "sort"), "+name")
+  }
+}
+
+// MARK: - Users: Fetch
+
+extension DataSyncRouterTests {
+  func test_UserFetch_Endpoint() throws {
+    let router = DataSyncUserRouter(.fetch(id: "alice"), configuration: config)
+    let request = try router.asURLRequest.get()
+
+    XCTAssertEqual(router.method, .get)
+    XCTAssertEqual(try router.path.get(), "/v1/datasync/subkeys/demo-sub/users/alice")
+    XCTAssertNil(router.validationError)
+    XCTAssertNil(request.httpBody)
+    XCTAssertNil(request.value(forHTTPHeaderField: "Content-Type"))
+  }
+
+  func test_UserFetch_EmptyIdFailsValidation() throws {
+    let router = DataSyncUserRouter(.fetch(id: ""), configuration: config)
+
+    XCTAssertEqual(router.method, .get)
+    XCTAssertEqual(router.validationError?.pubNubError?.reason, .missingRequiredParameter)
+  }
+}
+
+// MARK: - Users: Create
+
+extension DataSyncRouterTests {
+  func test_UserCreate_Endpoint() throws {
+    let router = DataSyncUserRouter(
+      .create(body: .init(id: "alice", entityClassVersion: 1, payload: ["name": "Alice"])),
+      configuration: config
+    )
+
+    let request = try router.asURLRequest.get()
+
+    XCTAssertEqual(router.method, .post)
+    XCTAssertEqual(try router.path.get(), "/v1/datasync/subkeys/demo-sub/users")
+    XCTAssertNil(router.validationError)
+    XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/vnd.pubnub.objects.user+json;version=1")
+    XCTAssertNotNil(request.httpBody)
+  }
+}
+
+// MARK: - Users: Replace
+
+extension DataSyncRouterTests {
+  func test_UserReplace_Endpoint() throws {
+    let router = DataSyncUserRouter(
+      .replace(id: "alice", body: .init(entityClassVersion: 1), ifMatch: "\"5\""),
+      configuration: config
+    )
+
+    let request = try router.asURLRequest.get()
+
+    XCTAssertEqual(router.method, .put)
+    XCTAssertEqual(try router.path.get(), "/v1/datasync/subkeys/demo-sub/users/alice")
+    XCTAssertNil(router.validationError)
+    XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/vnd.pubnub.objects.user+json;version=1")
+    XCTAssertEqual(request.value(forHTTPHeaderField: "If-Match"), "\"5\"")
+    XCTAssertNotNil(request.httpBody)
+  }
+
+  func test_UserReplace_EmptyIdFailsValidation() throws {
+    let router = DataSyncUserRouter(
+      .replace(id: "", body: .init(entityClassVersion: 1), ifMatch: nil),
+      configuration: config
+    )
+
+    XCTAssertEqual(router.method, .put)
+    XCTAssertEqual(router.validationError?.pubNubError?.reason, .missingRequiredParameter)
+  }
+}
+
+// MARK: - Users: Patch
+
+extension DataSyncRouterTests {
+  func test_UserPatch_Endpoint() throws {
+    let ops: [JSONPatchOperation] = [
+      .replace(path: "/payload/profileUrl", value: "https://x")
+    ]
+    let router = DataSyncUserRouter(
+      .patch(id: "alice", operations: ops, ifMatch: "\"2\""),
+      configuration: config
+    )
+
+    let request = try router.asURLRequest.get()
+
+    XCTAssertEqual(router.method, .patch)
+    XCTAssertEqual(try router.path.get(), "/v1/datasync/subkeys/demo-sub/users/alice")
+    XCTAssertNil(router.validationError)
+    XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json-patch+json")
+    XCTAssertEqual(request.value(forHTTPHeaderField: "If-Match"), "\"2\"")
+    XCTAssertNotNil(request.httpBody)
+  }
+
+  func test_UserPatch_EmptyOperationsFailsValidation() throws {
+    let router = DataSyncUserRouter(.patch(id: "alice", operations: [], ifMatch: nil), configuration: config)
+
+    XCTAssertEqual(router.method, .patch)
+    XCTAssertEqual(router.validationError?.pubNubError?.reason, .missingRequiredParameter)
+  }
+}
+
+// MARK: - Users: Remove
+
+extension DataSyncRouterTests {
+  func test_UserRemove_Endpoint() throws {
+    let router = DataSyncUserRouter(.remove(id: "alice", ifMatch: "\"9\""), configuration: config)
+    let request = try router.asURLRequest.get()
+
+    XCTAssertEqual(router.method, .delete)
+    XCTAssertEqual(try router.path.get(), "/v1/datasync/subkeys/demo-sub/users/alice")
+    XCTAssertNil(router.validationError)
+    XCTAssertEqual(request.value(forHTTPHeaderField: "If-Match"), "\"9\"")
+    XCTAssertNil(request.httpBody)
+  }
+
+  func test_UserRemove_OmitsIfMatchWhenNil() throws {
+    let router = DataSyncUserRouter(.remove(id: "alice", ifMatch: nil), configuration: config)
+    let request = try router.asURLRequest.get()
+
+    XCTAssertEqual(router.method, .delete)
+    XCTAssertEqual(try router.path.get(), "/v1/datasync/subkeys/demo-sub/users/alice")
+    XCTAssertNil(router.validationError)
+    XCTAssertNil(request.value(forHTTPHeaderField: "If-Match"))
+  }
+}
+
+// MARK: - Channels
+
+extension DataSyncRouterTests {
+  func test_ChannelFetch_Endpoint() throws {
+    let router = DataSyncChannelRouter(.fetch(id: "general"), configuration: config)
+
+    XCTAssertEqual(router.method, .get)
+    XCTAssertEqual(try router.path.get(), "/v1/datasync/subkeys/demo-sub/channels/general")
+    XCTAssertNil(router.validationError)
+  }
+
+  func test_ChannelCreate_SetsVendorContentType() throws {
+    let router = DataSyncChannelRouter(
+      .create(body: .init(entityClassVersion: 1)),
+      configuration: config
+    )
+
+    let request = try router.asURLRequest.get()
+
+    XCTAssertEqual(router.method, .post)
+    XCTAssertEqual(try router.path.get(), "/v1/datasync/subkeys/demo-sub/channels")
+    XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/vnd.pubnub.objects.channel+json;version=1")
+  }
+
+  func test_ChannelReplace_SetsVendorContentTypeAndIfMatch() throws {
+    let router = DataSyncChannelRouter(
+      .replace(id: "general", body: .init(entityClassVersion: 1), ifMatch: "\"5\""),
+      configuration: config
+    )
+
+    let request = try router.asURLRequest.get()
+
+    XCTAssertEqual(router.method, .put)
+    XCTAssertEqual(try router.path.get(), "/v1/datasync/subkeys/demo-sub/channels/general")
+    XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/vnd.pubnub.objects.channel+json;version=1")
+    XCTAssertEqual(request.value(forHTTPHeaderField: "If-Match"), "\"5\"")
+  }
+}
+
+// MARK: - Memberships
+
+extension DataSyncRouterTests {
+  func test_MembershipFetch_Endpoint() throws {
+    let router = DataSyncMembershipRouter(.fetch(id: "m-1"), configuration: config)
+
+    XCTAssertEqual(router.method, .get)
+    XCTAssertEqual(try router.path.get(), "/v1/datasync/subkeys/demo-sub/memberships/m-1")
+    XCTAssertNil(router.validationError)
+  }
+
+  func test_MembershipList_FilterQueryItems() throws {
+    let endpoint = DataSyncMembershipRouter.Endpoint.all(
+      userId: "alice", channelId: "general", relationshipClassVersion: 1,
+      cursor: nil, limit: nil, filter: nil, filterAdvanced: nil, sort: nil
+    )
+
+    let router = DataSyncMembershipRouter(endpoint, configuration: config)
+
+    XCTAssertEqual(router.method, .get)
+    XCTAssertEqual(try router.path.get(), "/v1/datasync/subkeys/demo-sub/memberships")
+    XCTAssertNil(router.validationError)
+    XCTAssertEqual(try queryValue(router, "user_id"), "alice")
+    XCTAssertEqual(try queryValue(router, "channel_id"), "general")
+    XCTAssertEqual(try queryValue(router, "relationship_class_version"), "1")
+  }
+
+  func test_MembershipCreate_SetsVendorContentType() throws {
+    let endpoint = DataSyncMembershipRouter.Endpoint.create(
+      body: .init(
+        channelId: "general",
+        userId: "alice",
+        relationshipClassVersion: 1
+      )
+    )
+
+    let router = DataSyncMembershipRouter(endpoint, configuration: config)
+    let request = try router.asURLRequest.get()
+
+    XCTAssertEqual(router.method, .post)
+    XCTAssertEqual(try router.path.get(), "/v1/datasync/subkeys/demo-sub/memberships")
+    XCTAssertNil(router.validationError)
+    XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/vnd.pubnub.objects.membership+json;version=1")
+  }
+}
+
+// MARK: - Entities
+
+extension DataSyncRouterTests {
+  func test_EntityFetch_Endpoint() throws {
+    let router = DataSyncEntityRouter(.fetch(id: "i789"), configuration: config)
+
+    XCTAssertEqual(router.method, .get)
+    XCTAssertEqual(try router.path.get(), "/v1/datasync/subkeys/demo-sub/entities/i789")
+    XCTAssertNil(router.validationError)
+  }
+
+  func test_EntityList_RequiresEntityClassQueryItem() throws {
+    let router = DataSyncEntityRouter(
+      .all(entityClass: "user", entityClassVersion: nil, cursor: nil, limit: nil, filter: nil, filterAdvanced: nil, sort: nil),
+      configuration: config
+    )
+
+    XCTAssertEqual(router.method, .get)
+    XCTAssertEqual(try router.path.get(), "/v1/datasync/subkeys/demo-sub/entities")
+    XCTAssertNil(router.validationError)
+    XCTAssertEqual(try queryValue(router, "entity_class"), "user")
+  }
+
+  func test_EntityList_MissingEntityClassFailsValidation() throws {
+    let router = DataSyncEntityRouter(
+      .all(entityClass: "", entityClassVersion: nil, cursor: nil, limit: nil, filter: nil, filterAdvanced: nil, sort: nil),
+      configuration: config
+    )
+
+    XCTAssertEqual(router.validationError?.pubNubError?.reason, .missingRequiredParameter)
+  }
+
+  func test_EntityCreate_SetsVendorContentType() throws {
+    let router = DataSyncEntityRouter(
+      .create(body: .init(entityClass: "user", entityClassVersion: 1)),
+      configuration: config
+    )
+
+    let request = try router.asURLRequest.get()
+
+    XCTAssertEqual(router.method, .post)
+    XCTAssertEqual(try router.path.get(), "/v1/datasync/subkeys/demo-sub/entities")
+    XCTAssertNil(router.validationError)
+    XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/vnd.pubnub.objects.entity+json;version=1")
+  }
+}
+
+// MARK: - Relationships
+
+extension DataSyncRouterTests {
+  func test_RelationshipFetch_Endpoint() throws {
+    let router = DataSyncRelationshipRouter(.fetch(id: "r-1"), configuration: config)
+
+    XCTAssertEqual(router.method, .get)
+    XCTAssertEqual(try router.path.get(), "/v1/datasync/subkeys/demo-sub/relationships/r-1")
+    XCTAssertNil(router.validationError)
+  }
+
+  func test_RelationshipList_FilterQueryItems() throws {
+    let router = DataSyncRelationshipRouter(
+      .all(
+        relationshipClass: "ProductOwner", entityAId: "u123", entityBId: "s456",
+        relationshipClassVersion: nil, cursor: nil, limit: nil, filter: nil, filterAdvanced: nil, sort: nil
+      ),
+      configuration: config
+    )
+
+    XCTAssertEqual(router.method, .get)
+    XCTAssertEqual(try router.path.get(), "/v1/datasync/subkeys/demo-sub/relationships")
+    XCTAssertNil(router.validationError)
+    XCTAssertEqual(try queryValue(router, "relationship_class"), "ProductOwner")
+    XCTAssertEqual(try queryValue(router, "entity_a_id"), "u123")
+    XCTAssertEqual(try queryValue(router, "entity_b_id"), "s456")
+  }
+
+  func test_RelationshipList_MissingClassFailsValidation() throws {
+    let router = DataSyncRelationshipRouter(
+      .all(
+        relationshipClass: "", entityAId: nil, entityBId: nil, relationshipClassVersion: nil,
+        cursor: nil, limit: nil, filter: nil, filterAdvanced: nil, sort: nil
+      ),
+      configuration: config
+    )
+
+    XCTAssertEqual(router.validationError?.pubNubError?.reason, .missingRequiredParameter)
+  }
+
+  func test_RelationshipCreate_SetsVendorContentType() throws {
+    let router = DataSyncRelationshipRouter(
+      .create(
+        body: .init(
+          entityAId: "u123",
+          entityBId: "s456",
+          relationshipClass: "ProductOwner",
+          relationshipClassVersion: 1
+        )
+      ),
+      configuration: config
+    )
+
+    let request = try router.asURLRequest.get()
+
+    XCTAssertEqual(router.method, .post)
+    XCTAssertEqual(try router.path.get(), "/v1/datasync/subkeys/demo-sub/relationships")
+    XCTAssertNil(router.validationError)
+    XCTAssertEqual(
+      request.value(forHTTPHeaderField: "Content-Type"),
+       "application/vnd.pubnub.objects.relationship+json;version=1"
+    )
+  }
+}
+
+// MARK: - Response Decoders
+
+extension DataSyncRouterTests {
+  func test_DecodeSingleResourceEnvelope() throws {
+    let json = """
+    {
+      "data": {
+        "id": "alice", "status": "active", "entityClassVersion": 1,
+        "createdAt": "2021-01-01T00:00:00.000Z", "updatedAt": "2021-01-01T00:00:00.000Z",
+        "eTag": "1", "payload": { "name": "Alice", "email": "alice@example.com" }
+      }
+    }
+    """
+
+    let response = try Constant.jsonDecoder.decode(
+      DataSyncSingleResponse<DataSyncResource>.self,
+      from: XCTUnwrap(json.data(using: .utf8))
+    )
+
+    XCTAssertEqual(response.data.id, "alice")
+    XCTAssertEqual(response.data.status, "active")
+    XCTAssertEqual(response.data.entityClassVersion, 1)
+    XCTAssertEqual(response.data.eTag, "1")
+  }
+
+  func test_DecodeListEnvelopeWithMeta() throws {
+    let json = """
+    {
+      "data": [
+        { "id": "alice", "entityClassVersion": 1, "eTag": "1" }
+      ],
+      "links": { "self": "/users?limit=20", "next": "/users?cursor=TjIw" },
+      "meta": { "has_next": true, "next_cursor": "TjIw", "limit": 20 }
+    }
+    """
+
+    let response = try Constant.jsonDecoder.decode(
+      DataSyncListResponse<DataSyncResource>.self,
+      from: XCTUnwrap(json.data(using: .utf8))
+    )
+
+    XCTAssertEqual(response.data.count, 1)
+    XCTAssertEqual(response.data.first?.id, "alice")
+    XCTAssertEqual(response.meta?.nextCursor, "TjIw")
+    XCTAssertEqual(response.meta?.hasNext, true)
+    XCTAssertEqual(response.meta?.limit, 20)
+    XCTAssertEqual(response.links?.next, "/users?cursor=TjIw")
+  }
+
+  func test_DecodeRelationshipResourceFields() throws {
+    let json = """
+    {
+      "data": {
+        "id": "r-123", "entityAId": "u123", "entityBId": "s456",
+        "relationshipClass": "ProductOwner", "relationshipClassVersion": 1,
+        "status": "active", "eTag": "1", "payload": { "custom": "fields" }
+      }
+    }
+    """
+
+    let response = try Constant.jsonDecoder.decode(
+      DataSyncSingleResponse<DataSyncResource>.self,
+      from: XCTUnwrap(json.data(using: .utf8))
+    )
+
+    XCTAssertEqual(response.data.id, "r-123")
+    XCTAssertEqual(response.data.entityAId, "u123")
+    XCTAssertEqual(response.data.entityBId, "s456")
+    XCTAssertEqual(response.data.relationshipClass, "ProductOwner")
+    XCTAssertEqual(response.data.relationshipClassVersion, 1)
+    XCTAssertEqual(response.data.status, "active")
+    XCTAssertEqual(response.data.eTag, "1")
+    XCTAssertEqual(response.data.payload?["custom"], "fields")
+  }
+}
+
+// MARK: - asURLRequest Content-Type regression
+
+extension DataSyncRouterTests {
+  func test_RouterSuppliedContentTypeSurvivesWithBody() throws {
+    // A router with an explicit Content-Type should not be overridden by the default.
+    let router = DataSyncUserRouter(
+      .create(body: .init(entityClassVersion: 1)),
+      configuration: config
+    )
+
+    let request = try router.asURLRequest.get()
+
+    XCTAssertEqual(
+      request.value(forHTTPHeaderField: "Content-Type"),
+       "application/vnd.pubnub.objects.user+json;version=1"
+    )
+    XCTAssertNotEqual(
+      request.value(forHTTPHeaderField: "Content-Type"),
+      Constant.defaultContentTypeHeader
+    )
+  }
+
+  func test_DefaultContentTypeStillAppliedWhenRouterSuppliesNone() throws {
+    // A router with a body but no explicit Content-Type still gets the default.
+    let router = PublishRouter(
+      PublishRouter.Endpoint.compressedPublish(
+        message: ["msg"],
+        channel: "c",
+        customMessageType: nil,
+        shouldStore: nil,
+        ttl: nil,
+        meta: nil
+      ),
+      configuration: config
+    )
+
+    let request = try router.asURLRequest.get()
+
+    XCTAssertEqual(
+      request.value(forHTTPHeaderField: "Content-Type"),
+      Constant.defaultContentTypeHeader
+    )
+  }
+}

--- a/Tests/PubNubUnitTests/Networking/Routers/DataSyncRouterTests.swift
+++ b/Tests/PubNubUnitTests/Networking/Routers/DataSyncRouterTests.swift
@@ -416,6 +416,26 @@ extension DataSyncRouterTests {
     XCTAssertEqual(body["userId"]?.stringOptional, "alice")
     XCTAssertEqual(body["relationshipClassVersion"]?.intOptional, 1)
   }
+
+  func test_MembershipCreate_EmptyChannelIdFailsValidation() throws {
+    let router = DataSyncMembershipRouter(
+      .create(body: .init(channelId: "", userId: "alice", relationshipClassVersion: 1)),
+      configuration: config
+    )
+
+    XCTAssertEqual(router.validationError?.pubNubError?.reason, .missingRequiredParameter)
+    XCTAssertEqual(router.validationError?.pubNubError?.details.first, ErrorDescription.emptyMembershipChannelId)
+  }
+
+  func test_MembershipCreate_EmptyUserIdFailsValidation() throws {
+    let router = DataSyncMembershipRouter(
+      .create(body: .init(channelId: "general", userId: "", relationshipClassVersion: 1)),
+      configuration: config
+    )
+
+    XCTAssertEqual(router.validationError?.pubNubError?.reason, .missingRequiredParameter)
+    XCTAssertEqual(router.validationError?.pubNubError?.details.first, ErrorDescription.emptyMembershipUserId)
+  }
 }
 
 // MARK: - Entities
@@ -468,6 +488,16 @@ extension DataSyncRouterTests {
 
     XCTAssertEqual(body["entityClass"]?.stringOptional, "user")
     XCTAssertEqual(body["entityClassVersion"]?.intOptional, 1)
+  }
+
+  func test_EntityCreate_EmptyEntityClassFailsValidation() throws {
+    let router = DataSyncEntityRouter(
+      .create(body: .init(entityClass: "", entityClassVersion: 1)),
+      configuration: config
+    )
+
+    XCTAssertEqual(router.validationError?.pubNubError?.reason, .missingRequiredParameter)
+    XCTAssertEqual(router.validationError?.pubNubError?.details.first, ErrorDescription.emptyEntityClass)
   }
 }
 

--- a/Tests/PubNubUnitTests/Networking/Routers/DataSyncRouterTests.swift
+++ b/Tests/PubNubUnitTests/Networking/Routers/DataSyncRouterTests.swift
@@ -17,6 +17,24 @@ final class DataSyncRouterTests: XCTestCase {
   private func queryValue(_ router: HTTPRouter, _ key: String) throws -> String? {
     try router.queryItems.get().first { $0.name == key }?.value
   }
+
+  private func queryNames(_ router: HTTPRouter) throws -> Set<String> {
+    Set(try router.queryItems.get().map { $0.name })
+  }
+
+  private func decodeBody(_ router: HTTPRouter) throws -> AnyJSON {
+    let request = try router.asURLRequest.get()
+    let body = try XCTUnwrap(request.httpBody)
+
+    return try Constant.jsonDecoder.decode(AnyJSON.self, from: body)
+  }
+
+  private func decodeBodyArray(_ router: HTTPRouter) throws -> [AnyJSON] {
+    let request = try router.asURLRequest.get()
+    let body = try XCTUnwrap(request.httpBody)
+
+    return try Constant.jsonDecoder.decode([AnyJSON].self, from: body)
+  }
 }
 
 // MARK: - Users: List
@@ -32,14 +50,37 @@ extension DataSyncRouterTests {
       configuration: config
     )
 
+    XCTAssertEqual(router.service, .dataSync)
+    XCTAssertEqual(router.pamVersion, .version3)
     XCTAssertEqual(router.method, .get)
     XCTAssertEqual(try router.path.get(), "/v1/datasync/subkeys/demo-sub/users")
+    XCTAssertNil(router.validationError)
     XCTAssertEqual(try queryValue(router, "entity_class_version"), "2")
     XCTAssertEqual(try queryValue(router, "cursor"), "TjIw")
     XCTAssertEqual(try queryValue(router, "limit"), "25")
     XCTAssertEqual(try queryValue(router, "filter"), "status=='active'")
     XCTAssertEqual(try queryValue(router, "filter_advanced"), "a AND b")
     XCTAssertEqual(try queryValue(router, "sort"), "+name")
+  }
+
+  func test_UserList_OmitsNilQueryItems() throws {
+    let endpoint = DataSyncUserRouter.Endpoint.all(
+      entityClassVersion: nil, cursor: nil, limit: nil,
+      filter: nil, filterAdvanced: nil, sort: nil
+    )
+    let router = DataSyncUserRouter(
+      endpoint,
+      configuration: config
+    )
+
+    let names = try queryNames(router)
+
+    XCTAssertFalse(names.contains("entity_class_version"))
+    XCTAssertFalse(names.contains("cursor"))
+    XCTAssertFalse(names.contains("limit"))
+    XCTAssertFalse(names.contains("filter"))
+    XCTAssertFalse(names.contains("filter_advanced"))
+    XCTAssertFalse(names.contains("sort"))
   }
 }
 
@@ -62,6 +103,13 @@ extension DataSyncRouterTests {
 
     XCTAssertEqual(router.method, .get)
     XCTAssertEqual(router.validationError?.pubNubError?.reason, .missingRequiredParameter)
+    XCTAssertEqual(router.validationError?.pubNubError?.details.first, ErrorDescription.emptyDataSyncId)
+  }
+
+  func test_UserFetch_EncodesSlashInId() throws {
+    let router = DataSyncUserRouter(.fetch(id: "a/b"), configuration: config)
+
+    XCTAssertEqual(try router.path.get(), "/v1/datasync/subkeys/demo-sub/users/a%2Fb")
   }
 }
 
@@ -80,7 +128,12 @@ extension DataSyncRouterTests {
     XCTAssertEqual(try router.path.get(), "/v1/datasync/subkeys/demo-sub/users")
     XCTAssertNil(router.validationError)
     XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/vnd.pubnub.objects.user+json;version=1")
-    XCTAssertNotNil(request.httpBody)
+
+    let body = try decodeBody(router)
+
+    XCTAssertEqual(body["id"]?.stringOptional, "alice")
+    XCTAssertEqual(body["entityClassVersion"]?.intOptional, 1)
+    XCTAssertEqual(body["payload"]?["name"]?.stringOptional, "Alice")
   }
 }
 
@@ -100,7 +153,9 @@ extension DataSyncRouterTests {
     XCTAssertNil(router.validationError)
     XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/vnd.pubnub.objects.user+json;version=1")
     XCTAssertEqual(request.value(forHTTPHeaderField: "If-Match"), "\"5\"")
-    XCTAssertNotNil(request.httpBody)
+
+    let body = try decodeBody(router)
+    XCTAssertEqual(body["entityClassVersion"]?.intOptional, 1)
   }
 
   func test_UserReplace_EmptyIdFailsValidation() throws {
@@ -111,6 +166,7 @@ extension DataSyncRouterTests {
 
     XCTAssertEqual(router.method, .put)
     XCTAssertEqual(router.validationError?.pubNubError?.reason, .missingRequiredParameter)
+    XCTAssertEqual(router.validationError?.pubNubError?.details.first, ErrorDescription.emptyDataSyncId)
   }
 }
 
@@ -133,7 +189,13 @@ extension DataSyncRouterTests {
     XCTAssertNil(router.validationError)
     XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json-patch+json")
     XCTAssertEqual(request.value(forHTTPHeaderField: "If-Match"), "\"2\"")
-    XCTAssertNotNil(request.httpBody)
+
+    let encodedOps = try decodeBodyArray(router)
+
+    XCTAssertEqual(encodedOps.count, 1)
+    XCTAssertEqual(encodedOps.first?["op"]?.stringOptional, "replace")
+    XCTAssertEqual(encodedOps.first?["path"]?.stringOptional, "/payload/profileUrl")
+    XCTAssertEqual(encodedOps.first?["value"]?.stringOptional, "https://x")
   }
 
   func test_UserPatch_EmptyOperationsFailsValidation() throws {
@@ -141,6 +203,7 @@ extension DataSyncRouterTests {
 
     XCTAssertEqual(router.method, .patch)
     XCTAssertEqual(router.validationError?.pubNubError?.reason, .missingRequiredParameter)
+    XCTAssertEqual(router.validationError?.pubNubError?.details.first, ErrorDescription.emptyPatchOperations)
   }
 }
 
@@ -166,6 +229,71 @@ extension DataSyncRouterTests {
     XCTAssertEqual(try router.path.get(), "/v1/datasync/subkeys/demo-sub/users/alice")
     XCTAssertNil(router.validationError)
     XCTAssertNil(request.value(forHTTPHeaderField: "If-Match"))
+  }
+}
+
+// MARK: - JSONPatchOperation encoding
+
+extension DataSyncRouterTests {
+  private func encode(_ op: JSONPatchOperation) throws -> AnyJSON {
+    let data = try Constant.jsonEncoder.encode([op])
+    let array = try Constant.jsonDecoder.decode([AnyJSON].self, from: data)
+
+    return try XCTUnwrap(array.first)
+  }
+
+  func test_JSONPatch_Add() throws {
+    let json = try encode(.add(path: "/payload/a", value: 1))
+
+    XCTAssertEqual(json["op"]?.stringOptional, "add")
+    XCTAssertEqual(json["path"]?.stringOptional, "/payload/a")
+    XCTAssertEqual(json["value"]?.intOptional, 1)
+    XCTAssertNil(json["from"])
+  }
+
+  func test_JSONPatch_Remove() throws {
+    let json = try encode(.remove(path: "/payload/a"))
+
+    XCTAssertEqual(json["op"]?.stringOptional, "remove")
+    XCTAssertEqual(json["path"]?.stringOptional, "/payload/a")
+    XCTAssertNil(json["value"])
+    XCTAssertNil(json["from"])
+  }
+
+  func test_JSONPatch_Replace() throws {
+    let json = try encode(.replace(path: "/payload/a", value: "x"))
+
+    XCTAssertEqual(json["op"]?.stringOptional, "replace")
+    XCTAssertEqual(json["path"]?.stringOptional, "/payload/a")
+    XCTAssertEqual(json["value"]?.stringOptional, "x")
+    XCTAssertNil(json["from"])
+  }
+
+  func test_JSONPatch_Move() throws {
+    let json = try encode(.move(from: "/payload/a", path: "/payload/b"))
+
+    XCTAssertEqual(json["op"]?.stringOptional, "move")
+    XCTAssertEqual(json["from"]?.stringOptional, "/payload/a")
+    XCTAssertEqual(json["path"]?.stringOptional, "/payload/b")
+    XCTAssertNil(json["value"])
+  }
+
+  func test_JSONPatch_Copy() throws {
+    let json = try encode(.copy(from: "/payload/a", path: "/payload/b"))
+
+    XCTAssertEqual(json["op"]?.stringOptional, "copy")
+    XCTAssertEqual(json["from"]?.stringOptional, "/payload/a")
+    XCTAssertEqual(json["path"]?.stringOptional, "/payload/b")
+    XCTAssertNil(json["value"])
+  }
+
+  func test_JSONPatch_Test() throws {
+    let json = try encode(.test(path: "/payload/a", value: true))
+
+    XCTAssertEqual(json["op"]?.stringOptional, "test")
+    XCTAssertEqual(json["path"]?.stringOptional, "/payload/a")
+    XCTAssertEqual(json["value"]?.boolOptional, true)
+    XCTAssertNil(json["from"])
   }
 }
 
@@ -206,6 +334,28 @@ extension DataSyncRouterTests {
     XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/vnd.pubnub.objects.channel+json;version=1")
     XCTAssertEqual(request.value(forHTTPHeaderField: "If-Match"), "\"5\"")
   }
+
+  func test_ChannelPatch_SetsJsonPatchContentType() throws {
+    let router = DataSyncChannelRouter(
+      .patch(id: "general", operations: [.remove(path: "/payload/x")], ifMatch: "\"3\""),
+      configuration: config
+    )
+
+    let request = try router.asURLRequest.get()
+
+    XCTAssertEqual(router.method, .patch)
+    XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json-patch+json")
+    XCTAssertEqual(request.value(forHTTPHeaderField: "If-Match"), "\"3\"")
+  }
+
+  func test_ChannelRemove_OmitsIfMatchWhenNil() throws {
+    let router = DataSyncChannelRouter(.remove(id: "general", ifMatch: nil), configuration: config)
+    let request = try router.asURLRequest.get()
+
+    XCTAssertEqual(router.method, .delete)
+    XCTAssertNil(request.value(forHTTPHeaderField: "If-Match"))
+    XCTAssertNil(request.httpBody)
+  }
 }
 
 // MARK: - Memberships
@@ -233,6 +383,14 @@ extension DataSyncRouterTests {
     XCTAssertEqual(try queryValue(router, "user_id"), "alice")
     XCTAssertEqual(try queryValue(router, "channel_id"), "general")
     XCTAssertEqual(try queryValue(router, "relationship_class_version"), "1")
+
+    let names = try queryNames(router)
+
+    XCTAssertFalse(names.contains("cursor"))
+    XCTAssertFalse(names.contains("limit"))
+    XCTAssertFalse(names.contains("filter"))
+    XCTAssertFalse(names.contains("filter_advanced"))
+    XCTAssertFalse(names.contains("sort"))
   }
 
   func test_MembershipCreate_SetsVendorContentType() throws {
@@ -251,6 +409,12 @@ extension DataSyncRouterTests {
     XCTAssertEqual(try router.path.get(), "/v1/datasync/subkeys/demo-sub/memberships")
     XCTAssertNil(router.validationError)
     XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/vnd.pubnub.objects.membership+json;version=1")
+
+    let body = try decodeBody(router)
+
+    XCTAssertEqual(body["channelId"]?.stringOptional, "general")
+    XCTAssertEqual(body["userId"]?.stringOptional, "alice")
+    XCTAssertEqual(body["relationshipClassVersion"]?.intOptional, 1)
   }
 }
 
@@ -284,6 +448,7 @@ extension DataSyncRouterTests {
     )
 
     XCTAssertEqual(router.validationError?.pubNubError?.reason, .missingRequiredParameter)
+    XCTAssertEqual(router.validationError?.pubNubError?.details.first, ErrorDescription.emptyEntityClass)
   }
 
   func test_EntityCreate_SetsVendorContentType() throws {
@@ -298,6 +463,11 @@ extension DataSyncRouterTests {
     XCTAssertEqual(try router.path.get(), "/v1/datasync/subkeys/demo-sub/entities")
     XCTAssertNil(router.validationError)
     XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/vnd.pubnub.objects.entity+json;version=1")
+
+    let body = try decodeBody(router)
+
+    XCTAssertEqual(body["entityClass"]?.stringOptional, "user")
+    XCTAssertEqual(body["entityClassVersion"]?.intOptional, 1)
   }
 }
 
@@ -339,6 +509,7 @@ extension DataSyncRouterTests {
     )
 
     XCTAssertEqual(router.validationError?.pubNubError?.reason, .missingRequiredParameter)
+    XCTAssertEqual(router.validationError?.pubNubError?.details.first, ErrorDescription.emptyRelationshipClass)
   }
 
   func test_RelationshipCreate_SetsVendorContentType() throws {
@@ -363,6 +534,13 @@ extension DataSyncRouterTests {
       request.value(forHTTPHeaderField: "Content-Type"),
        "application/vnd.pubnub.objects.relationship+json;version=1"
     )
+
+    let body = try decodeBody(router)
+
+    XCTAssertEqual(body["entityAId"]?.stringOptional, "u123")
+    XCTAssertEqual(body["entityBId"]?.stringOptional, "s456")
+    XCTAssertEqual(body["relationshipClass"]?.stringOptional, "ProductOwner")
+    XCTAssertEqual(body["relationshipClassVersion"]?.intOptional, 1)
   }
 }
 


### PR DESCRIPTION
- Add DataSync routers for channels, users, entities, memberships, and relationships
- Extend `HTTPRouter` with the `Data Sync` service and DataSync-specific query keys
- Add error descriptions for empty DataSync ids, entity/relationship classes, and patch operations
- Only set the default `Content-Type` header when the request doesn't already provide one
- Add unit test coverage for the new DataSync routers