### PR TITLE
Resolve entity naming clash between DataSync and subscribe APIs

### DIFF
--- a/Documentation/PubNub_11_0_Migration_Guide.md
+++ b/Documentation/PubNub_11_0_Migration_Guide.md
@@ -23,11 +23,11 @@ The initializers of `Subscription` and `SubscriptionSet` are no longer public. B
 ```swift
 // Before (10.0):
 let subscription = Subscription(entity: pubnub.channel("my-channel"))
-let set = SubscriptionSet(entities: [pubnub.channel("a"), pubnub.channelGroup("b")])
+let subscriptionSet = SubscriptionSet(entities: [pubnub.channel("a"), pubnub.channelGroup("b")])
 
 // Now (11.0):
 let subscription = pubnub.channel("my-channel").subscription()
-let set = pubnub.subscription(targets: [pubnub.channel("a"), pubnub.channelGroup("b")])
+let subscriptionSet = pubnub.subscription(targets: [pubnub.channel("a"), pubnub.channelGroup("b")])
 ```
 
 The `entities:` label is now `targets:`. In addition, the `Subscription.entity` property has been renamed to `Subscription.target` and is no longer public.

--- a/Documentation/PubNub_11_0_Migration_Guide.md
+++ b/Documentation/PubNub_11_0_Migration_Guide.md
@@ -16,7 +16,23 @@ For usage details, see the PubNub Swift SDK documentation.
 
 ## Breaking API Changes
 
-### 1. Unified Subscribe Event Model
+### 1. `Subscription` and `SubscriptionSet` Are Created Through Factory Methods
+
+The initializers of `Subscription` and `SubscriptionSet` are no longer public. Both types are now created only through the `PubNub` factory methods, which is how the documentation has always shown it.
+
+```swift
+// Before (10.0):
+let subscription = Subscription(entity: pubnub.channel("my-channel"))
+let set = SubscriptionSet(entities: [pubnub.channel("a"), pubnub.channelGroup("b")])
+
+// Now (11.0):
+let subscription = pubnub.channel("my-channel").subscription()
+let set = pubnub.subscription(targets: [pubnub.channel("a"), pubnub.channelGroup("b")])
+```
+
+The `entities:` label is now `targets:`. In addition, the `Subscription.entity` property has been renamed to `Subscription.target` and is no longer public.
+
+### 2. Unified Subscribe Event Model
 
 > **Note:** Skip this section if you use the modern listener API (`onMessage`, `onPresence`, …). Only the legacy `SubscriptionListener` is affected.
 
@@ -48,7 +64,7 @@ listener.didReceiveStatus = { status in
 
 Along with the types above, `CoreListener.MessageActionEvent`, `SubscribeResponseHeader`, and the `subscriptionChanged` / `responseReceived` cases of `PubNubSubscribeEvent` are removed.
 
-### 2. Listener Configuration Is Now Immutable
+### 3. Listener Configuration Is Now Immutable
 
 `BaseSubscriptionListener.queue` and `BaseSubscriptionListener.supressCancellationErrors` — inherited by `SubscriptionListener` and `PubNubEntityListener` — changed from `var` to `let`. Both are now set once at construction and cannot be reassigned afterwards.
 
@@ -69,7 +85,7 @@ let listener = SubscriptionListener(
 )
 ```
 
-Both parameters have defaults (`.main` and `true`), so `SubscriptionListener()` and `SubscriptionListener(queue:)` continue to compile unchanged — only post-construction assignment is affected. If you subclass `BaseSubscriptionListener` or `PubNubEntityListener`, forward these values through `super.init(queue:supressCancellationErrors:)` rather than setting the properties in your own initializer.
+Both parameters have defaults (`.main` and `true`), so `SubscriptionListener()` and `SubscriptionListener(queue:)` continue to compile unchanged — only post-construction assignment is affected.
 
 ## Deprecations (Non-Breaking Changes)
 

--- a/Documentation/PubNub_11_0_Migration_Guide.md
+++ b/Documentation/PubNub_11_0_Migration_Guide.md
@@ -8,7 +8,7 @@ This guide is meant to ease the transition to the 11.0 version of the SDK. To re
 
 ### Data Sync
 
-PubNub 11.0 adds Data Sync APIs for working with users, channels, memberships, and your custom entities and relationships through the `pubNub.dataSync` namespace.
+PubNub 11.0 adds Data Sync APIs for working with users, channels, memberships, and your custom entities and relationships through the `pubnub.dataSync` namespace.
 
 Data Sync helps keep shared application data consistent across clients while giving your app a structured way to model and update its domain data.
 

--- a/Snippets/DataSync/data-sync-channels.swift
+++ b/Snippets/DataSync/data-sync-channels.swift
@@ -82,7 +82,7 @@ pubnub.dataSync.getChannel(id: "general") { result in
         print("The channel has no stored payload")
       }
     } catch {
-      print("The payload isn't a \(ChannelDetails.self): \(error)")
+      print("Could not decode \(channel.className) version \(channel.classVersion) for channel \(channel.id): \(error)")
     }
   case let .failure(error):
     print("Get channel request failed with error: \(error.localizedDescription)")
@@ -115,8 +115,7 @@ pubnub.dataSync.createChannel(
 // snippet.end
 
 // snippet.set-channel
-// Set a channel's payload wholesale, only if it hasn't changed since it was read.
-// Every field to keep has to be sent back: an omitted field is cleared, not preserved
+// Replace every mutable field. Every field to keep must be sent back; an omitted field is cleared
 pubnub.dataSync.setChannel(
   id: "general",
   classVersion: 1,
@@ -127,7 +126,7 @@ pubnub.dataSync.setChannel(
     retentionDays: 90,
     isPrivate: false
   ),
-  ifMatchesEtag: "3w5e111uk7djz"
+  ifMatchesEtag: "3w5e111uk7djz" // Always provide the eTag from the most recent response
 ) { result in
   switch result {
   case let .success(channel):
@@ -139,8 +138,8 @@ pubnub.dataSync.setChannel(
 // snippet.end
 
 // snippet.update-channel
-// Change part of a channel, leaving the rest of its payload untouched.
-// The operations are applied atomically: if any one of them fails, the channel is left unchanged
+// Change selected fields, leaving every unaddressed field untouched.
+// The operations are atomic: if any one fails, the channel is left unchanged
 pubnub.dataSync.updateChannel(
   id: "general",
   operations: [
@@ -148,7 +147,8 @@ pubnub.dataSync.updateChannel(
     .replace(path: "/payload/retentionDays", value: 365),
     .replace(path: "/payload/isPrivate", value: true),
     .add(path: "/payload/archivedAt", value: "2026-08-11")
-  ]
+  ],
+  ifMatchesEtag: "3w5e111uk7djz" // Always provide the eTag from the most recent response
 ) { result in
   switch result {
   case let .success(channel):
@@ -161,7 +161,10 @@ pubnub.dataSync.updateChannel(
 
 // snippet.remove-channel
 // Remove a channel
-pubnub.dataSync.removeChannel(id: "general") { result in
+pubnub.dataSync.removeChannel(
+  id: "general",
+  ifMatchesEtag: "3w5e111uk7djz" // Always provide the eTag from the most recent response
+) { result in
   switch result {
   case .success:
     print("The channel was removed")

--- a/Snippets/DataSync/data-sync-entities.swift
+++ b/Snippets/DataSync/data-sync-entities.swift
@@ -86,7 +86,7 @@ pubnub.dataSync.getEntity(id: "course-swift-basics") { result in
         print("The entity has no stored payload")
       }
     } catch {
-      print("The payload isn't a \(CourseDetails.self): \(error)")
+      print("Could not decode \(entity.className) version \(entity.classVersion) for entity \(entity.id): \(error)")
     }
   case let .failure(error):
     print("Get entity request failed with error: \(error.localizedDescription)")
@@ -120,8 +120,7 @@ pubnub.dataSync.createEntity(
 // snippet.end
 
 // snippet.set-entity
-// Set an entity's payload wholesale, only if it hasn't changed since it was read.
-// Every field to keep has to be sent back: an omitted field is cleared, not preserved
+// Replace every mutable field. Every field to keep must be sent back; an omitted field is cleared
 pubnub.dataSync.setEntity(
   id: "course-swift-basics",
   classVersion: 1,
@@ -132,7 +131,7 @@ pubnub.dataSync.setEntity(
     isPublished: true,
     summary: "An introduction to Swift for new developers"
   ),
-  ifMatchesEtag: "3w5e111uk7djz"
+  ifMatchesEtag: "3w5e111uk7djz" // Always provide the eTag from the most recent response
 ) { result in
   switch result {
   case let .success(entity):
@@ -144,7 +143,7 @@ pubnub.dataSync.setEntity(
 // snippet.end
 
 // snippet.update-entity
-// Change part of an entity, leaving the rest of its payload untouched
+// Change selected fields, leaving every unaddressed field untouched
 pubnub.dataSync.updateEntity(
   id: "course-swift-basics",
   operations: [
@@ -152,7 +151,8 @@ pubnub.dataSync.updateEntity(
     .replace(path: "/payload/lessonCount", value: 32),
     .replace(path: "/payload/isPublished", value: true),
     .remove(path: "/payload/summary")
-  ]
+  ],
+  ifMatchesEtag: "3w5e111uk7djz" // Always provide the eTag from the most recent response
 ) { result in
   switch result {
   case let .success(entity):
@@ -165,7 +165,10 @@ pubnub.dataSync.updateEntity(
 
 // snippet.remove-entity
 // Remove an entity
-pubnub.dataSync.removeEntity(id: "course-swift-basics") { result in
+pubnub.dataSync.removeEntity(
+  id: "course-swift-basics",
+  ifMatchesEtag: "3w5e111uk7djz" // Always provide the eTag from the most recent response
+) { result in
   switch result {
   case .success:
     print("The entity was removed")

--- a/Snippets/DataSync/data-sync-entities.swift
+++ b/Snippets/DataSync/data-sync-entities.swift
@@ -40,7 +40,7 @@ struct CourseDetails: JSONCodable {
 
 // snippet.get-entities
 // Retrieve a page of entities of your own class
-pubnub.dataSync.getEntities(entityClass: "course", limit: 20) { result in
+pubnub.dataSync.getEntities(className: "course", limit: 20) { result in
   switch result {
   case let .success((entities, next)):
     print("The entities: \(entities)")
@@ -54,9 +54,9 @@ pubnub.dataSync.getEntities(entityClass: "course", limit: 20) { result in
 // snippet.get-entities-class-version
 // Restrict results to a single version of the class, resolved at a specific level
 pubnub.dataSync.getEntities(
-  entityClass: "course",
-  entityClassVersion: 1,
-  entityClassLevel: .subKey,
+  className: "course",
+  classVersion: 1,
+  classLevel: .subKey,
   limit: 20
 ) { result in
   switch result {
@@ -99,8 +99,8 @@ pubnub.dataSync.getEntity(id: "course-swift-basics") { result in
 // snippet.create-entity
 // Create an entity of your own class
 pubnub.dataSync.createEntity(
-  entityClass: "course",
-  entityClassVersion: 1,
+  className: "course",
+  classVersion: 1,
   id: "course-swift-basics",
   status: "draft",
   payload: CourseDetails(
@@ -124,7 +124,7 @@ pubnub.dataSync.createEntity(
 // Every field to keep has to be sent back: an omitted field is cleared, not preserved
 pubnub.dataSync.setEntity(
   id: "course-swift-basics",
-  entityClassVersion: 1,
+  classVersion: 1,
   status: "published",
   payload: CourseDetails(
     title: "Swift Basics",

--- a/Snippets/DataSync/data-sync-memberships.swift
+++ b/Snippets/DataSync/data-sync-memberships.swift
@@ -96,7 +96,7 @@ pubnub.dataSync.getMembership(id: "general-alice") { result in
         print("The membership has no stored payload")
       }
     } catch {
-      print("The payload isn't a \(MembershipDetails.self): \(error)")
+      print("Could not decode \(membership.className) version \(membership.classVersion)")
     }
   case let .failure(error):
     print("Get membership request failed with error: \(error.localizedDescription)")
@@ -126,14 +126,13 @@ pubnub.dataSync.createMembership(
 // snippet.end
 
 // snippet.set-membership
-// Set a membership's payload wholesale, only if it hasn't changed since it was read.
-// Every field to keep has to be sent back: an omitted field is cleared, not preserved
+// Replace every mutable field. Every field to keep must be sent back; an omitted field is cleared
 pubnub.dataSync.setMembership(
   id: "general-alice",
   classVersion: 1,
   status: "active",
   payload: MembershipDetails(role: "member", unreadCount: 7, isMuted: true),
-  ifMatchesEtag: "3w5e111uk7djz"
+  ifMatchesEtag: "3w5e111uk7djz" // Always provide the eTag from the most recent response
 ) { result in
   switch result {
   case let .success(membership):
@@ -145,7 +144,7 @@ pubnub.dataSync.setMembership(
 // snippet.end
 
 // snippet.update-membership
-// Change part of a membership, leaving the rest of its payload untouched.
+// Change selected fields, leaving every unaddressed field untouched.
 // A `Date` value is sent as an ISO 8601 string
 pubnub.dataSync.updateMembership(
   id: "general-alice",
@@ -154,7 +153,8 @@ pubnub.dataSync.updateMembership(
     .replace(path: "/payload/unreadCount", value: 0),
     .replace(path: "/payload/isMuted", value: false),
     .add(path: "/payload/lastReadAt", value: Date())
-  ]
+  ],
+  ifMatchesEtag: "3w5e111uk7djz" // Always provide the eTag from the most recent response
 ) { result in
   switch result {
   case let .success(membership):
@@ -167,7 +167,10 @@ pubnub.dataSync.updateMembership(
 
 // snippet.remove-membership
 // Remove a user from a channel
-pubnub.dataSync.removeMembership(id: "general-alice") { result in
+pubnub.dataSync.removeMembership(
+  id: "general-alice",
+  ifMatchesEtag: "3w5e111uk7djz" // Always provide the eTag from the most recent response
+) { result in
   switch result {
   case .success:
     print("The membership was removed")

--- a/Snippets/DataSync/data-sync-relationships.swift
+++ b/Snippets/DataSync/data-sync-relationships.swift
@@ -100,9 +100,9 @@ pubnub.dataSync.getRelationship(id: "alice-course-swift-basics") { result in
 // Connect two entities with a relationship of your own class
 pubnub.dataSync.createRelationship(
   className: "enrollment",
+  classVersion: 1,
   entityAId: "student-alice",
   entityBId: "course-swift-basics",
-  classVersion: 1,
   id: "alice-course-swift-basics",
   status: "active",
   payload: EnrollmentDetails(

--- a/Snippets/DataSync/data-sync-relationships.swift
+++ b/Snippets/DataSync/data-sync-relationships.swift
@@ -41,7 +41,7 @@ struct EnrollmentDetails: JSONCodable {
 
 // snippet.get-relationships
 // Retrieve a page of relationships of your own class
-pubnub.dataSync.getRelationships(relationshipClass: "enrollment", limit: 20) { result in
+pubnub.dataSync.getRelationships(className: "enrollment", limit: 20) { result in
   switch result {
   case let .success((relationships, next)):
     print("The relationships: \(relationships)")
@@ -55,7 +55,7 @@ pubnub.dataSync.getRelationships(relationshipClass: "enrollment", limit: 20) { r
 // snippet.get-relationships-by-side
 // Retrieve the relationships whose side A is a specific entity
 pubnub.dataSync.getRelationships(
-  relationshipClass: "enrollment",
+  className: "enrollment",
   entityAId: "student-alice",
   limit: 20
 ) { result in
@@ -99,10 +99,10 @@ pubnub.dataSync.getRelationship(id: "alice-course-swift-basics") { result in
 // snippet.create-relationship
 // Connect two entities with a relationship of your own class
 pubnub.dataSync.createRelationship(
-  relationshipClass: "enrollment",
+  className: "enrollment",
   entityAId: "student-alice",
   entityBId: "course-swift-basics",
-  relationshipClassVersion: 1,
+  classVersion: 1,
   id: "alice-course-swift-basics",
   status: "active",
   payload: EnrollmentDetails(
@@ -126,7 +126,7 @@ pubnub.dataSync.createRelationship(
 // Every field to keep has to be sent back: an omitted field is cleared, not preserved
 pubnub.dataSync.setRelationship(
   id: "alice-course-swift-basics",
-  relationshipClassVersion: 1,
+  classVersion: 1,
   status: "active",
   payload: EnrollmentDetails(
     role: "student",

--- a/Snippets/DataSync/data-sync-relationships.swift
+++ b/Snippets/DataSync/data-sync-relationships.swift
@@ -86,7 +86,10 @@ pubnub.dataSync.getRelationship(id: "alice-course-swift-basics") { result in
         print("The relationship has no stored payload")
       }
     } catch {
-      print("The payload isn't a \(EnrollmentDetails.self): \(error)")
+      print(
+        "Could not decode \(relationship.className) version \(relationship.classVersion) " +
+          "for relationship \(relationship.id): \(error)"
+      )
     }
   case let .failure(error):
     print("Get relationship request failed with error: \(error.localizedDescription)")
@@ -122,8 +125,7 @@ pubnub.dataSync.createRelationship(
 // snippet.end
 
 // snippet.set-relationship
-// Set a relationship's payload wholesale, only if it hasn't changed since it was read.
-// Every field to keep has to be sent back: an omitted field is cleared, not preserved
+// Replace every mutable field. Every field to keep must be sent back; an omitted field is cleared
 pubnub.dataSync.setRelationship(
   id: "alice-course-swift-basics",
   classVersion: 1,
@@ -134,7 +136,7 @@ pubnub.dataSync.setRelationship(
     isActive: true,
     grade: "A"
   ),
-  ifMatchesEtag: "3w5e111uk7djz"
+  ifMatchesEtag: "3w5e111uk7djz" // Always provide the eTag from the most recent response
 ) { result in
   switch result {
   case let .success(relationship):
@@ -146,14 +148,15 @@ pubnub.dataSync.setRelationship(
 // snippet.end
 
 // snippet.update-relationship
-// Change part of a relationship, leaving the rest of its payload untouched
+// Change selected fields, leaving every unaddressed field untouched
 pubnub.dataSync.updateRelationship(
   id: "alice-course-swift-basics",
   operations: [
     .replace(path: "/payload/completedLessons", value: 24),
     .replace(path: "/payload/isActive", value: false),
     .remove(path: "/payload/grade")
-  ]
+  ],
+  ifMatchesEtag: "3w5e111uk7djz" // Always provide the eTag from the most recent response
 ) { result in
   switch result {
   case let .success(relationship):
@@ -166,7 +169,10 @@ pubnub.dataSync.updateRelationship(
 
 // snippet.remove-relationship
 // Remove a relationship
-pubnub.dataSync.removeRelationship(id: "alice-course-swift-basics") { result in
+pubnub.dataSync.removeRelationship(
+  id: "alice-course-swift-basics",
+  ifMatchesEtag: "3w5e111uk7djz" // Always provide the eTag from the most recent response
+) { result in
   switch result {
   case .success:
     print("The relationship was removed")

--- a/Snippets/DataSync/data-sync-users.swift
+++ b/Snippets/DataSync/data-sync-users.swift
@@ -82,7 +82,7 @@ pubnub.dataSync.getUser(id: "alice") { result in
         print("The user has no stored payload")
       }
     } catch {
-      print("The payload isn't a \(UserProfile.self): \(error)")
+      print("Could not decode \(user.className) version \(user.classVersion) for user \(user.id): \(error)")
     }
   case let .failure(error):
     print("Get user request failed with error: \(error.localizedDescription)")
@@ -115,8 +115,7 @@ pubnub.dataSync.createUser(
 // snippet.end
 
 // snippet.set-user
-// Set a user's payload wholesale, only if it hasn't changed since it was read.
-// Every field to keep has to be sent back: an omitted field is cleared, not preserved
+// Replace every mutable field. Every field to keep must be sent back; an omitted field is cleared
 pubnub.dataSync.setUser(
   id: "alice",
   classVersion: 1,
@@ -127,7 +126,7 @@ pubnub.dataSync.setUser(
     loginCount: 12,
     isEmailVerified: true
   ),
-  ifMatchesEtag: "3w5e111uk7djz"
+  ifMatchesEtag: "3w5e111uk7djz" // Always provide the eTag from the most recent response
 ) { result in
   switch result {
   case let .success(user):
@@ -139,7 +138,7 @@ pubnub.dataSync.setUser(
 // snippet.end
 
 // snippet.update-user
-// Change part of a user, leaving the rest of its payload untouched
+// Change selected fields, leaving every unaddressed field untouched
 pubnub.dataSync.updateUser(
   id: "alice",
   operations: [
@@ -147,7 +146,8 @@ pubnub.dataSync.updateUser(
     .replace(path: "/payload/isEmailVerified", value: true),
     .replace(path: "/payload/loginCount", value: 13),
     .add(path: "/payload/nickname", value: "Ali")
-  ]
+  ],
+  ifMatchesEtag: "3w5e111uk7djz" // Always provide the eTag from the most recent response
 ) { result in
   switch result {
   case let .success(user):
@@ -160,7 +160,10 @@ pubnub.dataSync.updateUser(
 
 // snippet.remove-user
 // Remove a user
-pubnub.dataSync.removeUser(id: "alice") { result in
+pubnub.dataSync.removeUser(
+  id: "alice",
+  ifMatchesEtag: "3w5e111uk7djz" // Always provide the eTag from the most recent response
+) { result in
   switch result {
   case .success:
     print("The user was removed")

--- a/Snippets/Entities/entities.swift
+++ b/Snippets/Entities/entities.swift
@@ -19,17 +19,51 @@ let pubnub = PubNub(
 )
 
 // snippet.channel-entity
+// Create a Pub/Sub channel reference
 pubnub.channel("channelName")
 // snippet.end
 
 // snippet.channel-group-entity
+// Create a Pub/Sub channel group reference
 pubnub.channelGroup("channelGroupName")
 // snippet.end
 
 // snippet.channel-metadata-entity
-pubnub.channelMetadata("channelMetadataName")
+// Create an App Context channel metadata reference
+pubnub.channelMetadata("channelMetadataId")
 // snippet.end
 
 // snippet.user-metadata-entity
-pubnub.userMetadata("userMetadataName")
+// Create an App Context user metadata reference
+pubnub.userMetadata("userMetadataId")
+// snippet.end
+
+// snippet.data-sync-user-entity
+// Create a Data Sync user reference
+pubnub.dataSyncUser("player-1")
+// snippet.end
+
+// snippet.data-sync-channel-entity
+// Create a Data Sync channel reference
+pubnub.dataSyncChannel("team-1")
+// snippet.end
+
+// snippet.data-sync-membership-entity
+// Create a Data Sync membership reference
+pubnub.dataSyncMembership("membership-1")
+// snippet.end
+
+// snippet.data-sync-entity
+// Create a Data Sync custom entity reference
+pubnub.dataSyncEntity("match-1")
+// snippet.end
+
+// snippet.data-sync-relationship-entity
+// Create a Data Sync custom relationship reference
+pubnub.dataSyncRelationship("relationship-1")
+// snippet.end
+
+// snippet.data-sync-projection-subscription
+// Subscribe to a custom projection of a Data Sync entity
+pubnub.dataSyncEntity("match-1").subscription(projection: "stats")
 // snippet.end

--- a/Snippets/ListenersOld/listeners-old.swift
+++ b/Snippets/ListenersOld/listeners-old.swift
@@ -134,7 +134,20 @@ listener.didReceiveBatchSubscription = { events in
       }
 
     case .dataSyncChanged(let dataSyncEvent):
-      print("A DataSync event was received: \(dataSyncEvent)")
+      switch dataSyncEvent {
+      case let .entityCreated(entity):
+        print("Data Sync entity created: \(entity.id)")
+      case let .entityUpdated(entity):
+        print("Data Sync entity updated: \(entity.id)")
+      case let .entityDeleted(entity):
+        print("Data Sync entity deleted: \(entity.id)")
+      case let .relationshipCreated(relationship):
+        print("Data Sync relationship created: \(relationship.id)")
+      case let .relationshipUpdated(relationship):
+        print("Data Sync relationship updated: \(relationship.id)")
+      case let .relationshipDeleted(relationship):
+        print("Data Sync relationship deleted: \(relationship.id)")
+      }
     }
   }
 }

--- a/Snippets/SubscribeNew/subscriptions.swift
+++ b/Snippets/SubscribeNew/subscriptions.swift
@@ -27,7 +27,7 @@ let pubnub = PubNub(
 
 func subscriptionBasicExample() {
   // snippet.basic-usage
-  // Create a subscription for an example channel entity
+  // Create a subscription for an example channel
   let subscription = pubnub.channel("channel").subscription(options: ReceivePresenceEvents())
   // Triggers the subscription
   subscription.subscribe()
@@ -36,15 +36,15 @@ func subscriptionBasicExample() {
 
 func subscriptionSetAddRemoveExample() {
   // snippet.subscription-set-add-remove
-  // Create a reference to example channel entity
-  let weatherChannelEntity = pubnub.channel("weather-updates")
-  // Create a reference to example channel group entity
-  let newsGroupEntity = pubnub.channelGroup("news-feed")
+  // Create a reference to an example channel
+  let weatherChannel = pubnub.channel("weather-updates")
+  // Create a reference to an example channel group
+  let newsGroup = pubnub.channelGroup("news-feed")
 
-  // Create a SubscriptionSet object from entities above
-  let subscriptionSet = pubnub.subscription(entities: [weatherChannelEntity, newsGroupEntity])
+  // Create a SubscriptionSet object from the values above
+  let subscriptionSet = pubnub.subscription(targets: [weatherChannel, newsGroup])
 
-  // Create a subscription for another channel entity to demonstrate
+  // Create a subscription for another channel to demonstrate
   // adding and removing to/from a SubscriptionSet
   let sportsSubscription = pubnub.channel("sports-scores").subscription()
 
@@ -52,7 +52,7 @@ func subscriptionSetAddRemoveExample() {
   subscriptionSet.add(subscription: sportsSubscription)
   subscriptionSet.remove(subscription: sportsSubscription)
 
-  // Triggers `.subscribe()` on the SubscriptionSet, initiating subscriptions to all contained entities
+  // Triggers `.subscribe()` on the SubscriptionSet, initiating subscriptions to everything it contains
   subscriptionSet.subscribe()
   // snippet.end
 }
@@ -60,7 +60,7 @@ func subscriptionSetAddRemoveExample() {
 func cloneExample() {
   // snippet.clone
   let subscriptionSet = pubnub.subscription(
-    entities: [pubnub.channel("channel"), pubnub.channelGroup("channelGroup")],
+    targets: [pubnub.channel("channel"), pubnub.channelGroup("channelGroup")],
     options: ReceivePresenceEvents()
   )
   let subscription = pubnub
@@ -74,7 +74,7 @@ func cloneExample() {
 
 func unsubscribeExample() {
   let subscriptionSet = pubnub.subscription(
-    entities: [pubnub.channel("channel"), pubnub.channelGroup("channelGroup")],
+    targets: [pubnub.channel("channel"), pubnub.channelGroup("channelGroup")],
     options: ReceivePresenceEvents()
   )
   let subscription = pubnub

--- a/Snippets/SubscribeNew/subscriptions.swift
+++ b/Snippets/SubscribeNew/subscriptions.swift
@@ -27,7 +27,7 @@ let pubnub = PubNub(
 
 func subscriptionBasicExample() {
   // snippet.basic-usage
-  // Create a subscription for an example channel
+  // Create a subscription for a Pub/Sub channel
   let subscription = pubnub.channel("channel").subscription(options: ReceivePresenceEvents())
   // Triggers the subscription
   subscription.subscribe()
@@ -36,15 +36,15 @@ func subscriptionBasicExample() {
 
 func subscriptionSetAddRemoveExample() {
   // snippet.subscription-set-add-remove
-  // Create a reference to an example channel
+  // Create a reference to a Pub/Sub channel
   let weatherChannel = pubnub.channel("weather-updates")
-  // Create a reference to an example channel group
+  // Create a reference to a Pub/Sub channel group
   let newsGroup = pubnub.channelGroup("news-feed")
 
   // Create a SubscriptionSet object from the values above
   let subscriptionSet = pubnub.subscription(targets: [weatherChannel, newsGroup])
 
-  // Create a subscription for another channel to demonstrate
+  // Create a subscription for another Pub/Sub channel to demonstrate
   // adding and removing to/from a SubscriptionSet
   let sportsSubscription = pubnub.channel("sports-scores").subscription()
 
@@ -59,10 +59,12 @@ func subscriptionSetAddRemoveExample() {
 
 func cloneExample() {
   // snippet.clone
+  // Create a subscription set containing a Pub/Sub channel and channel group
   let subscriptionSet = pubnub.subscription(
     targets: [pubnub.channel("channel"), pubnub.channelGroup("channelGroup")],
     options: ReceivePresenceEvents()
   )
+  // Create a subscription for a Pub/Sub channel
   let subscription = pubnub
     .channel("channelName")
     .subscription()
@@ -88,10 +90,18 @@ func unsubscribeExample() {
 }
 
 // snippet.subscription
-// Create an example subscription for a channel
+// Create a subscription for a Pub/Sub channel
 let subscription = pubnub
   .channel("channelName")
   .subscription()
+
+// snippet.end
+
+// snippet.data-sync-subscription
+// Create a subscription for a custom projection of a Data Sync entity
+let dataSyncSubscription = pubnub
+  .dataSyncEntity("match-1")
+  .subscription(projection: "stats")
 
 // snippet.end
 
@@ -165,7 +175,7 @@ subscription.onMessageAction = { messageActionEvent in
 // snippet.end
 
 // snippet.on-app-context
-// Add a listener to receive App Context events
+// Add a listener to receive App Context user, channel, and membership metadata events
 subscription.onAppContext = { appContextEvent in
   switch appContextEvent {
   case let .userMetadataSet(changeset):
@@ -184,6 +194,26 @@ subscription.onAppContext = { appContextEvent in
     print("Membership set between \(membership.userMetadataId) and \(membership.channelMetadataId)")
   case let .membershipMetadataRemoved(membership):
     print("Membership removed between \(membership.userMetadataId) and \(membership.channelMetadataId)")
+  }
+}
+// snippet.end
+
+// snippet.on-data-sync
+// Add a listener to receive Data Sync entity and relationship events
+dataSyncSubscription.onDataSync = { dataSyncEvent in
+  switch dataSyncEvent {
+  case let .entityCreated(entity):
+    print("Data Sync entity created: \(entity.id)")
+  case let .entityUpdated(entity):
+    print("Data Sync entity updated: \(entity.id)")
+  case let .entityDeleted(entity):
+    print("Data Sync entity deleted: \(entity.id)")
+  case let .relationshipCreated(relationship):
+    print("Data Sync relationship created: \(relationship.id)")
+  case let .relationshipUpdated(relationship):
+    print("Data Sync relationship updated: \(relationship.id)")
+  case let .relationshipDeleted(relationship):
+    print("Data Sync relationship deleted: \(relationship.id)")
   }
 }
 // snippet.end
@@ -215,12 +245,14 @@ subscription.onEvent = { event in
   case let .presenceChanged(presence):
     print("Presence event: \(presence)")
   case let .appContextChanged(appContextEvent):
-    print("App Context change event: \(appContextEvent)")
+    print("App Context metadata change event: \(appContextEvent)")
   case let .messageActionChanged(messageActionEvent):
     print("Message Reaction event: \(messageActionEvent)")
   case let .fileChanged(fileEvent):
     print("File event: \(fileEvent)")
-  default:
+  case let .dataSyncChanged(dataSyncEvent):
+    print("Data Sync event: \(dataSyncEvent)")
+  @unknown default:
     break
   }
 }

--- a/Sources/PubNub/APIs/DataSync+PubNub.swift
+++ b/Sources/PubNub/APIs/DataSync+PubNub.swift
@@ -298,7 +298,7 @@ public extension PubNub.DataSyncAPI {
   ///   - classVersion: The version of the class the payload conforms to
   ///   - status: An arbitrary status to store with the entity
   ///   - payload: The replacement entity fields
-  ///   - ifMatchesEtag: The ``PubNubDataSyncEntity/eTag`` last read, to fail the request when the entity changed since
+  ///   - ifMatchesEtag: The entity's last known ``PubNubDataSyncEntity/eTag``, used to prevent modifying a newer revision
   ///   - custom: Custom configuration overrides for this request
   ///   - completion: The async `Result` of the method call
   ///     - **Success**: The replaced ``PubNubDataSyncEntity``
@@ -345,12 +345,13 @@ public extension PubNub.DataSyncAPI {
 
   /// Applies a set of JSON Patch operations to an entity.
   ///
-  /// The operations are applied atomically: if any one of them fails, the entity is left unchanged.
+  /// Unlike ``setEntity(id:classVersion:status:payload:ifMatchesEtag:custom:completion:)``, fields not addressed by an operation
+  /// are left untouched. The operations are applied atomically: if any one of them fails, the entity is left unchanged.
   ///
   /// - Parameters:
   ///   - id: The unique identifier of the entity
   ///   - operations: The RFC 6902 operations to apply, which must not be empty
-  ///   - ifMatchesEtag: The ``PubNubDataSyncEntity/eTag`` last read, to fail the request when the entity changed since
+  ///   - ifMatchesEtag: The entity's last known ``PubNubDataSyncEntity/eTag``, used to prevent modifying a newer revision
   ///   - custom: Custom configuration overrides for this request
   ///   - completion: The async `Result` of the method call
   ///     - **Success**: The patched ``PubNubDataSyncEntity``
@@ -391,7 +392,7 @@ public extension PubNub.DataSyncAPI {
   ///
   /// - Parameters:
   ///   - id: The unique identifier of the entity
-  ///   - ifMatchesEtag: The ``PubNubDataSyncEntity/eTag`` last read, to fail the request when the entity changed since
+  ///   - ifMatchesEtag: The entity's last known ``PubNubDataSyncEntity/eTag``, used to prevent modifying a newer revision
   ///   - custom: Custom configuration overrides for this request
   ///   - completion: The async `Result` of the method call
   ///     - **Success**: An acknowledgement that the entity was removed
@@ -607,7 +608,7 @@ public extension PubNub.DataSyncAPI {
   ///   - classVersion: The version of the `User` class the payload conforms to
   ///   - status: An arbitrary status to store with the user
   ///   - payload: The replacement user fields
-  ///   - ifMatchesEtag: The ``PubNubDataSyncEntity/eTag`` last read, to fail the request when the user changed since
+  ///   - ifMatchesEtag: The user's last known ``PubNubDataSyncEntity/eTag``, used to prevent modifying a newer revision
   ///   - custom: Custom configuration overrides for this request
   ///   - completion: The async `Result` of the method call
   ///     - **Success**: The replaced ``PubNubDataSyncEntity``
@@ -654,12 +655,13 @@ public extension PubNub.DataSyncAPI {
 
   /// Applies a set of JSON Patch operations to a user.
   ///
-  /// The operations are applied atomically: if any one of them fails, the user is left unchanged.
+  /// Unlike ``setUser(id:classVersion:status:payload:ifMatchesEtag:custom:completion:)``, fields not addressed by an operation
+  /// are left untouched. The operations are applied atomically: if any one of them fails, the user is left unchanged.
   ///
   /// - Parameters:
   ///   - id: The unique identifier of the user
   ///   - operations: The RFC 6902 operations to apply, which must not be empty
-  ///   - ifMatchesEtag: The ``PubNubDataSyncEntity/eTag`` last read, to fail the request when the user changed since
+  ///   - ifMatchesEtag: The user's last known ``PubNubDataSyncEntity/eTag``, used to prevent modifying a newer revision
   ///   - custom: Custom configuration overrides for this request
   ///   - completion: The async `Result` of the method call
   ///     - **Success**: The patched ``PubNubDataSyncEntity``
@@ -700,7 +702,7 @@ public extension PubNub.DataSyncAPI {
   ///
   /// - Parameters:
   ///   - id: The unique identifier of the user
-  ///   - ifMatchesEtag: The ``PubNubDataSyncEntity/eTag`` last read, to fail the request when the user changed since
+  ///   - ifMatchesEtag: The user's last known ``PubNubDataSyncEntity/eTag``, used to prevent modifying a newer revision
   ///   - custom: Custom configuration overrides for this request
   ///   - completion: The async `Result` of the method call
   ///     - **Success**: An acknowledgement that the user was removed
@@ -916,7 +918,7 @@ public extension PubNub.DataSyncAPI {
   ///   - classVersion: The version of the `Channel` class the payload conforms to
   ///   - status: An arbitrary status to store with the channel
   ///   - payload: The replacement channel fields
-  ///   - ifMatchesEtag: The ``PubNubDataSyncEntity/eTag`` last read, to fail the request when the channel changed since
+  ///   - ifMatchesEtag: The channel's last known ``PubNubDataSyncEntity/eTag``, used to prevent modifying a newer revision
   ///   - custom: Custom configuration overrides for this request
   ///   - completion: The async `Result` of the method call
   ///     - **Success**: The replaced ``PubNubDataSyncEntity``
@@ -963,12 +965,13 @@ public extension PubNub.DataSyncAPI {
 
   /// Applies a set of JSON Patch operations to a channel.
   ///
-  /// The operations are applied atomically: if any one of them fails, the channel is left unchanged.
+  /// Unlike ``setChannel(id:classVersion:status:payload:ifMatchesEtag:custom:completion:)``, fields not addressed by an operation
+  /// are left untouched. The operations are applied atomically: if any one of them fails, the channel is left unchanged.
   ///
   /// - Parameters:
   ///   - id: The unique identifier of the channel
   ///   - operations: The RFC 6902 operations to apply, which must not be empty
-  ///   - ifMatchesEtag: The ``PubNubDataSyncEntity/eTag`` last read, to fail the request when the channel changed since
+  ///   - ifMatchesEtag: The channel's last known ``PubNubDataSyncEntity/eTag``, used to prevent modifying a newer revision
   ///   - custom: Custom configuration overrides for this request
   ///   - completion: The async `Result` of the method call
   ///     - **Success**: The patched ``PubNubDataSyncEntity``
@@ -1009,7 +1012,7 @@ public extension PubNub.DataSyncAPI {
   ///
   /// - Parameters:
   ///   - id: The unique identifier of the channel
-  ///   - ifMatchesEtag: The ``PubNubDataSyncEntity/eTag`` last read, to fail the request when the channel changed since
+  ///   - ifMatchesEtag: The channel's last known ``PubNubDataSyncEntity/eTag``, used to prevent modifying a newer revision
   ///   - custom: Custom configuration overrides for this request
   ///   - completion: The async `Result` of the method call
   ///     - **Success**: An acknowledgement that the channel was removed
@@ -1216,7 +1219,7 @@ public extension PubNub.DataSyncAPI {
   ///   - classVersion: The version of the `Membership` class the payload conforms to
   ///   - status: An arbitrary status to store with the membership
   ///   - payload: The replacement membership fields
-  ///   - ifMatchesEtag: The ``PubNubDataSyncMembership/eTag`` last read, to fail the request when the membership changed since
+  ///   - ifMatchesEtag: The membership's last known ``PubNubDataSyncMembership/eTag``, used to prevent modifying a newer revision
   ///   - custom: Custom configuration overrides for this request
   ///   - completion: The async `Result` of the method call
   ///     - **Success**: The replaced ``PubNubDataSyncMembership``
@@ -1263,12 +1266,13 @@ public extension PubNub.DataSyncAPI {
 
   /// Applies a set of JSON Patch operations to a membership.
   ///
-  /// The operations are applied atomically: if any one of them fails, the membership is left unchanged.
+  /// Unlike ``setMembership(id:classVersion:status:payload:ifMatchesEtag:custom:completion:)``, fields not addressed by an operation
+  /// are left untouched. The operations are applied atomically: if any one of them fails, the membership is left unchanged.
   ///
   /// - Parameters:
   ///   - id: The unique identifier of the membership
   ///   - operations: The RFC 6902 operations to apply, which must not be empty
-  ///   - ifMatchesEtag: The ``PubNubDataSyncMembership/eTag`` last read, to fail the request when the membership changed since
+  ///   - ifMatchesEtag: The membership's last known ``PubNubDataSyncMembership/eTag``, used to prevent modifying a newer revision
   ///   - custom: Custom configuration overrides for this request
   ///   - completion: The async `Result` of the method call
   ///     - **Success**: The patched ``PubNubDataSyncMembership``
@@ -1309,7 +1313,7 @@ public extension PubNub.DataSyncAPI {
   ///
   /// - Parameters:
   ///   - id: The unique identifier of the membership
-  ///   - ifMatchesEtag: The ``PubNubDataSyncMembership/eTag`` last read, to fail the request when the membership changed since
+  ///   - ifMatchesEtag: The membership's last known ``PubNubDataSyncMembership/eTag``, used to prevent modifying a newer revision
   ///   - custom: Custom configuration overrides for this request
   ///   - completion: The async `Result` of the method call
   ///     - **Success**: An acknowledgement that the membership was removed
@@ -1525,7 +1529,7 @@ public extension PubNub.DataSyncAPI {
   ///   - classVersion: The version of the class the payload conforms to
   ///   - status: An arbitrary status to store with the relationship
   ///   - payload: The replacement relationship fields
-  ///   - ifMatchesEtag: The ``PubNubDataSyncRelationship/eTag`` last read, to fail the request when it changed since
+  ///   - ifMatchesEtag: The relationship's last known ``PubNubDataSyncRelationship/eTag``, used to prevent modifying a newer revision
   ///   - custom: Custom configuration overrides for this request
   ///   - completion: The async `Result` of the method call
   ///     - **Success**: The replaced ``PubNubDataSyncRelationship``
@@ -1576,12 +1580,13 @@ public extension PubNub.DataSyncAPI {
 
   /// Applies a set of JSON Patch operations to a relationship.
   ///
-  /// The operations are applied atomically: if any one of them fails, the relationship is left unchanged.
+  /// Unlike ``setRelationship(id:classVersion:status:payload:ifMatchesEtag:custom:completion:)``, fields not addressed by an operation
+  /// are left untouched. The operations are applied atomically: if any one of them fails, the relationship is left unchanged.
   ///
   /// - Parameters:
   ///   - id: The unique identifier of the relationship
   ///   - operations: The RFC 6902 operations to apply, which must not be empty
-  ///   - ifMatchesEtag: The ``PubNubDataSyncRelationship/eTag`` last read, to fail the request when it changed since
+  ///   - ifMatchesEtag: The relationship's last known ``PubNubDataSyncRelationship/eTag``, used to prevent modifying a newer revision
   ///   - custom: Custom configuration overrides for this request
   ///   - completion: The async `Result` of the method call
   ///     - **Success**: The patched ``PubNubDataSyncRelationship``
@@ -1622,7 +1627,7 @@ public extension PubNub.DataSyncAPI {
   ///
   /// - Parameters:
   ///   - id: The unique identifier of the relationship
-  ///   - ifMatchesEtag: The ``PubNubDataSyncRelationship/eTag`` last read, to fail the request when it changed since
+  ///   - ifMatchesEtag: The relationship's last known ``PubNubDataSyncRelationship/eTag``, used to prevent modifying a newer revision
   ///   - custom: Custom configuration overrides for this request
   ///   - completion: The async `Result` of the method call
   ///     - **Success**: An acknowledgement that the relationship was removed

--- a/Sources/PubNub/APIs/DataSync+PubNub.swift
+++ b/Sources/PubNub/APIs/DataSync+PubNub.swift
@@ -1348,9 +1348,9 @@ public extension PubNub.DataSyncAPI {
   ///
   /// - Parameters:
   ///   - className: The name of the class to list relationships of
+  ///   - classVersion: Restricts results to a single version of the class. If omitted, every version is returned
   ///   - entityAId: Restricts results to relationships whose side A is this entity
   ///   - entityBId: Restricts results to relationships whose side B is this entity
-  ///   - classVersion: Restricts results to a single version of the class. If omitted, every version is returned
   ///   - cursor: The ``PubNubDataSyncPage/cursor`` of a previous page, or `nil` for the first page
   ///   - limit: The number of relationships to retrieve, between 1 and 100. Defaults to 20
   ///   - filter: Expression used to filter the results. Mutually exclusive with `filterAdvanced`
@@ -1362,9 +1362,9 @@ public extension PubNub.DataSyncAPI {
   ///     - **Failure**: An `Error` describing the failure
   func getRelationships(
     className: String,
+    classVersion: Int? = nil,
     entityAId: String? = nil,
     entityBId: String? = nil,
-    classVersion: Int? = nil,
     cursor: String? = nil,
     limit: Int? = nil,
     filter: String? = nil,
@@ -1378,9 +1378,9 @@ public extension PubNub.DataSyncAPI {
       details: "List DataSync relationships",
       arguments: [
         ("className", className),
+        ("classVersion", classVersion),
         ("entityAId", entityAId),
         ("entityBId", entityBId),
-        ("classVersion", classVersion),
         ("cursor", cursor),
         ("limit", limit),
         ("filter", filter),
@@ -1454,9 +1454,9 @@ public extension PubNub.DataSyncAPI {
   ///
   /// - Parameters:
   ///   - className: The name of the class to create the relationship in
+  ///   - classVersion: The version of the class the payload conforms to
   ///   - entityAId: The unique identifier of the entity on side A
   ///   - entityBId: The unique identifier of the entity on side B
-  ///   - classVersion: The version of the class the payload conforms to
   ///   - id: The unique identifier to create the relationship with, or `nil` to let the service assign one
   ///   - status: An arbitrary status to store with the relationship
   ///   - payload: The relationship fields
@@ -1466,9 +1466,9 @@ public extension PubNub.DataSyncAPI {
   ///     - **Failure**: An `Error` describing the failure
   func createRelationship(
     className: String,
+    classVersion: Int,
     entityAId: String,
     entityBId: String,
-    classVersion: Int,
     id: String? = nil,
     status: String? = nil,
     payload: JSONCodable? = nil,
@@ -1480,9 +1480,9 @@ public extension PubNub.DataSyncAPI {
       details: "Create DataSync relationship",
       arguments: [
         ("className", className),
+        ("classVersion", classVersion),
         ("entityAId", entityAId),
         ("entityBId", entityBId),
-        ("classVersion", classVersion),
         ("id", id),
         ("status", status),
         ("payload", payload),

--- a/Sources/PubNub/APIs/DataSync+PubNub.swift
+++ b/Sources/PubNub/APIs/DataSync+PubNub.swift
@@ -443,7 +443,7 @@ public extension PubNub.DataSyncAPI {
   ///   - sort: List of properties to sort the results by
   ///   - custom: Custom configuration overrides for this request
   ///   - completion: The async `Result` of the method call
-  ///     - **Success**: A `Tuple` containing an `Array` of ``PubNubDataSyncUser``, and the next page (if one exists)
+  ///     - **Success**: A `Tuple` containing an `Array` of ``PubNubDataSyncEntity``, and the next page (if one exists)
   ///     - **Failure**: An `Error` describing the failure
   func getUsers(
     className: String? = nil,
@@ -455,7 +455,7 @@ public extension PubNub.DataSyncAPI {
     filterAdvanced: String? = nil,
     sort: [PubNub.DataSyncSortField] = [],
     custom requestConfig: PubNub.RequestConfiguration = PubNub.RequestConfiguration(),
-    completion: ((Result<(users: [PubNubDataSyncUser], next: PubNubDataSyncPage?), Error>) -> Void)?
+    completion: ((Result<(users: [PubNubDataSyncEntity], next: PubNubDataSyncPage?), Error>) -> Void)?
   ) {
     log(
       operation: "getUsers",
@@ -489,7 +489,7 @@ public extension PubNub.DataSyncAPI {
 
     route(
       router,
-      responseDecoder: DataSyncListValueResponseDecoder<PubNubDataSyncUser>(),
+      responseDecoder: DataSyncListValueResponseDecoder<PubNubDataSyncEntity>(),
       custom: requestConfig
     ) { result in
       completion?(result.map { (
@@ -505,12 +505,12 @@ public extension PubNub.DataSyncAPI {
   ///   - id: The unique identifier of the user
   ///   - custom: Custom configuration overrides for this request
   ///   - completion: The async `Result` of the method call
-  ///     - **Success**: The ``PubNubDataSyncUser`` belonging to the identifier
+  ///     - **Success**: The ``PubNubDataSyncEntity`` belonging to the identifier
   ///     - **Failure**: An `Error` describing the failure
   func getUser(
     id: String,
     custom requestConfig: PubNub.RequestConfiguration = PubNub.RequestConfiguration(),
-    completion: ((Result<PubNubDataSyncUser, Error>) -> Void)?
+    completion: ((Result<PubNubDataSyncEntity, Error>) -> Void)?
   ) {
     log(
       operation: "getUser",
@@ -525,7 +525,7 @@ public extension PubNub.DataSyncAPI {
 
     route(
       router,
-      responseDecoder: DataSyncSingleValueResponseDecoder<PubNubDataSyncUser>(),
+      responseDecoder: DataSyncSingleValueResponseDecoder<PubNubDataSyncEntity>(),
       custom: requestConfig
     ) { result in
       completion?(result.map { $0.payload.data })
@@ -547,7 +547,7 @@ public extension PubNub.DataSyncAPI {
   ///   - payload: The user fields
   ///   - custom: Custom configuration overrides for this request
   ///   - completion: The async `Result` of the method call
-  ///     - **Success**: The created ``PubNubDataSyncUser``
+  ///     - **Success**: The created ``PubNubDataSyncEntity``
   ///     - **Failure**: An `Error` describing the failure
   func createUser(
     className: String? = nil,
@@ -557,7 +557,7 @@ public extension PubNub.DataSyncAPI {
     status: String? = nil,
     payload: JSONCodable? = nil,
     custom requestConfig: PubNub.RequestConfiguration = PubNub.RequestConfiguration(),
-    completion: ((Result<PubNubDataSyncUser, Error>) -> Void)?
+    completion: ((Result<PubNubDataSyncEntity, Error>) -> Void)?
   ) {
     log(
       operation: "createUser",
@@ -589,7 +589,7 @@ public extension PubNub.DataSyncAPI {
 
     route(
       router,
-      responseDecoder: DataSyncSingleValueResponseDecoder<PubNubDataSyncUser>(),
+      responseDecoder: DataSyncSingleValueResponseDecoder<PubNubDataSyncEntity>(),
       custom: requestConfig
     ) { result in
       completion?(result.map { $0.payload.data })
@@ -607,10 +607,10 @@ public extension PubNub.DataSyncAPI {
   ///   - classVersion: The version of the `User` class the payload conforms to
   ///   - status: An arbitrary status to store with the user
   ///   - payload: The replacement user fields
-  ///   - ifMatchesEtag: The ``PubNubDataSyncUser/eTag`` last read, to fail the request when the user changed since
+  ///   - ifMatchesEtag: The ``PubNubDataSyncEntity/eTag`` last read, to fail the request when the user changed since
   ///   - custom: Custom configuration overrides for this request
   ///   - completion: The async `Result` of the method call
-  ///     - **Success**: The replaced ``PubNubDataSyncUser``
+  ///     - **Success**: The replaced ``PubNubDataSyncEntity``
   ///     - **Failure**: An `Error` describing the failure
   func setUser(
     id: String,
@@ -619,7 +619,7 @@ public extension PubNub.DataSyncAPI {
     payload: JSONCodable? = nil,
     ifMatchesEtag: String? = nil,
     custom requestConfig: PubNub.RequestConfiguration = PubNub.RequestConfiguration(),
-    completion: ((Result<PubNubDataSyncUser, Error>) -> Void)?
+    completion: ((Result<PubNubDataSyncEntity, Error>) -> Void)?
   ) {
     log(
       operation: "setUser",
@@ -645,7 +645,7 @@ public extension PubNub.DataSyncAPI {
 
     route(
       router,
-      responseDecoder: DataSyncSingleValueResponseDecoder<PubNubDataSyncUser>(),
+      responseDecoder: DataSyncSingleValueResponseDecoder<PubNubDataSyncEntity>(),
       custom: requestConfig
     ) { result in
       completion?(result.map { $0.payload.data })
@@ -659,17 +659,17 @@ public extension PubNub.DataSyncAPI {
   /// - Parameters:
   ///   - id: The unique identifier of the user
   ///   - operations: The RFC 6902 operations to apply, which must not be empty
-  ///   - ifMatchesEtag: The ``PubNubDataSyncUser/eTag`` last read, to fail the request when the user changed since
+  ///   - ifMatchesEtag: The ``PubNubDataSyncEntity/eTag`` last read, to fail the request when the user changed since
   ///   - custom: Custom configuration overrides for this request
   ///   - completion: The async `Result` of the method call
-  ///     - **Success**: The patched ``PubNubDataSyncUser``
+  ///     - **Success**: The patched ``PubNubDataSyncEntity``
   ///     - **Failure**: An `Error` describing the failure
   func updateUser(
     id: String,
     operations: [PubNubDataSyncPatchOperation],
     ifMatchesEtag: String? = nil,
     custom requestConfig: PubNub.RequestConfiguration = PubNub.RequestConfiguration(),
-    completion: ((Result<PubNubDataSyncUser, Error>) -> Void)?
+    completion: ((Result<PubNubDataSyncEntity, Error>) -> Void)?
   ) {
     log(
       operation: "updateUser",
@@ -689,7 +689,7 @@ public extension PubNub.DataSyncAPI {
 
     route(
       router,
-      responseDecoder: DataSyncSingleValueResponseDecoder<PubNubDataSyncUser>(),
+      responseDecoder: DataSyncSingleValueResponseDecoder<PubNubDataSyncEntity>(),
       custom: requestConfig
     ) { result in
       completion?(result.map { $0.payload.data })
@@ -700,7 +700,7 @@ public extension PubNub.DataSyncAPI {
   ///
   /// - Parameters:
   ///   - id: The unique identifier of the user
-  ///   - ifMatchesEtag: The ``PubNubDataSyncUser/eTag`` last read, to fail the request when the user changed since
+  ///   - ifMatchesEtag: The ``PubNubDataSyncEntity/eTag`` last read, to fail the request when the user changed since
   ///   - custom: Custom configuration overrides for this request
   ///   - completion: The async `Result` of the method call
   ///     - **Success**: An acknowledgement that the user was removed
@@ -752,7 +752,7 @@ public extension PubNub.DataSyncAPI {
   ///   - sort: List of properties to sort the results by
   ///   - custom: Custom configuration overrides for this request
   ///   - completion: The async `Result` of the method call
-  ///     - **Success**: A `Tuple` containing an `Array` of ``PubNubDataSyncChannel``, and the next page (if one exists)
+  ///     - **Success**: A `Tuple` containing an `Array` of ``PubNubDataSyncEntity``, and the next page (if one exists)
   ///     - **Failure**: An `Error` describing the failure
   func getChannels(
     className: String? = nil,
@@ -764,7 +764,7 @@ public extension PubNub.DataSyncAPI {
     filterAdvanced: String? = nil,
     sort: [PubNub.DataSyncSortField] = [],
     custom requestConfig: PubNub.RequestConfiguration = PubNub.RequestConfiguration(),
-    completion: ((Result<(channels: [PubNubDataSyncChannel], next: PubNubDataSyncPage?), Error>) -> Void)?
+    completion: ((Result<(channels: [PubNubDataSyncEntity], next: PubNubDataSyncPage?), Error>) -> Void)?
   ) {
     log(
       operation: "getChannels",
@@ -798,7 +798,7 @@ public extension PubNub.DataSyncAPI {
 
     route(
       router,
-      responseDecoder: DataSyncListValueResponseDecoder<PubNubDataSyncChannel>(),
+      responseDecoder: DataSyncListValueResponseDecoder<PubNubDataSyncEntity>(),
       custom: requestConfig
     ) { result in
       completion?(result.map { (
@@ -814,12 +814,12 @@ public extension PubNub.DataSyncAPI {
   ///   - id: The unique identifier of the channel
   ///   - custom: Custom configuration overrides for this request
   ///   - completion: The async `Result` of the method call
-  ///     - **Success**: The ``PubNubDataSyncChannel`` belonging to the identifier
+  ///     - **Success**: The ``PubNubDataSyncEntity`` belonging to the identifier
   ///     - **Failure**: An `Error` describing the failure
   func getChannel(
     id: String,
     custom requestConfig: PubNub.RequestConfiguration = PubNub.RequestConfiguration(),
-    completion: ((Result<PubNubDataSyncChannel, Error>) -> Void)?
+    completion: ((Result<PubNubDataSyncEntity, Error>) -> Void)?
   ) {
     log(
       operation: "getChannel",
@@ -834,7 +834,7 @@ public extension PubNub.DataSyncAPI {
 
     route(
       router,
-      responseDecoder: DataSyncSingleValueResponseDecoder<PubNubDataSyncChannel>(),
+      responseDecoder: DataSyncSingleValueResponseDecoder<PubNubDataSyncEntity>(),
       custom: requestConfig
     ) { result in
       completion?(result.map { $0.payload.data })
@@ -856,7 +856,7 @@ public extension PubNub.DataSyncAPI {
   ///   - payload: The channel fields
   ///   - custom: Custom configuration overrides for this request
   ///   - completion: The async `Result` of the method call
-  ///     - **Success**: The created ``PubNubDataSyncChannel``
+  ///     - **Success**: The created ``PubNubDataSyncEntity``
   ///     - **Failure**: An `Error` describing the failure
   func createChannel(
     className: String? = nil,
@@ -866,7 +866,7 @@ public extension PubNub.DataSyncAPI {
     status: String? = nil,
     payload: JSONCodable? = nil,
     custom requestConfig: PubNub.RequestConfiguration = PubNub.RequestConfiguration(),
-    completion: ((Result<PubNubDataSyncChannel, Error>) -> Void)?
+    completion: ((Result<PubNubDataSyncEntity, Error>) -> Void)?
   ) {
     log(
       operation: "createChannel",
@@ -898,7 +898,7 @@ public extension PubNub.DataSyncAPI {
 
     route(
       router,
-      responseDecoder: DataSyncSingleValueResponseDecoder<PubNubDataSyncChannel>(),
+      responseDecoder: DataSyncSingleValueResponseDecoder<PubNubDataSyncEntity>(),
       custom: requestConfig
     ) { result in
       completion?(result.map { $0.payload.data })
@@ -916,10 +916,10 @@ public extension PubNub.DataSyncAPI {
   ///   - classVersion: The version of the `Channel` class the payload conforms to
   ///   - status: An arbitrary status to store with the channel
   ///   - payload: The replacement channel fields
-  ///   - ifMatchesEtag: The ``PubNubDataSyncChannel/eTag`` last read, to fail the request when the channel changed since
+  ///   - ifMatchesEtag: The ``PubNubDataSyncEntity/eTag`` last read, to fail the request when the channel changed since
   ///   - custom: Custom configuration overrides for this request
   ///   - completion: The async `Result` of the method call
-  ///     - **Success**: The replaced ``PubNubDataSyncChannel``
+  ///     - **Success**: The replaced ``PubNubDataSyncEntity``
   ///     - **Failure**: An `Error` describing the failure
   func setChannel(
     id: String,
@@ -928,7 +928,7 @@ public extension PubNub.DataSyncAPI {
     payload: JSONCodable? = nil,
     ifMatchesEtag: String? = nil,
     custom requestConfig: PubNub.RequestConfiguration = PubNub.RequestConfiguration(),
-    completion: ((Result<PubNubDataSyncChannel, Error>) -> Void)?
+    completion: ((Result<PubNubDataSyncEntity, Error>) -> Void)?
   ) {
     log(
       operation: "setChannel",
@@ -954,7 +954,7 @@ public extension PubNub.DataSyncAPI {
 
     route(
       router,
-      responseDecoder: DataSyncSingleValueResponseDecoder<PubNubDataSyncChannel>(),
+      responseDecoder: DataSyncSingleValueResponseDecoder<PubNubDataSyncEntity>(),
       custom: requestConfig
     ) { result in
       completion?(result.map { $0.payload.data })
@@ -968,17 +968,17 @@ public extension PubNub.DataSyncAPI {
   /// - Parameters:
   ///   - id: The unique identifier of the channel
   ///   - operations: The RFC 6902 operations to apply, which must not be empty
-  ///   - ifMatchesEtag: The ``PubNubDataSyncChannel/eTag`` last read, to fail the request when the channel changed since
+  ///   - ifMatchesEtag: The ``PubNubDataSyncEntity/eTag`` last read, to fail the request when the channel changed since
   ///   - custom: Custom configuration overrides for this request
   ///   - completion: The async `Result` of the method call
-  ///     - **Success**: The patched ``PubNubDataSyncChannel``
+  ///     - **Success**: The patched ``PubNubDataSyncEntity``
   ///     - **Failure**: An `Error` describing the failure
   func updateChannel(
     id: String,
     operations: [PubNubDataSyncPatchOperation],
     ifMatchesEtag: String? = nil,
     custom requestConfig: PubNub.RequestConfiguration = PubNub.RequestConfiguration(),
-    completion: ((Result<PubNubDataSyncChannel, Error>) -> Void)?
+    completion: ((Result<PubNubDataSyncEntity, Error>) -> Void)?
   ) {
     log(
       operation: "updateChannel",
@@ -998,7 +998,7 @@ public extension PubNub.DataSyncAPI {
 
     route(
       router,
-      responseDecoder: DataSyncSingleValueResponseDecoder<PubNubDataSyncChannel>(),
+      responseDecoder: DataSyncSingleValueResponseDecoder<PubNubDataSyncEntity>(),
       custom: requestConfig
     ) { result in
       completion?(result.map { $0.payload.data })
@@ -1009,7 +1009,7 @@ public extension PubNub.DataSyncAPI {
   ///
   /// - Parameters:
   ///   - id: The unique identifier of the channel
-  ///   - ifMatchesEtag: The ``PubNubDataSyncChannel/eTag`` last read, to fail the request when the channel changed since
+  ///   - ifMatchesEtag: The ``PubNubDataSyncEntity/eTag`` last read, to fail the request when the channel changed since
   ///   - custom: Custom configuration overrides for this request
   ///   - completion: The async `Result` of the method call
   ///     - **Success**: An acknowledgement that the channel was removed

--- a/Sources/PubNub/APIs/DataSync+PubNub.swift
+++ b/Sources/PubNub/APIs/DataSync+PubNub.swift
@@ -128,9 +128,9 @@ public extension PubNub.DataSyncAPI {
   /// Gets a page of entities of a given class.
   ///
   /// - Parameters:
-  ///   - entityClass: The name of the class to list entities of
-  ///   - entityClassVersion: Restricts results to a single class version. If omitted, every version is returned, including classes that extend this one
-  ///   - entityClassLevel: The level to resolve the class name at. If omitted, the first level declaring it wins, searching `subKey`, `account`, then `global`
+  ///   - className: The name of the class to list entities of
+  ///   - classVersion: Restricts results to a single class version. If omitted, every version is returned, including classes that extend this one
+  ///   - classLevel: The level to resolve the class name at. If omitted, the first level declaring it wins, searching `subKey`, `account`, then `global`
   ///   - cursor: The ``PubNubDataSyncPage/cursor`` of a previous page, or `nil` for the first page
   ///   - limit: The number of entities to retrieve, between 1 and 100. Defaults to 20
   ///   - filter: Expression used to filter the results. Mutually exclusive with `filterAdvanced`
@@ -141,9 +141,9 @@ public extension PubNub.DataSyncAPI {
   ///     - **Success**: A `Tuple` containing an `Array` of ``PubNubDataSyncEntity``, and the next page (if one exists)
   ///     - **Failure**: An `Error` describing the failure
   func getEntities(
-    entityClass: String,
-    entityClassVersion: Int? = nil,
-    entityClassLevel: PubNubDataSyncClassLevel? = nil,
+    className: String,
+    classVersion: Int? = nil,
+    classLevel: PubNubDataSyncClassLevel? = nil,
     cursor: String? = nil,
     limit: Int? = nil,
     filter: String? = nil,
@@ -156,9 +156,9 @@ public extension PubNub.DataSyncAPI {
       operation: "getEntities",
       details: "List DataSync entities",
       arguments: [
-        ("entityClass", entityClass),
-        ("entityClassVersion", entityClassVersion),
-        ("entityClassLevel", entityClassLevel?.stringValue),
+        ("className", className),
+        ("classVersion", classVersion),
+        ("classLevel", classLevel?.stringValue),
         ("cursor", cursor),
         ("limit", limit),
         ("filter", filter),
@@ -170,9 +170,9 @@ public extension PubNub.DataSyncAPI {
 
     let router = DataSyncEntityRouter(
       .all(
-        entityClass: entityClass,
-        entityClassVersion: entityClassVersion,
-        entityClassLevel: entityClassLevel?.stringValue,
+        entityClass: className,
+        entityClassVersion: classVersion,
+        entityClassLevel: classLevel?.stringValue,
         cursor: cursor,
         limit: limit,
         filter: filter,
@@ -230,9 +230,9 @@ public extension PubNub.DataSyncAPI {
   /// Creates an entity of a given class.
   ///
   /// - Parameters:
-  ///   - entityClass: The name of the class to create the entity in
-  ///   - entityClassVersion: The version of the class the payload conforms to
-  ///   - entityClassLevel: The level to resolve the class name at. If omitted, the first level declaring it wins, searching `subKey`, `account`, then `global`
+  ///   - className: The name of the class to create the entity in
+  ///   - classVersion: The version of the class the payload conforms to
+  ///   - classLevel: The level to resolve the class name at. If omitted, the first level declaring it wins, searching `subKey`, `account`, then `global`
   ///   - id: The unique identifier to create the entity with, or `nil` to let the service assign one
   ///   - status: An arbitrary status to store with the entity
   ///   - payload: The entity fields
@@ -241,9 +241,9 @@ public extension PubNub.DataSyncAPI {
   ///     - **Success**: The created ``PubNubDataSyncEntity``
   ///     - **Failure**: An `Error` describing the failure
   func createEntity(
-    entityClass: String,
-    entityClassVersion: Int,
-    entityClassLevel: PubNubDataSyncClassLevel? = nil,
+    className: String,
+    classVersion: Int,
+    classLevel: PubNubDataSyncClassLevel? = nil,
     id: String? = nil,
     status: String? = nil,
     payload: JSONCodable? = nil,
@@ -254,9 +254,9 @@ public extension PubNub.DataSyncAPI {
       operation: "createEntity",
       details: "Create DataSync entity",
       arguments: [
-        ("entityClass", entityClass),
-        ("entityClassVersion", entityClassVersion),
-        ("entityClassLevel", entityClassLevel?.stringValue),
+        ("className", className),
+        ("classVersion", classVersion),
+        ("classLevel", classLevel?.stringValue),
         ("id", id),
         ("status", status),
         ("payload", payload),
@@ -268,9 +268,9 @@ public extension PubNub.DataSyncAPI {
       .create(
         body: .init(
           id: id,
-          entityClass: entityClass,
-          entityClassVersion: entityClassVersion,
-          entityClassLevel: entityClassLevel?.stringValue,
+          entityClass: className,
+          entityClassVersion: classVersion,
+          entityClassLevel: classLevel?.stringValue,
           status: status,
           payload: payload?.codableValue
         )
@@ -295,7 +295,7 @@ public extension PubNub.DataSyncAPI {
   ///
   /// - Parameters:
   ///   - id: The unique identifier of the entity
-  ///   - entityClassVersion: The version of the class the payload conforms to
+  ///   - classVersion: The version of the class the payload conforms to
   ///   - status: An arbitrary status to store with the entity
   ///   - payload: The replacement entity fields
   ///   - ifMatchesEtag: The ``PubNubDataSyncEntity/eTag`` last read, to fail the request when the entity changed since
@@ -305,7 +305,7 @@ public extension PubNub.DataSyncAPI {
   ///     - **Failure**: An `Error` describing the failure
   func setEntity(
     id: String,
-    entityClassVersion: Int,
+    classVersion: Int,
     status: String? = nil,
     payload: JSONCodable? = nil,
     ifMatchesEtag: String? = nil,
@@ -317,7 +317,7 @@ public extension PubNub.DataSyncAPI {
       details: "Replace DataSync entity",
       arguments: [
         ("id", id),
-        ("entityClassVersion", entityClassVersion),
+        ("classVersion", classVersion),
         ("status", status),
         ("payload", payload),
         ("ifMatchesEtag", ifMatchesEtag),
@@ -328,7 +328,7 @@ public extension PubNub.DataSyncAPI {
     let router = DataSyncEntityRouter(
       .replace(
         id: id,
-        body: .init(status: status, entityClassVersion: entityClassVersion, payload: payload?.codableValue),
+        body: .init(status: status, entityClassVersion: classVersion, payload: payload?.codableValue),
         ifMatch: ifMatchesEtag
       ),
       configuration: configuration(from: requestConfig)
@@ -345,7 +345,7 @@ public extension PubNub.DataSyncAPI {
 
   /// Applies a set of JSON Patch operations to an entity.
   ///
-  /// The operations are applied atomically: if any one of them fails, the channel is left unchanged.
+  /// The operations are applied atomically: if any one of them fails, the entity is left unchanged.
   ///
   /// - Parameters:
   ///   - id: The unique identifier of the entity
@@ -431,8 +431,8 @@ public extension PubNub.DataSyncAPI {
   /// Called without any class parameters, this lists users of the built-in `User` class declared at `global`.
   ///
   /// - Parameters:
-  ///   - classVersion: Restricts results to a single version of the `User` class. If omitted, every version is returned, including classes that extend `User`
   ///   - className: The class to list, which must be `User` or a class that extends it. Defaults to `User`
+  ///   - classVersion: Restricts results to a single version of the `User` class. If omitted, every version is returned, including classes that extend `User`
   ///   - classLevel: The level to resolve `className` at
   ///     - **Omitted**: the first level declaring it wins, searching `subKey`, `account`, then `global`
   ///     - **Provided**: only that level is searched
@@ -446,8 +446,8 @@ public extension PubNub.DataSyncAPI {
   ///     - **Success**: A `Tuple` containing an `Array` of ``PubNubDataSyncUser``, and the next page (if one exists)
   ///     - **Failure**: An `Error` describing the failure
   func getUsers(
-    classVersion: Int? = nil,
     className: String? = nil,
+    classVersion: Int? = nil,
     classLevel: PubNubDataSyncClassLevel? = nil,
     cursor: String? = nil,
     limit: Int? = nil,
@@ -461,8 +461,8 @@ public extension PubNub.DataSyncAPI {
       operation: "getUsers",
       details: "List DataSync users",
       arguments: [
-        ("classVersion", classVersion),
         ("className", className),
+        ("classVersion", classVersion),
         ("classLevel", classLevel?.stringValue),
         ("cursor", cursor),
         ("limit", limit),
@@ -537,8 +537,8 @@ public extension PubNub.DataSyncAPI {
   /// Called without any class parameters, this creates a user of the built-in `User` class declared at `global`.
   ///
   /// - Parameters:
-  ///   - classVersion: The version of the `User` class the payload conforms to
   ///   - className: The class to create the user in, which must be `User` or a class that extends it. Defaults to `User`
+  ///   - classVersion: The version of the `User` class the payload conforms to
   ///   - classLevel: The level to resolve `className` at
   ///     - **Omitted**: the first level declaring it wins, searching `subKey`, `account`, then `global`
   ///     - **Provided**: only that level is searched
@@ -550,8 +550,8 @@ public extension PubNub.DataSyncAPI {
   ///     - **Success**: The created ``PubNubDataSyncUser``
   ///     - **Failure**: An `Error` describing the failure
   func createUser(
-    classVersion: Int,
     className: String? = nil,
+    classVersion: Int,
     classLevel: PubNubDataSyncClassLevel? = nil,
     id: String? = nil,
     status: String? = nil,
@@ -563,8 +563,8 @@ public extension PubNub.DataSyncAPI {
       operation: "createUser",
       details: "Create DataSync user",
       arguments: [
-        ("classVersion", classVersion),
         ("className", className),
+        ("classVersion", classVersion),
         ("classLevel", classLevel?.stringValue),
         ("id", id),
         ("status", status),
@@ -654,7 +654,7 @@ public extension PubNub.DataSyncAPI {
 
   /// Applies a set of JSON Patch operations to a user.
   ///
-  /// The operations are applied atomically: if any one of them fails, the channel is left unchanged.
+  /// The operations are applied atomically: if any one of them fails, the user is left unchanged.
   ///
   /// - Parameters:
   ///   - id: The unique identifier of the user
@@ -740,8 +740,8 @@ public extension PubNub.DataSyncAPI {
   /// Called without any class parameters, this lists channels of the built-in `Channel` class declared at `global`.
   ///
   /// - Parameters:
-  ///   - classVersion: Restricts results to a single version of the `Channel` class. If omitted, every version is returned, including classes that extend `Channel`
   ///   - className: The class to list, which must be `Channel` or a class that extends it. Defaults to `Channel`
+  ///   - classVersion: Restricts results to a single version of the `Channel` class. If omitted, every version is returned, including classes that extend `Channel`
   ///   - classLevel: The level to resolve `className` at
   ///     - **Omitted**: the first level declaring it wins, searching `subKey`, `account`, then `global`
   ///     - **Provided**: only that level is searched
@@ -755,8 +755,8 @@ public extension PubNub.DataSyncAPI {
   ///     - **Success**: A `Tuple` containing an `Array` of ``PubNubDataSyncChannel``, and the next page (if one exists)
   ///     - **Failure**: An `Error` describing the failure
   func getChannels(
-    classVersion: Int? = nil,
     className: String? = nil,
+    classVersion: Int? = nil,
     classLevel: PubNubDataSyncClassLevel? = nil,
     cursor: String? = nil,
     limit: Int? = nil,
@@ -770,8 +770,8 @@ public extension PubNub.DataSyncAPI {
       operation: "getChannels",
       details: "List DataSync channels",
       arguments: [
-        ("classVersion", classVersion),
         ("className", className),
+        ("classVersion", classVersion),
         ("classLevel", classLevel?.stringValue),
         ("cursor", cursor),
         ("limit", limit),
@@ -846,8 +846,8 @@ public extension PubNub.DataSyncAPI {
   /// Called without any class parameters, this creates a channel of the built-in `Channel` class declared at `global`.
   ///
   /// - Parameters:
-  ///   - classVersion: The version of the `Channel` class the payload conforms to
   ///   - className: The class to create the channel in, which must be `Channel` or a class that extends it. Defaults to `Channel`
+  ///   - classVersion: The version of the `Channel` class the payload conforms to
   ///   - classLevel: The level to resolve `className` at
   ///     - **Omitted**: the first level declaring it wins, searching `subKey`, `account`, then `global`
   ///     - **Provided**: only that level is searched
@@ -859,8 +859,8 @@ public extension PubNub.DataSyncAPI {
   ///     - **Success**: The created ``PubNubDataSyncChannel``
   ///     - **Failure**: An `Error` describing the failure
   func createChannel(
-    classVersion: Int,
     className: String? = nil,
+    classVersion: Int,
     classLevel: PubNubDataSyncClassLevel? = nil,
     id: String? = nil,
     status: String? = nil,
@@ -872,8 +872,8 @@ public extension PubNub.DataSyncAPI {
       operation: "createChannel",
       details: "Create DataSync channel",
       arguments: [
-        ("classVersion", classVersion),
         ("className", className),
+        ("classVersion", classVersion),
         ("classLevel", classLevel?.stringValue),
         ("id", id),
         ("status", status),
@@ -1263,7 +1263,7 @@ public extension PubNub.DataSyncAPI {
 
   /// Applies a set of JSON Patch operations to a membership.
   ///
-  /// The operations are applied atomically: if any one of them fails, the channel is left unchanged.
+  /// The operations are applied atomically: if any one of them fails, the membership is left unchanged.
   ///
   /// - Parameters:
   ///   - id: The unique identifier of the membership
@@ -1347,10 +1347,10 @@ public extension PubNub.DataSyncAPI {
   /// Gets a page of relationships of a given class.
   ///
   /// - Parameters:
-  ///   - relationshipClass: The name of the class to list relationships of
+  ///   - className: The name of the class to list relationships of
   ///   - entityAId: Restricts results to relationships whose side A is this entity
   ///   - entityBId: Restricts results to relationships whose side B is this entity
-  ///   - relationshipClassVersion: Restricts results to a single version of the class. If omitted, every version is returned
+  ///   - classVersion: Restricts results to a single version of the class. If omitted, every version is returned
   ///   - cursor: The ``PubNubDataSyncPage/cursor`` of a previous page, or `nil` for the first page
   ///   - limit: The number of relationships to retrieve, between 1 and 100. Defaults to 20
   ///   - filter: Expression used to filter the results. Mutually exclusive with `filterAdvanced`
@@ -1361,10 +1361,10 @@ public extension PubNub.DataSyncAPI {
   ///     - **Success**: A `Tuple` containing an `Array` of ``PubNubDataSyncRelationship``, and the next page (if one exists)
   ///     - **Failure**: An `Error` describing the failure
   func getRelationships(
-    relationshipClass: String,
+    className: String,
     entityAId: String? = nil,
     entityBId: String? = nil,
-    relationshipClassVersion: Int? = nil,
+    classVersion: Int? = nil,
     cursor: String? = nil,
     limit: Int? = nil,
     filter: String? = nil,
@@ -1377,10 +1377,10 @@ public extension PubNub.DataSyncAPI {
       operation: "getRelationships",
       details: "List DataSync relationships",
       arguments: [
-        ("relationshipClass", relationshipClass),
+        ("className", className),
         ("entityAId", entityAId),
         ("entityBId", entityBId),
-        ("relationshipClassVersion", relationshipClassVersion),
+        ("classVersion", classVersion),
         ("cursor", cursor),
         ("limit", limit),
         ("filter", filter),
@@ -1392,10 +1392,10 @@ public extension PubNub.DataSyncAPI {
 
     let router = DataSyncRelationshipRouter(
       .all(
-        relationshipClass: relationshipClass,
+        relationshipClass: className,
         entityAId: entityAId,
         entityBId: entityBId,
-        relationshipClassVersion: relationshipClassVersion,
+        relationshipClassVersion: classVersion,
         cursor: cursor,
         limit: limit,
         filter: filter,
@@ -1453,10 +1453,10 @@ public extension PubNub.DataSyncAPI {
   /// Creates a relationship connecting two entities.
   ///
   /// - Parameters:
-  ///   - relationshipClass: The name of the class to create the relationship in
+  ///   - className: The name of the class to create the relationship in
   ///   - entityAId: The unique identifier of the entity on side A
   ///   - entityBId: The unique identifier of the entity on side B
-  ///   - relationshipClassVersion: The version of the class the payload conforms to
+  ///   - classVersion: The version of the class the payload conforms to
   ///   - id: The unique identifier to create the relationship with, or `nil` to let the service assign one
   ///   - status: An arbitrary status to store with the relationship
   ///   - payload: The relationship fields
@@ -1465,10 +1465,10 @@ public extension PubNub.DataSyncAPI {
   ///     - **Success**: The created ``PubNubDataSyncRelationship``
   ///     - **Failure**: An `Error` describing the failure
   func createRelationship(
-    relationshipClass: String,
+    className: String,
     entityAId: String,
     entityBId: String,
-    relationshipClassVersion: Int,
+    classVersion: Int,
     id: String? = nil,
     status: String? = nil,
     payload: JSONCodable? = nil,
@@ -1479,10 +1479,10 @@ public extension PubNub.DataSyncAPI {
       operation: "createRelationship",
       details: "Create DataSync relationship",
       arguments: [
-        ("relationshipClass", relationshipClass),
+        ("className", className),
         ("entityAId", entityAId),
         ("entityBId", entityBId),
-        ("relationshipClassVersion", relationshipClassVersion),
+        ("classVersion", classVersion),
         ("id", id),
         ("status", status),
         ("payload", payload),
@@ -1496,8 +1496,8 @@ public extension PubNub.DataSyncAPI {
           id: id,
           entityAId: entityAId,
           entityBId: entityBId,
-          relationshipClass: relationshipClass,
-          relationshipClassVersion: relationshipClassVersion,
+          relationshipClass: className,
+          relationshipClassVersion: classVersion,
           status: status,
           payload: payload?.codableValue
         )
@@ -1522,7 +1522,7 @@ public extension PubNub.DataSyncAPI {
   ///
   /// - Parameters:
   ///   - id: The unique identifier of the relationship
-  ///   - relationshipClassVersion: The version of the class the payload conforms to
+  ///   - classVersion: The version of the class the payload conforms to
   ///   - status: An arbitrary status to store with the relationship
   ///   - payload: The replacement relationship fields
   ///   - ifMatchesEtag: The ``PubNubDataSyncRelationship/eTag`` last read, to fail the request when it changed since
@@ -1532,7 +1532,7 @@ public extension PubNub.DataSyncAPI {
   ///     - **Failure**: An `Error` describing the failure
   func setRelationship(
     id: String,
-    relationshipClassVersion: Int,
+    classVersion: Int,
     status: String? = nil,
     payload: JSONCodable? = nil,
     ifMatchesEtag: String? = nil,
@@ -1544,7 +1544,7 @@ public extension PubNub.DataSyncAPI {
       details: "Replace DataSync relationship",
       arguments: [
         ("id", id),
-        ("relationshipClassVersion", relationshipClassVersion),
+        ("classVersion", classVersion),
         ("status", status),
         ("payload", payload),
         ("ifMatchesEtag", ifMatchesEtag),
@@ -1557,7 +1557,7 @@ public extension PubNub.DataSyncAPI {
         id: id,
         body: .init(
           status: status,
-          relationshipClassVersion: relationshipClassVersion,
+          relationshipClassVersion: classVersion,
           payload: payload?.codableValue
         ),
         ifMatch: ifMatchesEtag
@@ -1576,7 +1576,7 @@ public extension PubNub.DataSyncAPI {
 
   /// Applies a set of JSON Patch operations to a relationship.
   ///
-  /// The operations are applied atomically: if any one of them fails, the channel is left unchanged.
+  /// The operations are applied atomically: if any one of them fails, the relationship is left unchanged.
   ///
   /// - Parameters:
   ///   - id: The unique identifier of the relationship

--- a/Sources/PubNub/APIs/Subscribable+PubNub.swift
+++ b/Sources/PubNub/APIs/Subscribable+PubNub.swift
@@ -11,69 +11,85 @@
 import Foundation
 
 public extension PubNub {
-  /// Returns a handle to the channel with the given name.
+  /// Returns a reference to the channel with the given name.
   ///
-  /// This sends no request and changes nothing on the server; it only names the channel that can be
-  /// subscribed to and unsubscribed from.
+  /// This sends no request and changes nothing on the server.
   ///
-  /// - Parameters:
-  ///   - name: The name identifying the channel.
-  /// - Returns: A `Channel` handle for that name.
+  /// - Parameter name: The name of the channel
+  /// - Returns: A `Channel` for the given name
   func channel(_ name: String) -> Channel {
     Channel(name: name, pubnub: self)
   }
 
-  /// Returns a handle to the channel group with the given name.
+  /// Returns a reference to the channel group with the given name.
   ///
-  /// This sends no request and changes nothing on the server: it neither creates the group nor alters
+  /// This sends no request and changes nothing on the server: it neither creates the group nor changes
   /// which channels belong to it.
   ///
-  /// - Parameters:
-  ///   - name: The name identifying the channel group.
-  /// - Returns: A `ChannelGroup` handle for that name.
+  /// - Parameter name: The name of the channel group
+  /// - Returns: A `ChannelGroup` for the given name
   func channelGroup(_ name: String) -> ChannelGroup {
     ChannelGroup(name: name, pubnub: self)
   }
 
-  /// Returns a handle to the stream of App Context changes made to the given user metadata record.
+  /// Returns a reference to the App Context user metadata record with the given identifier.
   ///
   /// This sends no request and changes nothing on the server: it neither creates nor reads the record.
   ///
-  /// - Parameters:
-  ///   - name: The identifier of the user metadata record whose changes should be delivered.
-  /// - Returns: A `UserMetadata` handle for that identifier.
+  /// - Parameter name: The identifier of the user metadata record
+  /// - Returns: A `UserMetadata` for the given identifier
   func userMetadata(_ name: String) -> UserMetadata {
     UserMetadata(id: name, pubnub: self)
   }
 
-  /// Returns a handle to the stream of App Context changes made to the given channel metadata record.
+  /// Returns a reference to the App Context channel metadata record with the given identifier.
   ///
   /// This sends no request and changes nothing on the server: it neither creates nor reads the record.
   ///
-  /// - Parameters:
-  ///   - name: The identifier of the channel metadata record whose changes should be delivered.
-  /// - Returns: A `ChannelMetadata` handle for that identifier.
+  /// - Parameter name: The identifier of the channel metadata record
+  /// - Returns: A `ChannelMetadata` for the given identifier
   func channelMetadata(_ name: String) -> ChannelMetadata {
     ChannelMetadata(id: name, pubnub: self)
   }
 
-  /// Creates a `SubscriptionSet` object from the collection of `Subscribable` values.
+  /// Creates a `SubscriptionSet` from a collection of `Subscribable` values.
   ///
-  /// Use this function to set up and manage subscriptions for several `Subscribable` values at once.
+  /// Use this function to subscribe to several `Subscribable` values at once.
   ///
   /// - Parameters:
   ///   - queue: The dispatch queue on which the subscription events should be handled
-  ///   - entities: A collection of `Subscribable` values to subscribe to
+  ///   - targets: The values to receive events for
   ///   - options: Additional options for configuring the subscription
-  /// - Returns: A `SubscriptionSet` instance for managing the specified values.
+  /// - Returns: A `SubscriptionSet` managing the given values
   func subscription(
     queue: DispatchQueue = .main,
-    entities: any Collection<Subscribable>,
+    targets: any Collection<Subscribable>,
     options: SubscriptionOptions = SubscriptionOptions.empty()
   ) -> SubscriptionSet {
     SubscriptionSet(
       queue: queue,
-      entities: entities,
+      targets: targets,
+      options: options
+    )
+  }
+
+  /// Creates a `SubscriptionSet` from existing `Subscription` values.
+  ///
+  /// Use this function to manage subscriptions you already created as one unit.
+  ///
+  /// - Parameters:
+  ///   - queue: The dispatch queue on which the subscription events should be handled
+  ///   - subscriptions: The existing `Subscription` values to manage together
+  ///   - options: Additional options for configuring the subscription
+  /// - Returns: A `SubscriptionSet` managing the given subscriptions
+  func subscription(
+    queue: DispatchQueue = .main,
+    subscriptions: any Collection<Subscription>,
+    options: SubscriptionOptions = SubscriptionOptions.empty()
+  ) -> SubscriptionSet {
+    SubscriptionSet(
+      queue: queue,
+      subscriptions: subscriptions,
       options: options
     )
   }

--- a/Sources/PubNub/APIs/Subscribable+PubNub.swift
+++ b/Sources/PubNub/APIs/Subscribable+PubNub.swift
@@ -52,6 +52,31 @@ public extension PubNub {
     ChannelMetadata(id: name, pubnub: self)
   }
 
+  /// Returns a reference to the Data Sync user with the given identifier.
+  func dataSyncUser(_ id: String) -> DataSyncUser {
+    DataSyncUser(id: id, pubnub: self)
+  }
+
+  /// Returns a reference to the Data Sync channel with the given identifier.
+  func dataSyncChannel(_ id: String) -> DataSyncChannel {
+    DataSyncChannel(id: id, pubnub: self)
+  }
+
+  /// Returns a reference to the Data Sync membership with the given identifier.
+  func dataSyncMembership(_ id: String) -> DataSyncMembership {
+    DataSyncMembership(id: id, pubnub: self)
+  }
+
+  /// Returns a reference to the Data Sync entity with the given identifier.
+  func dataSyncEntity(_ id: String) -> DataSyncEntity {
+    DataSyncEntity(id: id, pubnub: self)
+  }
+
+  /// Returns a reference to the Data Sync relationship with the given identifier.
+  func dataSyncRelationship(_ id: String) -> DataSyncRelationship {
+    DataSyncRelationship(id: id, pubnub: self)
+  }
+
   /// Creates a `SubscriptionSet` from a collection of `Subscribable` values.
   ///
   /// Use this function to subscribe to several `Subscribable` values at once.

--- a/Sources/PubNub/KMP/KMPPubNub+DataSyncChannels.swift
+++ b/Sources/PubNub/KMP/KMPPubNub+DataSyncChannels.swift
@@ -22,8 +22,8 @@ import Foundation
 @objc
 public extension KMPPubNub {
   func getDataSyncChannels(
-    classVersion: NSNumber?,
     className: String?,
+    classVersion: NSNumber?,
     classLevel: String?,
     cursor: String?,
     limit: NSNumber?,
@@ -34,8 +34,8 @@ public extension KMPPubNub {
     onFailure: @escaping ((Error) -> Void)
   ) {
     pubnub.dataSync.getChannels(
-      classVersion: classVersion?.intValue,
       className: className,
+      classVersion: classVersion?.intValue,
       classLevel: dataSyncClassLevel(from: classLevel),
       cursor: cursor,
       limit: limit?.intValue,
@@ -71,8 +71,8 @@ public extension KMPPubNub {
   }
 
   func createDataSyncChannel(
-    classVersion: Int,
     className: String?,
+    classVersion: Int,
     classLevel: String?,
     id: String?,
     status: String?,
@@ -81,8 +81,8 @@ public extension KMPPubNub {
     onFailure: @escaping ((Error) -> Void)
   ) {
     pubnub.dataSync.createChannel(
-      classVersion: classVersion,
       className: className,
+      classVersion: classVersion,
       classLevel: dataSyncClassLevel(from: classLevel),
       id: id,
       status: status,

--- a/Sources/PubNub/KMP/KMPPubNub+DataSyncEntities.swift
+++ b/Sources/PubNub/KMP/KMPPubNub+DataSyncEntities.swift
@@ -22,9 +22,9 @@ import Foundation
 @objc
 public extension KMPPubNub {
   func getDataSyncEntities(
-    entityClass: String,
-    entityClassVersion: NSNumber?,
-    entityClassLevel: String?,
+    className: String,
+    classVersion: NSNumber?,
+    classLevel: String?,
     cursor: String?,
     limit: NSNumber?,
     filter: String?,
@@ -34,9 +34,9 @@ public extension KMPPubNub {
     onFailure: @escaping ((Error) -> Void)
   ) {
     pubnub.dataSync.getEntities(
-      entityClass: entityClass,
-      entityClassVersion: entityClassVersion?.intValue,
-      entityClassLevel: dataSyncClassLevel(from: entityClassLevel),
+      className: className,
+      classVersion: classVersion?.intValue,
+      classLevel: dataSyncClassLevel(from: classLevel),
       cursor: cursor,
       limit: limit?.intValue,
       filter: filter,
@@ -71,9 +71,9 @@ public extension KMPPubNub {
   }
 
   func createDataSyncEntity(
-    entityClass: String,
-    entityClassVersion: Int,
-    entityClassLevel: String?,
+    className: String,
+    classVersion: Int,
+    classLevel: String?,
     id: String?,
     status: String?,
     payload: Any?,
@@ -81,9 +81,9 @@ public extension KMPPubNub {
     onFailure: @escaping ((Error) -> Void)
   ) {
     pubnub.dataSync.createEntity(
-      entityClass: entityClass,
-      entityClassVersion: entityClassVersion,
-      entityClassLevel: dataSyncClassLevel(from: entityClassLevel),
+      className: className,
+      classVersion: classVersion,
+      classLevel: dataSyncClassLevel(from: classLevel),
       id: id,
       status: status,
       payload: asOptionalCodable(payload)
@@ -99,7 +99,7 @@ public extension KMPPubNub {
 
   func setDataSyncEntity(
     id: String,
-    entityClassVersion: Int,
+    classVersion: Int,
     status: String?,
     payload: Any?,
     ifMatchesEtag: String?,
@@ -108,7 +108,7 @@ public extension KMPPubNub {
   ) {
     pubnub.dataSync.setEntity(
       id: id,
-      entityClassVersion: entityClassVersion,
+      classVersion: classVersion,
       status: status,
       payload: asOptionalCodable(payload),
       ifMatchesEtag: ifMatchesEtag

--- a/Sources/PubNub/KMP/KMPPubNub+DataSyncRelationships.swift
+++ b/Sources/PubNub/KMP/KMPPubNub+DataSyncRelationships.swift
@@ -22,10 +22,10 @@ import Foundation
 @objc
 public extension KMPPubNub {
   func getDataSyncRelationships(
-    relationshipClass: String,
+    className: String,
     entityAId: String?,
     entityBId: String?,
-    relationshipClassVersion: NSNumber?,
+    classVersion: NSNumber?,
     cursor: String?,
     limit: NSNumber?,
     filter: String?,
@@ -35,10 +35,10 @@ public extension KMPPubNub {
     onFailure: @escaping ((Error) -> Void)
   ) {
     pubnub.dataSync.getRelationships(
-      relationshipClass: relationshipClass,
+      className: className,
       entityAId: entityAId,
       entityBId: entityBId,
-      relationshipClassVersion: relationshipClassVersion?.intValue,
+      classVersion: classVersion?.intValue,
       cursor: cursor,
       limit: limit?.intValue,
       filter: filter,
@@ -73,10 +73,10 @@ public extension KMPPubNub {
   }
 
   func createDataSyncRelationship(
-    relationshipClass: String,
+    className: String,
     entityAId: String,
     entityBId: String,
-    relationshipClassVersion: Int,
+    classVersion: Int,
     id: String?,
     status: String?,
     payload: Any?,
@@ -84,10 +84,10 @@ public extension KMPPubNub {
     onFailure: @escaping ((Error) -> Void)
   ) {
     pubnub.dataSync.createRelationship(
-      relationshipClass: relationshipClass,
+      className: className,
       entityAId: entityAId,
       entityBId: entityBId,
-      relationshipClassVersion: relationshipClassVersion,
+      classVersion: classVersion,
       id: id,
       status: status,
       payload: asOptionalCodable(payload)
@@ -103,7 +103,7 @@ public extension KMPPubNub {
 
   func setDataSyncRelationship(
     id: String,
-    relationshipClassVersion: Int,
+    classVersion: Int,
     status: String?,
     payload: Any?,
     ifMatchesEtag: String?,
@@ -112,7 +112,7 @@ public extension KMPPubNub {
   ) {
     pubnub.dataSync.setRelationship(
       id: id,
-      relationshipClassVersion: relationshipClassVersion,
+      classVersion: classVersion,
       status: status,
       payload: asOptionalCodable(payload),
       ifMatchesEtag: ifMatchesEtag

--- a/Sources/PubNub/KMP/KMPPubNub+DataSyncRelationships.swift
+++ b/Sources/PubNub/KMP/KMPPubNub+DataSyncRelationships.swift
@@ -23,9 +23,9 @@ import Foundation
 public extension KMPPubNub {
   func getDataSyncRelationships(
     className: String,
+    classVersion: NSNumber?,
     entityAId: String?,
     entityBId: String?,
-    classVersion: NSNumber?,
     cursor: String?,
     limit: NSNumber?,
     filter: String?,
@@ -36,9 +36,9 @@ public extension KMPPubNub {
   ) {
     pubnub.dataSync.getRelationships(
       className: className,
+      classVersion: classVersion?.intValue,
       entityAId: entityAId,
       entityBId: entityBId,
-      classVersion: classVersion?.intValue,
       cursor: cursor,
       limit: limit?.intValue,
       filter: filter,
@@ -74,9 +74,9 @@ public extension KMPPubNub {
 
   func createDataSyncRelationship(
     className: String,
+    classVersion: Int,
     entityAId: String,
     entityBId: String,
-    classVersion: Int,
     id: String?,
     status: String?,
     payload: Any?,
@@ -85,9 +85,9 @@ public extension KMPPubNub {
   ) {
     pubnub.dataSync.createRelationship(
       className: className,
+      classVersion: classVersion,
       entityAId: entityAId,
       entityBId: entityBId,
-      classVersion: classVersion,
       id: id,
       status: status,
       payload: asOptionalCodable(payload)

--- a/Sources/PubNub/KMP/KMPPubNub+DataSyncUsers.swift
+++ b/Sources/PubNub/KMP/KMPPubNub+DataSyncUsers.swift
@@ -22,8 +22,8 @@ import Foundation
 @objc
 public extension KMPPubNub {
   func getDataSyncUsers(
-    classVersion: NSNumber?,
     className: String?,
+    classVersion: NSNumber?,
     classLevel: String?,
     cursor: String?,
     limit: NSNumber?,
@@ -34,8 +34,8 @@ public extension KMPPubNub {
     onFailure: @escaping ((Error) -> Void)
   ) {
     pubnub.dataSync.getUsers(
-      classVersion: classVersion?.intValue,
       className: className,
+      classVersion: classVersion?.intValue,
       classLevel: dataSyncClassLevel(from: classLevel),
       cursor: cursor,
       limit: limit?.intValue,
@@ -71,8 +71,8 @@ public extension KMPPubNub {
   }
 
   func createDataSyncUser(
-    classVersion: Int,
     className: String?,
+    classVersion: Int,
     classLevel: String?,
     id: String?,
     status: String?,
@@ -81,8 +81,8 @@ public extension KMPPubNub {
     onFailure: @escaping ((Error) -> Void)
   ) {
     pubnub.dataSync.createUser(
-      classVersion: classVersion,
       className: className,
+      classVersion: classVersion,
       classLevel: dataSyncClassLevel(from: classLevel),
       id: id,
       status: status,

--- a/Sources/PubNub/KMP/KMPPubNub.swift
+++ b/Sources/PubNub/KMP/KMPPubNub.swift
@@ -101,6 +101,26 @@ public extension KMPPubNub {
   func channelMetadata(with id: String) -> KMPChannelMetadataEntity {
     KMPChannelMetadataEntity(channelMetadata: pubnub.channelMetadata(id))
   }
+
+  func dataSyncUser(with id: String) -> KMPDataSyncUserReference {
+    KMPDataSyncUserReference(user: pubnub.dataSyncUser(id))
+  }
+
+  func dataSyncChannel(with id: String) -> KMPDataSyncChannelReference {
+    KMPDataSyncChannelReference(channel: pubnub.dataSyncChannel(id))
+  }
+
+  func dataSyncMembership(with id: String) -> KMPDataSyncMembershipReference {
+    KMPDataSyncMembershipReference(membership: pubnub.dataSyncMembership(id))
+  }
+
+  func dataSyncEntity(with id: String) -> KMPDataSyncEntityReference {
+    KMPDataSyncEntityReference(entity: pubnub.dataSyncEntity(id))
+  }
+
+  func dataSyncRelationship(with id: String) -> KMPDataSyncRelationshipReference {
+    KMPDataSyncRelationshipReference(relationship: pubnub.dataSyncRelationship(id))
+  }
 }
 
 // MARK: - LogLevel

--- a/Sources/PubNub/KMP/Wrappers/KMPDataSyncEvent.swift
+++ b/Sources/PubNub/KMP/Wrappers/KMPDataSyncEvent.swift
@@ -92,9 +92,9 @@ public class KMPDataSyncRelationshipUpdatedResult: KMPDataSyncEvent {
 
 @objc
 public class KMPDataSyncRelationshipDeletedResult: KMPDataSyncEvent {
-  @objc public let removedObject: KMPDataSyncRemovedObject
+  @objc public let removedObject: KMPDataSyncRemovedRelationship
 
-  init(removedObject: KMPDataSyncRemovedObject) {
+  init(removedObject: KMPDataSyncRemovedRelationship) {
     self.removedObject = removedObject
     super.init(event: "relationshipDeleted")
   }
@@ -120,6 +120,24 @@ public class KMPDataSyncRemovedObject: NSObject {
   }
 }
 
+// MARK: - KMPDataSyncRemovedRelationship
+
+@objc
+public class KMPDataSyncRemovedRelationship: NSObject {
+  @objc public let id: String
+  // Named `objectClass` rather than `className` because `NSObject` already exposes a `className` selector
+  @objc public let objectClass: String
+  @objc public let classVersion: Int
+  @objc public let deletedAt: Date
+
+  init(removedRelationship: PubNubDataSyncRemovedRelationship) {
+    self.id = removedRelationship.id
+    self.objectClass = removedRelationship.className
+    self.classVersion = removedRelationship.classVersion
+    self.deletedAt = removedRelationship.deletedAt
+  }
+}
+
 // MARK: - KMPDataSyncEvent (Factory Method)
 
 extension KMPDataSyncEvent {
@@ -135,8 +153,10 @@ extension KMPDataSyncEvent {
       return KMPDataSyncRelationshipCreatedResult(relationship: KMPDataSyncRelationship(relationship: relationship))
     case .relationshipUpdated(let relationship):
       return KMPDataSyncRelationshipUpdatedResult(relationship: KMPDataSyncRelationship(relationship: relationship))
-    case .relationshipDeleted(let removedObject):
-      return KMPDataSyncRelationshipDeletedResult(removedObject: KMPDataSyncRemovedObject(removedObject: removedObject))
+    case .relationshipDeleted(let removedRelationship):
+      return KMPDataSyncRelationshipDeletedResult(
+        removedObject: KMPDataSyncRemovedRelationship(removedRelationship: removedRelationship)
+      )
     }
   }
 }

--- a/Sources/PubNub/KMP/Wrappers/KMPDataSyncObject.swift
+++ b/Sources/PubNub/KMP/Wrappers/KMPDataSyncObject.swift
@@ -63,7 +63,7 @@ public class KMPDataSyncUser: NSObject {
   @objc public let status: String?
   @objc public let payload: KMPAnyJSON?
 
-  init(user: PubNubDataSyncUser) {
+  init(user: PubNubDataSyncEntity) {
     self.id = user.id
     self.entityClass = user.className
     self.classLevel = user.classLevel.stringValue
@@ -93,7 +93,7 @@ public class KMPDataSyncChannel: NSObject {
   @objc public let status: String?
   @objc public let payload: KMPAnyJSON?
 
-  init(channel: PubNubDataSyncChannel) {
+  init(channel: PubNubDataSyncEntity) {
     self.id = channel.id
     self.entityClass = channel.className
     self.classLevel = channel.classLevel.stringValue

--- a/Sources/PubNub/KMP/Wrappers/KMPDataSyncObject.swift
+++ b/Sources/PubNub/KMP/Wrappers/KMPDataSyncObject.swift
@@ -114,7 +114,6 @@ public class KMPDataSyncRelationship: NSObject {
   @objc public let id: String
   // Named `relationshipClass` rather than `className` because `NSObject` already exposes a `className` selector
   @objc public let relationshipClass: String
-  @objc public let classLevel: String?
   @objc public let classVersion: Int
   @objc public let entityAId: String
   @objc public let entityBId: String
@@ -128,7 +127,6 @@ public class KMPDataSyncRelationship: NSObject {
   init(relationship: PubNubDataSyncRelationship) {
     self.id = relationship.id
     self.relationshipClass = relationship.className
-    self.classLevel = relationship.classLevel?.stringValue
     self.classVersion = relationship.classVersion
     self.entityAId = relationship.entityAId
     self.entityBId = relationship.entityBId

--- a/Sources/PubNub/KMP/Wrappers/KMPEntity.swift
+++ b/Sources/PubNub/KMP/Wrappers/KMPEntity.swift
@@ -64,3 +64,94 @@ public class KMPChannelMetadataEntity: KMPEntity {
     super.init(entity: channelMetadata)
   }
 }
+
+// MARK: - Data Sync
+
+@objc
+public class KMPDataSyncReference: KMPEntity {
+  @objc public let id: String
+
+  init(id: String, entity: Subscribable) {
+    self.id = id
+    super.init(entity: entity)
+  }
+
+  @objc
+  public func subscription(withProjection projection: String) -> KMPSubscription {
+    KMPSubscription(subscription: dataSyncSubscription(projection: projection))
+  }
+
+  func dataSyncSubscription(projection: String) -> Subscription {
+    fatalError("Subclasses must implement dataSyncSubscription(projection:)")
+  }
+}
+
+@objc
+public class KMPDataSyncUserReference: KMPDataSyncReference {
+  private let user: DataSyncUser
+
+  init(user: DataSyncUser) {
+    self.user = user
+    super.init(id: user.id, entity: user)
+  }
+
+  override func dataSyncSubscription(projection: String) -> Subscription {
+    user.subscription(projection: projection)
+  }
+}
+
+@objc
+public class KMPDataSyncChannelReference: KMPDataSyncReference {
+  private let channel: DataSyncChannel
+
+  init(channel: DataSyncChannel) {
+    self.channel = channel
+    super.init(id: channel.id, entity: channel)
+  }
+
+  override func dataSyncSubscription(projection: String) -> Subscription {
+    channel.subscription(projection: projection)
+  }
+}
+
+@objc
+public class KMPDataSyncMembershipReference: KMPDataSyncReference {
+  private let membership: DataSyncMembership
+
+  init(membership: DataSyncMembership) {
+    self.membership = membership
+    super.init(id: membership.id, entity: membership)
+  }
+
+  override func dataSyncSubscription(projection: String) -> Subscription {
+    membership.subscription(projection: projection)
+  }
+}
+
+@objc
+public class KMPDataSyncEntityReference: KMPDataSyncReference {
+  private let dataSyncEntity: DataSyncEntity
+
+  init(entity: DataSyncEntity) {
+    self.dataSyncEntity = entity
+    super.init(id: entity.id, entity: entity)
+  }
+
+  override func dataSyncSubscription(projection: String) -> Subscription {
+    dataSyncEntity.subscription(projection: projection)
+  }
+}
+
+@objc
+public class KMPDataSyncRelationshipReference: KMPDataSyncReference {
+  private let relationship: DataSyncRelationship
+
+  init(relationship: DataSyncRelationship) {
+    self.relationship = relationship
+    super.init(id: relationship.id, entity: relationship)
+  }
+
+  override func dataSyncSubscription(projection: String) -> Subscription {
+    relationship.subscription(projection: projection)
+  }
+}

--- a/Sources/PubNub/KMP/Wrappers/KMPEntity.swift
+++ b/Sources/PubNub/KMP/Wrappers/KMPEntity.swift
@@ -23,11 +23,6 @@ import Foundation
   init(entity: Subscribable) {
     self.entity = entity
   }
-
-  @objc
-  public var name: String {
-    entity.name
-  }
 }
 
 @objc

--- a/Sources/PubNub/KMP/Wrappers/KMPSubscription.swift
+++ b/Sources/PubNub/KMP/Wrappers/KMPSubscription.swift
@@ -29,6 +29,10 @@ public class KMPSubscription: NSObject {
   @objc public var onFile: ((KMPFileChangeEvent) -> Void)?
   @objc public var onDataSync: ((KMPDataSyncEvent) -> Void)?
 
+  init(subscription: Subscription) {
+    self.subscription = subscription
+  }
+
   @objc
   public init(entity: KMPEntity, receivePresenceEvents: Bool) {
     self.subscription = Subscription(

--- a/Sources/PubNub/KMP/Wrappers/KMPSubscription.swift
+++ b/Sources/PubNub/KMP/Wrappers/KMPSubscription.swift
@@ -32,14 +32,14 @@ public class KMPSubscription: NSObject {
   @objc
   public init(entity: KMPEntity, receivePresenceEvents: Bool) {
     self.subscription = Subscription(
-      entity: entity.entity,
+      target: entity.entity,
       options: receivePresenceEvents ? ReceivePresenceEvents() : .empty()
     )
   }
 
   @objc
   public init(entity: KMPEntity) {
-    self.subscription = Subscription(entity: entity.entity)
+    self.subscription = Subscription(target: entity.entity)
   }
 
   @objc
@@ -65,7 +65,7 @@ public class KMPSubscription: NSObject {
       listener.onMessageAction?(KMPMessageAction(action: $0))
     }
     eventListener.onFileEvent = { [weak self] in
-      listener.onFile?(KMPFileChangeEvent.from(event: $0, with: self?.subscription.entity.pubnub))
+      listener.onFile?(KMPFileChangeEvent.from(event: $0, with: self?.subscription.target.pubnub))
     }
     eventListener.onAppContext = {
       listener.onAppContext?(KMPAppContextEventResult.from(event: $0))
@@ -102,7 +102,7 @@ public class KMPSubscription: NSObject {
   @objc
   public func append(subscription: KMPSubscription) -> KMPSubscriptionSet {
     let underlyingSubscription = Subscription(
-      entity: subscription.subscription.entity
+      target: subscription.subscription.target
     )
 
     underlyingSubscription.onMessage = {
@@ -164,7 +164,7 @@ public class KMPSubscriptionSet: NSObject {
 
   @objc
   public func addListener(_ listener: KMPEventListener) {
-    let pubnub = subscriptionSet.currentSubscriptions.lockedRead { $0.first }?.entity.pubnub
+    let pubnub = subscriptionSet.currentSubscriptions.lockedRead { $0.first }?.target.pubnub
     let eventListener = EventListener(uuid: listener.uuid)
 
     eventListener.onMessage = {
@@ -216,7 +216,7 @@ public class KMPSubscriptionSet: NSObject {
 
   @objc
   public func append(subscription: KMPSubscription) {
-    let underlyingSubscription = Subscription(entity: subscription.subscription.entity)
+    let underlyingSubscription = Subscription(target: subscription.subscription.target)
 
     underlyingSubscription.onMessage = {
       subscription.onMessage?(KMPMessage(message: $0))

--- a/Sources/PubNub/Models/PubNubDataSync.swift
+++ b/Sources/PubNub/Models/PubNubDataSync.swift
@@ -64,7 +64,7 @@ extension PubNubDataSyncClassLevel: Codable {
 
 // MARK: - PubNubDataSyncEntity
 
-/// Represents a DataSync entity in PubNub DataSync.
+/// Represents a DataSync entity, including specialized user and channel entities.
 public struct PubNubDataSyncEntity: Hashable {
   /// The unique identifier of the entity
   public let id: String
@@ -115,140 +115,6 @@ public struct PubNubDataSyncEntity: Hashable {
 }
 
 extension PubNubDataSyncEntity: Codable {
-  enum CodingKeys: String, CodingKey {
-    case id
-    case className = "entityClass"
-    case classLevel = "entityClassLevel"
-    case classVersion = "entityClassVersion"
-    case createdAt
-    case updatedAt
-    case eTag
-    case expiresAt
-    case status
-    case concretePayload = "payload"
-  }
-}
-
-// MARK: - PubNubDataSyncUser
-
-/// Represents a DataSync user in PubNub DataSync.
-public struct PubNubDataSyncUser: Hashable {
-  /// The unique identifier of the user
-  public let id: String
-  /// The name of the user's class, which is `User` or a class that extends it
-  public let className: String
-  /// The level the user's class is registered at
-  public let classLevel: PubNubDataSyncClassLevel
-  /// The version of the user's class
-  public let classVersion: Int
-  /// The date the user was created
-  public let createdAt: Date
-  /// The date the user was last updated
-  public let updatedAt: Date
-  /// The user revision used for optimistic concurrency
-  public let eTag: String
-  /// The date the user expires, derived from the time-to-live of its class, or `nil` if the class defines no TTL
-  public let expiresAt: Date?
-  /// The user status
-  public let status: String?
-  /// The user fields
-  public var payload: JSONCodable? { concretePayload }
-
-  let concretePayload: AnyJSON?
-
-  init(
-    id: String,
-    className: String,
-    classLevel: PubNubDataSyncClassLevel,
-    classVersion: Int,
-    createdAt: Date,
-    updatedAt: Date,
-    eTag: String,
-    expiresAt: Date? = nil,
-    status: String? = nil,
-    payload: JSONCodable? = nil
-  ) {
-    self.id = id
-    self.className = className
-    self.classLevel = classLevel
-    self.classVersion = classVersion
-    self.createdAt = createdAt
-    self.updatedAt = updatedAt
-    self.eTag = eTag
-    self.expiresAt = expiresAt
-    self.status = status
-    self.concretePayload = payload?.codableValue
-  }
-}
-
-extension PubNubDataSyncUser: Codable {
-  enum CodingKeys: String, CodingKey {
-    case id
-    case className = "entityClass"
-    case classLevel = "entityClassLevel"
-    case classVersion = "entityClassVersion"
-    case createdAt
-    case updatedAt
-    case eTag
-    case expiresAt
-    case status
-    case concretePayload = "payload"
-  }
-}
-
-// MARK: - PubNubDataSyncChannel
-
-/// Represents a DataSync channel in PubNub DataSync.
-public struct PubNubDataSyncChannel: Hashable {
-  /// The unique identifier of the channel
-  public let id: String
-  /// The name of the channel's class, which is `Channel` or a class that extends it
-  public let className: String
-  /// The level the channel's class is registered at
-  public let classLevel: PubNubDataSyncClassLevel
-  /// The version of the channel's class
-  public let classVersion: Int
-  /// The date the channel was created
-  public let createdAt: Date
-  /// The date the channel was last updated
-  public let updatedAt: Date
-  /// The channel revision used for optimistic concurrency
-  public let eTag: String
-  /// The date the channel expires, derived from the time-to-live of its class, or `nil` if the class defines no TTL
-  public let expiresAt: Date?
-  /// The channel status
-  public let status: String?
-  /// The channel fields
-  public var payload: JSONCodable? { concretePayload }
-
-  let concretePayload: AnyJSON?
-
-  init(
-    id: String,
-    className: String,
-    classLevel: PubNubDataSyncClassLevel,
-    classVersion: Int,
-    createdAt: Date,
-    updatedAt: Date,
-    eTag: String,
-    expiresAt: Date? = nil,
-    status: String? = nil,
-    payload: JSONCodable? = nil
-  ) {
-    self.id = id
-    self.className = className
-    self.classLevel = classLevel
-    self.classVersion = classVersion
-    self.createdAt = createdAt
-    self.updatedAt = updatedAt
-    self.eTag = eTag
-    self.expiresAt = expiresAt
-    self.status = status
-    self.concretePayload = payload?.codableValue
-  }
-}
-
-extension PubNubDataSyncChannel: Codable {
   enum CodingKeys: String, CodingKey {
     case id
     case className = "entityClass"
@@ -339,31 +205,32 @@ extension PubNubDataSyncRelationship: Codable {
 
 /// Represents a DataSync membership connecting a channel and a user in PubNub DataSync.
 public struct PubNubDataSyncMembership: Hashable {
+  /// The membership represented as a general DataSync relationship.
+  public let relationship: PubNubDataSyncRelationship
   /// The unique identifier of the membership
-  public let id: String
+  public var id: String { relationship.id }
   /// The unique identifier of the channel the membership belongs to
-  public let channelId: String
+  public var channelId: String { relationship.entityAId }
   /// The unique identifier of the user the membership belongs to
-  public let userId: String
+  public var userId: String { relationship.entityBId }
   /// The name of the membership's class, which is `Membership` or a class that extends it
-  public let className: String
+  public var className: String { relationship.className }
   /// The version of the membership's class
-  public let classVersion: Int
+  public var classVersion: Int { relationship.classVersion }
   /// The date the membership was created
-  public let createdAt: Date
+  public var createdAt: Date { relationship.createdAt }
   /// The date the membership was last updated
-  public let updatedAt: Date
+  public var updatedAt: Date { relationship.updatedAt }
   /// The membership revision used for optimistic concurrency
-  public let eTag: String
-  /// The date the membership expires, derived from the time-to-live of its class,
-  /// or `nil` if the class defines no TTL
-  public let expiresAt: Date?
+  public var eTag: String { relationship.eTag }
+  /// The date the membership expires, derived from the time-to-live of its class, or `nil` if the class defines no TTL
+  public var expiresAt: Date? { relationship.expiresAt }
   /// The membership status
-  public let status: String?
+  public var status: String? { relationship.status }
   /// The membership fields
-  public var payload: JSONCodable? { concretePayload }
+  public var payload: JSONCodable? { relationship.payload }
 
-  let concretePayload: AnyJSON?
+  var concretePayload: AnyJSON? { relationship.concretePayload }
 
   init(
     id: String,
@@ -378,17 +245,19 @@ public struct PubNubDataSyncMembership: Hashable {
     status: String? = nil,
     payload: JSONCodable? = nil
   ) {
-    self.id = id
-    self.channelId = channelId
-    self.userId = userId
-    self.className = className
-    self.classVersion = classVersion
-    self.createdAt = createdAt
-    self.updatedAt = updatedAt
-    self.eTag = eTag
-    self.expiresAt = expiresAt
-    self.status = status
-    self.concretePayload = payload?.codableValue
+    self.relationship = PubNubDataSyncRelationship(
+      id: id,
+      className: className,
+      classVersion: classVersion,
+      entityAId: channelId,
+      entityBId: userId,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      eTag: eTag,
+      expiresAt: expiresAt,
+      status: status,
+      payload: payload
+    )
   }
 }
 
@@ -405,5 +274,39 @@ extension PubNubDataSyncMembership: Codable {
     case expiresAt
     case status
     case concretePayload = "payload"
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+
+    self.init(
+      id: try container.decode(String.self, forKey: .id),
+      channelId: try container.decode(String.self, forKey: .channelId),
+      userId: try container.decode(String.self, forKey: .userId),
+      className: try container.decode(String.self, forKey: .className),
+      classVersion: try container.decode(Int.self, forKey: .classVersion),
+      createdAt: try container.decode(Date.self, forKey: .createdAt),
+      updatedAt: try container.decode(Date.self, forKey: .updatedAt),
+      eTag: try container.decode(String.self, forKey: .eTag),
+      expiresAt: try container.decodeIfPresent(Date.self, forKey: .expiresAt),
+      status: try container.decodeIfPresent(String.self, forKey: .status),
+      payload: try container.decodeIfPresent(AnyJSON.self, forKey: .concretePayload)
+    )
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+
+    try container.encode(id, forKey: .id)
+    try container.encode(channelId, forKey: .channelId)
+    try container.encode(userId, forKey: .userId)
+    try container.encode(className, forKey: .className)
+    try container.encode(classVersion, forKey: .classVersion)
+    try container.encode(createdAt, forKey: .createdAt)
+    try container.encode(updatedAt, forKey: .updatedAt)
+    try container.encode(eTag, forKey: .eTag)
+    try container.encodeIfPresent(expiresAt, forKey: .expiresAt)
+    try container.encodeIfPresent(status, forKey: .status)
+    try container.encodeIfPresent(concretePayload, forKey: .concretePayload)
   }
 }

--- a/Sources/PubNub/Models/PubNubDataSync.swift
+++ b/Sources/PubNub/Models/PubNubDataSync.swift
@@ -271,11 +271,7 @@ public struct PubNubDataSyncRelationship: Hashable {
   public let id: String
   /// The name of the relationship's class
   public let className: String
-  /// The level the relationship's class is registered at, or `nil` when the level wasn't reported
-  ///
-  /// Relationships read through ``PubNub/DataSyncAPI/getRelationships(relationshipClass:entityAId:entityBId:relationshipClassVersion:cursor:limit:filter:filterAdvanced:sort:custom:completion:)``
-  /// and its siblings leave this `nil`, because the service doesn't report a level on the relationship resource. Relationships delivered as a
-  /// ``PubNubDataSyncEvent`` carry it.
+  /// The level the relationship's class is registered at
   public let classLevel: PubNubDataSyncClassLevel?
   /// The version of the relationship's class
   public let classVersion: Int

--- a/Sources/PubNub/Models/PubNubDataSync.swift
+++ b/Sources/PubNub/Models/PubNubDataSync.swift
@@ -271,8 +271,6 @@ public struct PubNubDataSyncRelationship: Hashable {
   public let id: String
   /// The name of the relationship's class
   public let className: String
-  /// The level the relationship's class is registered at
-  public let classLevel: PubNubDataSyncClassLevel?
   /// The version of the relationship's class
   public let classVersion: Int
   /// The unique identifier of the entity on side A of the relationship
@@ -297,7 +295,6 @@ public struct PubNubDataSyncRelationship: Hashable {
   init(
     id: String,
     className: String,
-    classLevel: PubNubDataSyncClassLevel? = nil,
     classVersion: Int,
     entityAId: String,
     entityBId: String,
@@ -310,7 +307,6 @@ public struct PubNubDataSyncRelationship: Hashable {
   ) {
     self.id = id
     self.className = className
-    self.classLevel = classLevel
     self.classVersion = classVersion
     self.entityAId = entityAId
     self.entityBId = entityBId
@@ -327,7 +323,6 @@ extension PubNubDataSyncRelationship: Codable {
   enum CodingKeys: String, CodingKey {
     case id
     case className = "relationshipClass"
-    case classLevel = "relationshipClassLevel"
     case classVersion = "relationshipClassVersion"
     case entityAId
     case entityBId

--- a/Sources/PubNub/Networking/Routers/Subscribe Payloads/SubscribeDataSyncPayload.swift
+++ b/Sources/PubNub/Networking/Routers/Subscribe Payloads/SubscribeDataSyncPayload.swift
@@ -102,7 +102,7 @@ extension SubscribeDataSyncPayload: Decodable {
         payload: try data.decodeIfPresent(AnyJSON.self, forKey: .payload)
       )
       event = action == .create ? .relationshipCreated(relationship) : .relationshipUpdated(relationship)
-    case (.entity, .delete), (.relationship, .delete):
+    case (.entity, .delete):
       let removed = PubNubDataSyncRemovedObject(
         id: identifier,
         className: className,
@@ -110,7 +110,16 @@ extension SubscribeDataSyncPayload: Decodable {
         classVersion: classVersion,
         deletedAt: try data.decode(Date.self, forKey: .deletedAt)
       )
-      event = type == .entity ? .entityDeleted(removed) : .relationshipDeleted(removed)
+      event = .entityDeleted(removed)
+    case (.relationship, .delete):
+      event = .relationshipDeleted(
+        PubNubDataSyncRemovedRelationship(
+          id: identifier,
+          className: className,
+          classVersion: classVersion,
+          deletedAt: try data.decode(Date.self, forKey: .deletedAt)
+        )
+      )
     }
   }
 }

--- a/Sources/PubNub/Networking/Routers/Subscribe Payloads/SubscribeDataSyncPayload.swift
+++ b/Sources/PubNub/Networking/Routers/Subscribe Payloads/SubscribeDataSyncPayload.swift
@@ -91,7 +91,6 @@ extension SubscribeDataSyncPayload: Decodable {
       let relationship = PubNubDataSyncRelationship(
         id: identifier,
         className: className,
-        classLevel: classLevel,
         classVersion: classVersion,
         entityAId: try data.decode(String.self, forKey: .entityAId),
         entityBId: try data.decode(String.self, forKey: .entityBId),

--- a/Sources/PubNub/PubNub.swift
+++ b/Sources/PubNub/PubNub.swift
@@ -394,8 +394,7 @@ extension PubNub {
   }
 
   func internalSubscribe(
-    with channels: [Subscription],
-    and groups: [Subscription],
+    with subscriptions: [Subscription],
     at timetoken: Timetoken?
   ) {
     logger.debug(
@@ -404,8 +403,8 @@ extension PubNub {
           operation: "internalSubscribe",
           details: "Triggering subscribe operation from Subscription objects",
           arguments: [
-            ("channels", channels.flatMap { $0.subscriptionNames }),
-            ("channelGroups", groups.flatMap { $0.subscriptionNames }),
+            ("channels", subscriptions.flatMap { $0.subscriptionTopology.channels }),
+            ("channelGroups", subscriptions.flatMap { $0.subscriptionTopology.channelGroups }),
             ("timetoken", timetoken)
           ]
         )
@@ -413,20 +412,15 @@ extension PubNub {
     )
 
     subscription.internalSubscribe(
-      with: channels,
-      and: groups,
+      with: subscriptions,
       at: timetoken
     )
   }
 
   func internalUnsubscribe(
-    from channels: [Subscription],
-    and groups: [Subscription]
+    from subscriptions: [Subscription]
   ) {
-    subscription.internalUnsubscribe(
-      from: channels,
-      and: groups
-    )
+    subscription.internalUnsubscribe(from: subscriptions)
   }
 }
 

--- a/Sources/PubNub/Subscribe/API/EventListener.swift
+++ b/Sources/PubNub/Subscribe/API/EventListener.swift
@@ -179,8 +179,8 @@ public protocol SubscriptionDisposable {
 // Types that conform to this protocol are responsible for handling and processing these payloads
 // into concrete events for the user.
 protocol SubscribeMessagesReceiver: AnyObject {
-  // A dictionary representing the names of the underlying subscriptions
-  var subscriptionTopology: [SubscribeTarget: [String]] { get }
+  // The names the conforming type contributes to the Subscribe loop
+  var subscriptionTopology: SubscriptionTopology { get }
   // This method should return an array of `PubNubEvent` instances,
   // representing the concrete events for the user.
   @discardableResult func onPayloadsReceived(payloads: [SubscribeMessagePayload]) -> [PubNubEvent]

--- a/Sources/PubNub/Subscribe/API/PubNubDataSyncEvent.swift
+++ b/Sources/PubNub/Subscribe/API/PubNubDataSyncEvent.swift
@@ -23,7 +23,7 @@ public enum PubNubDataSyncEvent {
   /// A relationship was updated
   case relationshipUpdated(PubNubDataSyncRelationship)
   /// A relationship was deleted
-  case relationshipDeleted(PubNubDataSyncRemovedObject)
+  case relationshipDeleted(PubNubDataSyncRemovedRelationship)
 }
 
 /// A DataSync entity or relationship that was deleted.
@@ -37,5 +37,17 @@ public struct PubNubDataSyncRemovedObject: Hashable {
   /// The version of the deleted object's class
   public let classVersion: Int
   /// The date the object was deleted
+  public let deletedAt: Date
+}
+
+/// A DataSync relationship that was deleted.
+public struct PubNubDataSyncRemovedRelationship: Hashable {
+  /// The unique identifier of the deleted relationship
+  public let id: String
+  /// The name of the deleted relationship's class
+  public let className: String
+  /// The version of the deleted relationship's class
+  public let classVersion: Int
+  /// The date the relationship was deleted
   public let deletedAt: Date
 }

--- a/Sources/PubNub/Subscribe/API/Subscribable.swift
+++ b/Sources/PubNub/Subscribe/API/Subscribable.swift
@@ -34,7 +34,7 @@ public extension SubscribeCapable {
 public class Subscribable {
   weak var pubnub: PubNub?
 
-  init(pubnub: PubNub) {
+  init(pubnub: PubNub?) {
     self.pubnub = pubnub
   }
 

--- a/Sources/PubNub/Subscribe/API/Subscribable.swift
+++ b/Sources/PubNub/Subscribe/API/Subscribable.swift
@@ -63,7 +63,7 @@ public class Subscribable {
   }
 }
 
-//// The names a value contributes to the Subscribe loop, grouped by the list each name joins.
+// The names a value contributes to the Subscribe loop, grouped by the list each name joins.
 struct SubscriptionTopology: Hashable {
   // Names sent to the Subscribe loop as channels
   var channels: [String] = []
@@ -91,7 +91,7 @@ struct SubscriptionTopology: Hashable {
 }
 
 extension SubscriptionTopology {
-  // Whether the payload was delivered because of one of the names in this topology.
+  // Whether the payload matches one of the names in this topology.
   //
   // Channel names are matched against the channel the message was published to, while channel
   // group names are matched against the subscription that caused the delivery.

--- a/Sources/PubNub/Subscribe/API/Subscribable.swift
+++ b/Sources/PubNub/Subscribe/API/Subscribable.swift
@@ -30,19 +30,19 @@ public extension SubscribeCapable {
   }
 }
 
-/// A base class for the named streams that can be subscribed to and unsubscribed from using the PubNub service.
+/// The base class for references you can create a `Subscription` from.
 public class Subscribable {
-  /// The name this subscribable contributes to the Subscribe loop
-  public let name: String
-  /// The PubNub client that created this subscribable
   weak var pubnub: PubNub?
-  /// Determines whether ``name`` is sent to the Subscribe loop as a channel or as a channel group
-  let subscribeTarget: SubscribeTarget
 
-  init(name: String, subscribeTarget: SubscribeTarget, pubnub: PubNub) {
-    self.name = name
-    self.subscribeTarget = subscribeTarget
+  init(pubnub: PubNub) {
     self.pubnub = pubnub
+  }
+
+  // Declares what this value contributes to the Subscribe loop: which names join the channel list, which join the
+  // channel group list, and whether they expand to presence names. Subclasses own their identifiers, so each one
+  // overrides this, and may contribute several names rather than being limited to one.
+  func subscriptionTopology(includingPresence: Bool) -> SubscriptionTopology {
+    .empty
   }
 
   /// Creates a `Subscription` object for this value.
@@ -57,22 +57,62 @@ public class Subscribable {
   ) -> Subscription {
     Subscription(
       queue: queue,
-      entity: self,
+      target: self,
       options: options
     )
   }
 }
 
-/// The bucket a ``Subscribable`` name occupies in the Subscribe loop.
-enum SubscribeTarget {
-  /// The name is sent as a channel
-  case channel
-  /// The name is sent as a channel group
-  case channelGroup
+//// The names a value contributes to the Subscribe loop, grouped by the list each name joins.
+struct SubscriptionTopology: Hashable {
+  // Names sent to the Subscribe loop as channels
+  var channels: [String] = []
+  // Names sent to the Subscribe loop as channel groups
+  var channelGroups: [String] = []
+
+  // A topology contributing no names
+  static let empty = SubscriptionTopology()
+
+  var isEmpty: Bool {
+    channels.isEmpty && channelGroups.isEmpty
+  }
+
+  // Whether any name is shared with `other` within the same list
+  func intersects(_ other: SubscriptionTopology) -> Bool {
+    !Set(channels).isDisjoint(with: other.channels) || !Set(channelGroups).isDisjoint(with: other.channelGroups)
+  }
+
+  static func + (lhs: Self, rhs: Self) -> Self {
+    Self(
+      channels: lhs.channels + rhs.channels,
+      channelGroups: lhs.channelGroups + rhs.channelGroups
+    )
+  }
+}
+
+extension SubscriptionTopology {
+  // Whether the payload was delivered because of one of the names in this topology.
+  //
+  // Channel names are matched against the channel the message was published to, while channel
+  // group names are matched against the subscription that caused the delivery.
+  func matches(_ payload: SubscribeMessagePayload) -> Bool {
+    channels.contains {
+      Self.isMatching($0, string: payload.channel)
+    } || channelGroups.contains {
+      Self.isMatching($0, string: payload.subscription ?? payload.channel)
+    }
+  }
+
+  private static func isMatching(_ name: String, string: String) -> Bool {
+    guard name.hasSuffix(".*") else {
+      return name.trimmingPresenceChannelSuffix == string
+    }
+    if let firstIndex = name.lastIndex(of: "."), let secondIndex = string.lastIndex(of: ".") {
+      return name.prefix(upTo: firstIndex) == string.prefix(upTo: secondIndex)
+    }
+    return false
+  }
 }
 
 /// A typealias representing an interface for PubNub subscriptions.
-///
-/// This alias combines the conformance of `EventListenerInterface` and `SubscribeCapable`.
-/// Thus, objects conforming to this type can both emit PubNub events and perform subscription-related actions.
 public typealias SubscriptionInterface = EventListenerInterface & SubscriptionDisposable & SubscribeCapable

--- a/Sources/PubNub/Subscribe/API/Subscribables.swift
+++ b/Sources/PubNub/Subscribe/API/Subscribables.swift
@@ -77,3 +77,156 @@ public class ChannelMetadata: Subscribable {
     SubscriptionTopology(channels: [id])
   }
 }
+
+// MARK: - Data Sync
+
+/// A reference to a Data Sync user by identifier.
+public class DataSyncUser: Subscribable {
+  /// The identifier of the Data Sync user
+  public let id: String
+
+  init(id: String, pubnub: PubNub) {
+    self.id = id
+    super.init(pubnub: pubnub)
+  }
+
+  override func subscriptionTopology(includingPresence: Bool) -> SubscriptionTopology {
+    SubscriptionTopology(channels: [id])
+  }
+
+  /// Creates a subscription to a projection of this Data Sync user.
+  public func subscription(
+    projection projectionName: String,
+    queue: DispatchQueue = .main,
+    options: SubscriptionOptions = SubscriptionOptions.empty()
+  ) -> Subscription {
+    makeProjectionSubscription(projectionName, id: id, queue: queue, options: options)
+  }
+}
+
+/// A reference to a Data Sync channel by identifier.
+public class DataSyncChannel: Subscribable {
+  /// The identifier of the Data Sync channel
+  public let id: String
+
+  init(id: String, pubnub: PubNub) {
+    self.id = id
+    super.init(pubnub: pubnub)
+  }
+
+  override func subscriptionTopology(includingPresence: Bool) -> SubscriptionTopology {
+    SubscriptionTopology(channels: [id])
+  }
+
+  /// Creates a subscription to a projection of this Data Sync channel.
+  public func subscription(
+    projection projectionName: String,
+    queue: DispatchQueue = .main,
+    options: SubscriptionOptions = SubscriptionOptions.empty()
+  ) -> Subscription {
+    makeProjectionSubscription(projectionName, id: id, queue: queue, options: options)
+  }
+}
+
+/// A reference to a Data Sync membership by identifier.
+public class DataSyncMembership: Subscribable {
+  /// The identifier of the Data Sync membership
+  public let id: String
+
+  init(id: String, pubnub: PubNub) {
+    self.id = id
+    super.init(pubnub: pubnub)
+  }
+
+  override func subscriptionTopology(includingPresence: Bool) -> SubscriptionTopology {
+    SubscriptionTopology(channels: [id])
+  }
+
+  /// Creates a subscription to a projection of this Data Sync membership.
+  public func subscription(
+    projection projectionName: String,
+    queue: DispatchQueue = .main,
+    options: SubscriptionOptions = SubscriptionOptions.empty()
+  ) -> Subscription {
+    makeProjectionSubscription(projectionName, id: id, queue: queue, options: options)
+  }
+}
+
+/// A reference to a Data Sync entity by identifier.
+public class DataSyncEntity: Subscribable {
+  /// The identifier of the Data Sync entity
+  public let id: String
+
+  init(id: String, pubnub: PubNub) {
+    self.id = id
+    super.init(pubnub: pubnub)
+  }
+
+  override func subscriptionTopology(includingPresence: Bool) -> SubscriptionTopology {
+    SubscriptionTopology(channels: [id])
+  }
+
+  /// Creates a subscription to a projection of this Data Sync entity.
+  public func subscription(
+    projection projectionName: String,
+    queue: DispatchQueue = .main,
+    options: SubscriptionOptions = SubscriptionOptions.empty()
+  ) -> Subscription {
+    makeProjectionSubscription(projectionName, id: id, queue: queue, options: options)
+  }
+}
+
+/// A reference to a Data Sync relationship by identifier.
+public class DataSyncRelationship: Subscribable {
+  /// The identifier of the Data Sync relationship
+  public let id: String
+
+  init(id: String, pubnub: PubNub) {
+    self.id = id
+    super.init(pubnub: pubnub)
+  }
+
+  override func subscriptionTopology(includingPresence: Bool) -> SubscriptionTopology {
+    SubscriptionTopology(channels: [id])
+  }
+
+  /// Creates a subscription to a projection of this Data Sync relationship.
+  public func subscription(
+    projection projectionName: String,
+    queue: DispatchQueue = .main,
+    options: SubscriptionOptions = SubscriptionOptions.empty()
+  ) -> Subscription {
+    makeProjectionSubscription(projectionName, id: id, queue: queue, options: options)
+  }
+}
+
+private extension Subscribable {
+  func makeProjectionSubscription(
+    _ projectionName: String,
+    id: String,
+    queue: DispatchQueue,
+    options: SubscriptionOptions
+  ) -> Subscription {
+    Subscription(
+      queue: queue,
+      target: DataSyncProjection(
+        channelName: projectionName == "default" ? id : "__\(projectionName)__\(id)",
+        pubnub: pubnub
+      ),
+      options: options
+    )
+  }
+}
+
+private final class DataSyncProjection: Subscribable {
+  private let channelName: String
+
+  init(channelName: String, pubnub: PubNub?) {
+    self.channelName = channelName
+    super.init(pubnub: pubnub)
+  }
+
+  override func subscriptionTopology(includingPresence: Bool) -> SubscriptionTopology {
+    SubscriptionTopology(channels: [channelName])
+  }
+}

--- a/Sources/PubNub/Subscribe/API/Subscribables.swift
+++ b/Sources/PubNub/Subscribe/API/Subscribables.swift
@@ -12,36 +12,68 @@ import Foundation
 
 // MARK: - Channel
 
-/// A channel you can subscribe to and unsubscribe from.
+/// A reference to a channel by name.
 public class Channel: Subscribable {
+  /// The name identifying this channel
+  public let name: String
+
   init(name: String, pubnub: PubNub) {
-    super.init(name: name, subscribeTarget: .channel, pubnub: pubnub)
+    self.name = name
+    super.init(pubnub: pubnub)
+  }
+
+  override func subscriptionTopology(includingPresence: Bool) -> SubscriptionTopology {
+    SubscriptionTopology(channels: includingPresence ? [name, name.presenceChannelName] : [name])
   }
 }
 
 // MARK: - ChannelGroup
 
-/// A channel group you can subscribe to and unsubscribe from.
+/// A reference to a channel group by name.
 public class ChannelGroup: Subscribable {
+  /// The name identifying this channel group
+  public let name: String
+
   init(name: String, pubnub: PubNub) {
-    super.init(name: name, subscribeTarget: .channelGroup, pubnub: pubnub)
+    self.name = name
+    super.init(pubnub: pubnub)
+  }
+
+  override func subscriptionTopology(includingPresence: Bool) -> SubscriptionTopology {
+    SubscriptionTopology(channelGroups: includingPresence ? [name, name.presenceChannelName] : [name])
   }
 }
 
 // MARK: - UserMetadata
 
-/// A user metadata record whose App Context changes you can subscribe to.
+/// A reference to an App Context user metadata record by identifier.
 public class UserMetadata: Subscribable {
+  /// The identifier of the user metadata record
+  public let id: String
+
   init(id: String, pubnub: PubNub) {
-    super.init(name: id, subscribeTarget: .channel, pubnub: pubnub)
+    self.id = id
+    super.init(pubnub: pubnub)
+  }
+
+  override func subscriptionTopology(includingPresence: Bool) -> SubscriptionTopology {
+    SubscriptionTopology(channels: [id])
   }
 }
 
 // MARK: - ChannelMetadata
 
-/// A channel metadata record whose App Context changes you can subscribe to.
+/// A reference to an App Context channel metadata record by identifier.
 public class ChannelMetadata: Subscribable {
+  /// The identifier of the channel metadata record
+  public let id: String
+
   init(id: String, pubnub: PubNub) {
-    super.init(name: id, subscribeTarget: .channel, pubnub: pubnub)
+    self.id = id
+    super.init(pubnub: pubnub)
+  }
+
+  override func subscriptionTopology(includingPresence: Bool) -> SubscriptionTopology {
+    SubscriptionTopology(channels: [id])
   }
 }

--- a/Sources/PubNub/Subscribe/API/Subscription.swift
+++ b/Sources/PubNub/Subscribe/API/Subscription.swift
@@ -10,37 +10,33 @@
 
 import Foundation
 
-/// A final class representing a PubNub subscription.
+/// A subscription to a single `Subscribable`.
 ///
-/// Use this class to create and manage subscriptions for a specific `Subscribable` entity.
-/// Utilize closures inherited from `EventListenerInterface` for the handling of subscription-related events.
-/// You can also create an additional `EventListener` and register it by calling `addEventListener(_:)`.
+/// Handle events with the closures inherited from `EventListenerInterface`,
+/// or register additional listeners with `addEventListener(_:)`.
 public final class Subscription: EventListenerInterface, SubscriptionDisposable, EventListenerHandler {
-  /// Initializes a `Subscription` object.
-  ///
-  /// - Parameters:
-  ///   - queue: An underlying queue to dispatch events
-  ///   - entity: An object that should be added to the Subscribe loop.
-  ///   - options: Additional subscription options
-  public init(
-    queue: DispatchQueue = .main,
-    entity: Subscribable,
-    options: SubscriptionOptions = SubscriptionOptions.empty()
-  ) {
+  init(queue: DispatchQueue = .main, target: Subscribable, options: SubscriptionOptions = .empty()) {
+    let resolvedOptions = SubscriptionOptions.empty() + options
+
     self.queue = queue
-    self.entity = entity
-    self.options = SubscriptionOptions.empty() + options
+    self.target = target
+    self.options = resolvedOptions
+    self.subscriptionTopology = target.subscriptionTopology(includingPresence: resolvedOptions.hasPresenceOption())
   }
 
   public let queue: DispatchQueue
   /// A unique identifier for `Subscription`
   public let uuid: UUID = UUID()
-  /// An underlying entity that should be added to the Subscribe loop
-  public let entity: Subscribable
   /// Attached options
   public let options: SubscriptionOptions
-  /// Whether current subscription is disposed or not
+  /// Whether the subscription is disposed
   public private(set) var isDisposed = false
+
+  // The stream this subscription receives events for
+  let target: Subscribable
+  // The names this subscription contributes to the Subscribe loop
+  let subscriptionTopology: SubscriptionTopology
+
   // Stores the timetoken the user subscribed with
   private(set) var timetoken: Timetoken?
   // Stores additional listeners
@@ -66,35 +62,14 @@ public final class Subscription: EventListenerInterface, SubscriptionDisposable,
   )
 
   internal var pubnub: PubNub? {
-    entity.pubnub
+    target.pubnub
   }
 
-  internal var subscribeTarget: SubscribeTarget {
-    entity.subscribeTarget
-  }
-
-  internal var subscriptionNames: [String] {
-    let hasPresenceOption = options.hasPresenceOption()
-    let name = entity.name
-
-    switch entity {
-    case is Channel:
-      return hasPresenceOption ? [name, name.presenceChannelName] : [name]
-    case is ChannelGroup:
-      return hasPresenceOption ? [name, name.presenceChannelName] : [name]
-    default:
-      return [entity.name]
-    }
-  }
-
-  /// Creates a clone of the current instance of `Subscription`.
-  ///
-  /// Use this method to create a new instance with the same configuration as the current `Subscription`.
-  /// The clone is a separate instance that can be used independently.
+  /// Creates an independent copy of this `Subscription` with the same configuration.
   public func clone() -> Subscription {
     let clonedSubscription = Subscription(
       queue: queue,
-      entity: entity,
+      target: target,
       options: options
     )
     if pubnub?.hasRegisteredAdapter(with: uuid) ?? false {
@@ -103,10 +78,7 @@ public final class Subscription: EventListenerInterface, SubscriptionDisposable,
     return clonedSubscription
   }
 
-  /// Disposes the current `Subscription`, ending the subscription.
-  ///
-  /// Use this method to gracefully end the subscription and release associated resources.
-  /// Once disposed, the subscription interface cannot be restarted.
+  /// Ends the subscription and releases its resources. A disposed `Subscription` cannot be restarted.
   public func dispose() {
     clearCallbacks()
     unsubscribe()
@@ -135,33 +107,24 @@ public final class Subscription: EventListenerInterface, SubscriptionDisposable,
 }
 
 extension Subscription: SubscribeCapable {
-  /// Subscribes to the associated `entity` with the specified timetoken.
+  /// Starts receiving events for the associated target.
   ///
-  /// - Parameter timetoken: The timetoken to use for subscribing. If `nil`, the `0` value is used.
+  /// - Parameter timetoken: The timetoken to subscribe from. If `nil`, `0` is used.
   public func subscribe(with timetoken: Timetoken?) {
     guard let pubnub = pubnub, !isDisposed else {
       return
     }
-    let channels = subscribeTarget == .channel ? [self] : []
-    let channelGroups = subscribeTarget == .channelGroup ? [self] : []
-
-    pubnub.internalSubscribe(with: channels, and: channelGroups, at: timetoken)
+    pubnub.internalSubscribe(with: [self], at: timetoken)
   }
 
-  /// Unsubscribes from the associated entity, ending the PubNub subscription.
+  /// Stops receiving events for the associated target. The subscription can be restarted afterwards.
   ///
-  /// Use this method to gracefully end the subscription and stop receiving messages for the associated entity.
-  /// If there are no remaining subscriptions that match the associated entity, the unsubscribe action will be performed,
-  /// and the entity will be deregistered from the Subscribe loop. After unsubscribing, the subscription interface
-  /// can be restarted if needed.
+  /// Names are deregistered from the Subscribe loop only if no other subscription still contributes them.
   public func unsubscribe() {
     guard let pubnub = pubnub, !isDisposed else {
       return
     }
-    let channels = subscribeTarget == .channel ? [self] : []
-    let groups = subscribeTarget == .channelGroup ? [self] : []
-
-    pubnub.internalUnsubscribe(from: channels, and: groups)
+    pubnub.internalUnsubscribe(from: [self])
   }
 }
 
@@ -178,10 +141,6 @@ extension Subscription: Hashable {
 // MARK: - SubscribeMessagesReceiver
 
 extension Subscription: SubscribeMessagesReceiver {
-  var subscriptionTopology: [SubscribeTarget: [String]] {
-    [subscribeTarget: subscriptionNames]
-  }
-
   @discardableResult func onPayloadsReceived(payloads: [SubscribeMessagePayload]) -> [PubNubEvent] {
     let events = payloads.compactMap { event(from: $0) }
     // Emit events to the current Subscription's closures
@@ -193,32 +152,11 @@ extension Subscription: SubscribeMessagesReceiver {
   }
 
   func event(from payload: SubscribeMessagePayload) -> PubNubEvent? {
-    let isNewerOrEqualToTimetoken = payload.publishTimetoken.timetoken >= timetoken ?? 0
-    let isMatchingEntity: Bool
-
-    if subscribeTarget == .channel {
-      isMatchingEntity = isMatchingEntityName(entity.name, string: payload.channel)
-    } else if subscribeTarget == .channelGroup {
-      isMatchingEntity = isMatchingEntityName(entity.name, string: payload.subscription ?? payload.channel)
-    } else {
-      isMatchingEntity = true
-    }
-
-    if isMatchingEntity && isNewerOrEqualToTimetoken {
-      let event = payload.asPubNubEvent()
-      return options.filterCriteriaSatisfied(event: event) ? event : nil
-    } else {
+    guard subscriptionTopology.matches(payload), payload.publishTimetoken.timetoken >= timetoken ?? 0 else {
       return nil
     }
-  }
 
-  fileprivate func isMatchingEntityName(_ entityName: String, string: String) -> Bool {
-    guard entityName.hasSuffix(".*") else {
-      return entityName.trimmingPresenceChannelSuffix == string
-    }
-    if let firstIndex = entityName.lastIndex(of: "."), let secondIndex = string.lastIndex(of: ".") {
-      return entityName.prefix(upTo: firstIndex) == string.prefix(upTo: secondIndex)
-    }
-    return false
+    let event = payload.asPubNubEvent()
+    return options.filterCriteriaSatisfied(event: event) ? event : nil
   }
 }

--- a/Sources/PubNub/Subscribe/API/SubscriptionSet.swift
+++ b/Sources/PubNub/Subscribe/API/SubscriptionSet.swift
@@ -10,11 +10,10 @@
 
 import Foundation
 
-/// A final class representing a set of `Subscription`.
+/// A group of `Subscription` managed as one unit.
 ///
-/// Use this class to manage multiple `Subscription` concurrently.
-/// Utilize closures inherited from `EventListenerInterface` for the handling of subscription-related events.
-/// You can also create an additional `EventListener` and register it by calling `addEventListener(_:)`.
+/// Handle events with the closures inherited from `EventListenerInterface`,
+/// or register additional listeners with `addEventListener(_:)`.
 public final class SubscriptionSet: EventListenerInterface, SubscriptionDisposable, EventListenerHandler {
   @available(*, deprecated, message: "Use the granular callbacks (onMessage, onSignal, onPresence, etc.) instead")
   public var onEvent: ((PubNubEvent) -> Void)?
@@ -31,9 +30,9 @@ public final class SubscriptionSet: EventListenerInterface, SubscriptionDisposab
   public let queue: DispatchQueue
   /// Additional subscription options
   public let options: SubscriptionOptions
-  /// A unique identifier for the current `SubscriptionSet`
+  /// A unique identifier for `SubscriptionSet`
   public let uuid: UUID = UUID()
-  /// Whether current subscription is disposed or not
+  /// Whether the set is disposed
   public var isDisposed: Bool { isDisposedContainer.lockedRead { $0 } }
 
   let isDisposedContainer: Atomic<Bool> = Atomic(false)
@@ -48,50 +47,28 @@ public final class SubscriptionSet: EventListenerInterface, SubscriptionDisposab
     queue: queue
   )
 
-  /// Initializes `SubscriptionSet` object with the specified parameters.
-  ///
-  /// - Parameters:
-  ///   - queue: The dispatch queue on which the subscription events should be handled
-  ///   - entities: A collection of `Subscribable` entities to include in the Subscribe loop
-  ///   - options: Additional subscription options
-  public init(
-    queue: DispatchQueue = .main,
-    entities: any Collection<Subscribable> = [],
-    options: SubscriptionOptions = SubscriptionOptions.empty()
-  ) {
+  init(queue: DispatchQueue = .main, targets: any Collection<Subscribable> = [], options: SubscriptionOptions = .empty()) {
     self.queue = queue
     self.options = SubscriptionOptions.empty() + options
-    self.currentSubscriptions = Atomic(Set(entities.map { Subscription(queue: queue, entity: $0, options: options) }))
+    self.currentSubscriptions = Atomic(Set(targets.map { Subscription(queue: queue, target: $0, options: options) }))
   }
 
-  /// Initializes `SubscriptionSet` object with the specified parameters.
-  ///
-  /// - Parameters:
-  ///   - queue: The dispatch queue on which the subscription events should be handled
-  ///   - subscriptions: A collection of existing `Subscription` instances to include in the Subscribe loop
-  ///   - options: Additional subscription options
-  public init(
-    queue: DispatchQueue = .main,
-    subscriptions: any Collection<Subscription> = [],
-    options: SubscriptionOptions = SubscriptionOptions.empty()
-  ) {
+  init(queue: DispatchQueue = .main, subscriptions: any Collection<Subscription> = [], options: SubscriptionOptions = .empty()) {
     self.queue = queue
     self.options = options
     self.currentSubscriptions = Atomic(Set(subscriptions))
   }
 
-  /// Adds `Subscription` to the existing set of subscriptions.
+  /// Adds a `Subscription` to the set.
   ///
-  /// - Parameters:
-  ///   - subscription: `Subscription` to add
+  /// - Parameter subscription: `Subscription` to add
   public func add(subscription: Subscription) {
     currentSubscriptions.lockedWrite { $0.insert(subscription) }
   }
 
-  /// Adds a collection of `Subscription` to the existing set of subscriptions.
+  /// Adds a collection of `Subscription` to the set.
   ///
-  /// - Parameters:
-  ///   - subscriptions: List of `Subscription` to add
+  /// - Parameter subscriptions: `Subscription` values to add
   public func add(subscriptions: any Collection<Subscription>) {
     currentSubscriptions.lockedWrite {
       for subscription in subscriptions {
@@ -100,18 +77,16 @@ public final class SubscriptionSet: EventListenerInterface, SubscriptionDisposab
     }
   }
 
-  /// Removes `Subscription` from the existing set of subscriptions.
+  /// Removes a `Subscription` from the set.
   ///
-  /// - Parameters:
-  ///   - subscription: `Subscription` to remove
+  /// - Parameter subscription: `Subscription` to remove
   public func remove(subscription: Subscription) {
     currentSubscriptions.lockedWrite { $0.remove(subscription) }
   }
 
-  /// Removes a collection of `Subscription` from the existing set of subscriptions.
+  /// Removes a collection of `Subscription` from the set.
   ///
-  /// - Parameters:
-  ///   - subscriptions: Collection of `Subscription` to remove
+  /// - Parameter subscriptions: `Subscription` values to remove
   public func remove(subscriptions: any Collection<Subscription>) {
     currentSubscriptions.lockedWrite {
       for subscription in subscriptions {
@@ -120,10 +95,7 @@ public final class SubscriptionSet: EventListenerInterface, SubscriptionDisposab
     }
   }
 
-  /// Creates a clone of the current instance of `SubscriptionSet`.
-  ///
-  /// Use this method to create a new instance with the same configuration as the current `SubscriptionSet`.
-  /// The clone is a separate instance that can be used independently.
+  /// Creates an independent copy of this `SubscriptionSet` with the same configuration.
   public func clone() -> SubscriptionSet {
     let existingSubscriptions = currentSubscriptions.lockedRead { $0 }
 
@@ -139,10 +111,7 @@ public final class SubscriptionSet: EventListenerInterface, SubscriptionDisposab
     return clonedSubscriptionSet
   }
 
-  /// Disposes of the current instance of `SubscriptionSet`, ending all associated subscriptions.
-  ///
-  /// Use this method to gracefully end the subscription and release associated resources.
-  /// Once disposed, the subscription interface cannot be restarted.
+  /// Ends all subscriptions in the set and releases their resources. A disposed set cannot be restarted.
   public func dispose() {
     clearCallbacks()
     currentSubscriptions.lockedRead { $0 }.forEach { $0.dispose() }
@@ -171,13 +140,9 @@ public final class SubscriptionSet: EventListenerInterface, SubscriptionDisposab
 }
 
 extension SubscriptionSet: SubscribeCapable {
-  /// Subscribes to all entities within the current `SubscriptionSet` with the specified timetoken.
+  /// Starts receiving events for every subscription in the set.
   ///
-  /// Use this method to initiate or resume subscriptions for all entities within the set.
-  /// If a timetoken is provided, it represents the starting point for the subscription.
-  /// Otherwise, the `0` timetoken is used.
-  ///
-  /// - Parameter timetoken: The timetoken to use for the subscriptions
+  /// - Parameter timetoken: The timetoken to subscribe from. If `nil`, `0` is used.
   public func subscribe(with timetoken: Timetoken?) {
     let existingSubscriptions = currentSubscriptions.lockedRead { $0 }
 
@@ -186,28 +151,12 @@ extension SubscriptionSet: SubscribeCapable {
     }
 
     pubnub.registerAdapter(adapter)
-
-    let channels = existingSubscriptions.filter {
-      $0.subscribeTarget == .channel
-    }.allObjects
-
-    let groups = existingSubscriptions.filter {
-      $0.subscribeTarget == .channelGroup
-    }.allObjects
-
-    pubnub.internalSubscribe(
-      with: channels,
-      and: groups,
-      at: timetoken
-    )
+    pubnub.internalSubscribe(with: existingSubscriptions.allObjects, at: timetoken)
   }
 
-  /// Unsubscribes from all entities within the current `SubscriptionSet`. If there are no remaining
-  /// subscriptions that match the associated entities, the unsubscribe action will be performed,
-  /// and the entities will be deregistered from the Subscribe loop.
+  /// Stops receiving events for every subscription in the set. The set can be restarted afterwards.
   ///
-  /// Use this method to gracefully end all subscriptions and stop receiving messages for all
-  /// associated entities. After unsubscribing, the subscription set can be restarted if needed.
+  /// Names are deregistered from the Subscribe loop only if no other subscription still contributes them.
   public func unsubscribe() {
     let existingSubscriptions = currentSubscriptions.lockedRead { $0 }
 
@@ -216,28 +165,17 @@ extension SubscriptionSet: SubscribeCapable {
     }
 
     pubnub.subscription.remove(adapter)
-    pubnub.internalUnsubscribe(
-      from: existingSubscriptions.filter { $0.subscribeTarget == .channel },
-      and: existingSubscriptions.filter { $0.subscribeTarget == .channelGroup }
-    )
+    pubnub.internalUnsubscribe(from: existingSubscriptions.allObjects)
   }
 }
 
 // MARK: - SubscribeMessagesReceiver
 
 extension SubscriptionSet: SubscribeMessagesReceiver {
-  var subscriptionTopology: [SubscribeTarget: [String]] {
-    var result: [SubscribeTarget: [String]] = [:]
-    result[.channel] = []
-    result[.channelGroup] = []
-
-    let existingSubscriptions = currentSubscriptions.lockedRead { $0 }
-
-    return existingSubscriptions.reduce(into: result, { accumulatedRes, current in
-      let currentRes = current.subscriptionTopology
-      accumulatedRes[.channel]?.append(contentsOf: currentRes[.channel] ?? [])
-      accumulatedRes[.channelGroup]?.append(contentsOf: currentRes[.channelGroup] ?? [])
-    })
+  var subscriptionTopology: SubscriptionTopology {
+    currentSubscriptions.lockedRead { $0 }.reduce(SubscriptionTopology.empty) {
+      $0 + $1.subscriptionTopology
+    }
   }
 
   // Processes payloads according to the following rules:

--- a/Sources/PubNub/Subscribe/Core/SubscriptionSession.swift
+++ b/Sources/PubNub/Subscribe/Core/SubscriptionSession.swift
@@ -115,25 +115,24 @@ class SubscriptionSession: EventListenerInterface, StatusListenerInterface {
     and channelGroupSubscriptions: [Subscription] = [],
     at cursor: SubscribeCursor? = nil
   ) {
+    let allSubscriptions = channelSubscriptions + channelGroupSubscriptions
+
     internalSubscribe(
-      with: channelSubscriptions,
-      and: channelGroupSubscriptions,
+      with: allSubscriptions,
       at: cursor?.timetoken
     )
 
-    let channelSubsToMerge = channelSubscriptions.reduce(
-      into: [String: Subscription]()
-    ) { accumulatedValue, subscription in
-      subscription.subscriptionNames.forEach {
-        accumulatedValue[$0] = subscription
-      }
-    }
+    var channelSubsToMerge = [String: Subscription]()
+    var channelGroupSubsToMerge = [String: Subscription]()
 
-    let channelGroupSubsToMerge = channelGroupSubscriptions.reduce(
-      into: [String: Subscription]()
-    ) { accumulatedValue, subscription in
-      subscription.subscriptionNames.forEach {
-        accumulatedValue[$0] = subscription
+    for subscription in allSubscriptions {
+      let topology = subscription.subscriptionTopology
+
+      for name in topology.channels {
+        channelSubsToMerge[name] = subscription
+      }
+      for name in topology.channelGroups {
+        channelGroupSubsToMerge[name] = subscription
       }
     }
 
@@ -178,8 +177,7 @@ class SubscriptionSession: EventListenerInterface, StatusListenerInterface {
     }
 
     internalUnsubscribe(
-      from: matchingChannelsToUnsubscribe,
-      and: matchingChannelGroupsToUnsubscribe
+      from: matchingChannelsToUnsubscribe + matchingChannelGroupsToUnsubscribe
     )
 
     globalChannelSubscriptions.lockedWrite { currentContainer in
@@ -217,44 +215,39 @@ extension SubscriptionSession {
   // Composes final PubNubChannel lists the user should subscribe to
   // according to provided raw input and forwards the result to the underlying Subscription strategy.
   func internalSubscribe(
-    with channels: [Subscription],
-    and channelGroups: [Subscription],
+    with subscriptions: [Subscription],
     at timetoken: Timetoken?
   ) {
-    if channels.isEmpty, channelGroups.isEmpty {
+    let topology = subscriptions.reduce(SubscriptionTopology.empty) {
+      $0 + $1.subscriptionTopology
+    }
+
+    if topology.isEmpty {
       return
     }
-    for channelSubscription in channels {
-      registerAdapter(channelSubscription.adapter)
-    }
-    for groupSubscription in channelGroups {
-      registerAdapter(groupSubscription.adapter)
+    for subscription in subscriptions {
+      registerAdapter(subscription.adapter)
     }
 
     strategy.subscribe(
-      to: channels.flatMap { $0.subscriptionNames },
-      and: channelGroups.flatMap { $0.subscriptionNames },
+      to: topology.channels,
+      and: topology.channelGroups,
       at: SubscribeCursor(timetoken: timetoken)
     )
   }
 
   func internalUnsubscribe(
-    from channels: [Subscription],
-    and channelGroups: [Subscription]
+    from subscriptions: [Subscription]
   ) {
-    let channelsToUnsubscribe = resolveItemsToUnsubscribe(from: channels)
-    let channelGroupsToUnsubscribe = resolveItemsToUnsubscribe(from: channelGroups)
+    let topologyToUnsubscribe = resolveTopologyToUnsubscribe(from: subscriptions)
 
-    for channelSubscription in channels {
-      remove(channelSubscription.adapter)
-    }
-    for channelGroupSubscription in channelGroups {
-      remove(channelGroupSubscription.adapter)
+    for subscription in subscriptions {
+      remove(subscription.adapter)
     }
 
     strategy.unsubscribe(
-      from: channelsToUnsubscribe,
-      and: channelGroupsToUnsubscribe
+      from: topologyToUnsubscribe.channels,
+      and: topologyToUnsubscribe.channelGroups
     )
   }
 
@@ -271,18 +264,19 @@ extension SubscriptionSession {
     let matchingSubscriptions = remainingSubscriptions.compactMap {
      $0.receiver
     }.filter {
-      !Set($0.subscriptionTopology[subscription.subscribeTarget] ?? []).isDisjoint(with: subscription.subscriptionNames)
+      $0.subscriptionTopology.intersects(subscription.subscriptionTopology)
     }
 
     return !matchingSubscriptions.isEmpty
   }
 
-  private func resolveItemsToUnsubscribe(from subscriptions: [Subscription]) -> [String] {
-    return subscriptions.flatMap {
-      if !hasOverlappingSubscriptions(for: $0) {
-        return $0.subscriptionNames
+  // Returns the names that no longer have any subscription keeping them in the Subscribe loop
+  private func resolveTopologyToUnsubscribe(from subscriptions: [Subscription]) -> SubscriptionTopology {
+    return subscriptions.reduce(SubscriptionTopology.empty) { accumulatedResult, subscription in
+      if hasOverlappingSubscriptions(for: subscription) {
+        return accumulatedResult
       } else {
-        return []
+        return accumulatedResult + subscription.subscriptionTopology
       }
     }
   }
@@ -333,8 +327,8 @@ extension SubscriptionSession: Hashable, CustomStringConvertible {
 // MARK: - SubscribeMessagePayloadReceiver
 
 extension SubscriptionSession: SubscribeMessagesReceiver {
-  var subscriptionTopology: [SubscribeTarget: [String]] {
-    [.channel: subscribedChannels, .channelGroup: subscribedChannelGroups]
+  var subscriptionTopology: SubscriptionTopology {
+    SubscriptionTopology(channels: subscribedChannels, channelGroups: subscribedChannelGroups)
   }
 
   func onPayloadsReceived(payloads: [SubscribeMessagePayload]) -> [PubNubEvent] {

--- a/Tests/PubNubIntegrationTests/DataSyncEntityEndpointIntegrationTests.swift
+++ b/Tests/PubNubIntegrationTests/DataSyncEntityEndpointIntegrationTests.swift
@@ -24,8 +24,8 @@ class DataSyncEntityEndpointIntegrationTests: XCTestCase {
     let payload = TestPatientPayload.standard(mrn: "MRN-100001")
 
     client.dataSync.createEntity(
-      entityClass: patientClass.name,
-      entityClassVersion: patientClass.version,
+      className: patientClass.name,
+      classVersion: patientClass.version,
       id: patientId,
       status: "active",
       payload: payload
@@ -68,8 +68,8 @@ class DataSyncEntityEndpointIntegrationTests: XCTestCase {
     let patientId = randomString()
 
     client.dataSync.createEntity(
-      entityClass: patientClass.name,
-      entityClassVersion: patientClass.version,
+      className: patientClass.name,
+      classVersion: patientClass.version,
       id: patientId,
       status: "active",
       payload: TestPatientPayload.standard(mrn: "MRN-100003")
@@ -81,7 +81,7 @@ class DataSyncEntityEndpointIntegrationTests: XCTestCase {
 
         client.dataSync.setEntity(
           id: patientId,
-          entityClassVersion: self.patientClass.version,
+          classVersion: self.patientClass.version,
           status: "inactive",
           payload: replacementPayload
         ) { replaceResult in
@@ -115,8 +115,8 @@ class DataSyncEntityEndpointIntegrationTests: XCTestCase {
     let patientId = randomString()
 
     client.dataSync.createEntity(
-      entityClass: patientClass.name,
-      entityClassVersion: patientClass.version,
+      className: patientClass.name,
+      classVersion: patientClass.version,
       id: patientId,
       status: "active",
       payload: TestPatientPayload.standard(mrn: "MRN-100004")
@@ -166,8 +166,8 @@ class DataSyncEntityEndpointIntegrationTests: XCTestCase {
     let patientId = randomString()
 
     client.dataSync.createEntity(
-      entityClass: patientClass.name,
-      entityClassVersion: patientClass.version,
+      className: patientClass.name,
+      classVersion: patientClass.version,
       id: patientId,
       status: "active",
       payload: TestPatientPayload.standard(mrn: "MRN-100005")
@@ -176,7 +176,7 @@ class DataSyncEntityEndpointIntegrationTests: XCTestCase {
       case .success:
         client.dataSync.setEntity(
           id: patientId,
-          entityClassVersion: self.patientClass.version,
+          classVersion: self.patientClass.version,
           status: "inactive",
           payload: TestPatientPayload(fullName: "Swift ITest Patient Renamed"),
           ifMatchesEtag: "stale-etag"
@@ -212,8 +212,8 @@ class DataSyncEntityEndpointIntegrationTests: XCTestCase {
 
     // The conflict is keyed on the identifier alone, so a wholly different payload still collides
     client.dataSync.createEntity(
-      entityClass: patientClass.name,
-      entityClassVersion: patientClass.version,
+      className: patientClass.name,
+      classVersion: patientClass.version,
       id: patientId,
       status: "active",
       payload: TestPatientPayload(mrn: "MRN-999999", fullName: "Someone Else Entirely", diagnosis: "Migraine")
@@ -242,7 +242,7 @@ class DataSyncEntityEndpointIntegrationTests: XCTestCase {
 
     createEntities(client: client, patientIds.map { .patient(id: $0) })
 
-    client.dataSync.getEntities(entityClass: patientClass.name) { result in
+    client.dataSync.getEntities(className: patientClass.name) { result in
       switch result {
       case let .success((entities, _)):
         let fetchedIds = Set(entities.map { $0.id })
@@ -268,7 +268,7 @@ class DataSyncEntityEndpointIntegrationTests: XCTestCase {
 
     createEntities(client: client, [.patient(id: patientId), .practitioner(id: practitionerId)])
 
-    client.dataSync.getEntities(entityClass: practitionerClass.name, limit: 100) { result in
+    client.dataSync.getEntities(className: practitionerClass.name, limit: 100) { result in
       switch result {
       case let .success((entities, _)):
         let fetchedIds = Set(entities.map { $0.id })
@@ -298,8 +298,8 @@ class DataSyncEntityEndpointIntegrationTests: XCTestCase {
     createEntities(client: client, [.patient(id: patientV1Id), .patientV2(id: patientV2Id)])
 
     client.dataSync.getEntities(
-      entityClass: patientClass.name,
-      entityClassVersion: patientClass.version,
+      className: patientClass.name,
+      classVersion: patientClass.version,
       filter: ownEntitiesOnly
     ) { result in
       switch result {
@@ -331,7 +331,7 @@ class DataSyncEntityEndpointIntegrationTests: XCTestCase {
     createEntities(client: client, [.patient(id: patientV1Id), .patientV2(id: patientV2Id)])
 
     client.dataSync.getEntities(
-      entityClass: patientClass.name,
+      className: patientClass.name,
       limit: 100,
       filter: "mrn LIKE '\(Constants.prefix)*'"
     ) { result in
@@ -361,7 +361,7 @@ class DataSyncEntityEndpointIntegrationTests: XCTestCase {
 
     createEntities(client: client, patientIds.map { .patient(id: $0) })
 
-    client.dataSync.getEntities(entityClass: patientClass.name, limit: 1) { firstResult in
+    client.dataSync.getEntities(className: patientClass.name, limit: 1) { firstResult in
       switch firstResult {
       case let .success((firstPage, next)):
         XCTAssertEqual(firstPage.count, 1)
@@ -390,7 +390,7 @@ class DataSyncEntityEndpointIntegrationTests: XCTestCase {
     createEntities(client: client, patientIds.map { .patient(id: $0) })
 
     client.dataSync.getEntities(
-      entityClass: patientClass.name,
+      className: patientClass.name,
       limit: 1,
       filter: ownEntitiesOnly
     ) { [unowned client] firstResult in
@@ -401,7 +401,7 @@ class DataSyncEntityEndpointIntegrationTests: XCTestCase {
 
         // Omitting `limit` lets the service apply its own default, which the second page reports back
         client.dataSync.getEntities(
-          entityClass: self.patientClass.name,
+          className: self.patientClass.name,
           cursor: next?.cursor,
           filter: ownEntitiesOnly
         ) { secondResult in
@@ -606,8 +606,8 @@ class DataSyncEntityEndpointIntegrationTests: XCTestCase {
     let patientId = randomString()
 
     client.dataSync.createEntity(
-      entityClass: patientClass.name,
-      entityClassVersion: patientClass.version,
+      className: patientClass.name,
+      classVersion: patientClass.version,
       id: patientId,
       status: "active",
       payload: TestPatientPayload.standard(mrn: "MRN-100006")

--- a/Tests/PubNubIntegrationTests/DataSyncEntityEventIntegrationTests.swift
+++ b/Tests/PubNubIntegrationTests/DataSyncEntityEventIntegrationTests.swift
@@ -57,8 +57,8 @@ final class DataSyncEntityEventIntegrationTests: XCTestCase {
 
     let trigger = { [unowned adminClient, unowned self] in
       adminClient.dataSync.createEntity(
-        entityClass: self.patientClass.name,
-        entityClassVersion: self.patientClass.version,
+        className: self.patientClass.name,
+        classVersion: self.patientClass.version,
         id: self.patientId,
         status: "active",
         payload: TestPatientPayload.standard(mrn: self.patientId)
@@ -233,10 +233,10 @@ final class DataSyncEntityEventIntegrationTests: XCTestCase {
 
     let trigger = { [unowned adminClient, unowned self] in
       adminClient.dataSync.createRelationship(
-        relationshipClass: self.attendingPhysicianClass.name,
+        className: self.attendingPhysicianClass.name,
         entityAId: self.practitionerId,
         entityBId: self.patientId,
-        relationshipClassVersion: self.attendingPhysicianClass.version,
+        classVersion: self.attendingPhysicianClass.version,
         id: self.relationshipId,
         status: "active",
         payload: TestAttendingPhysicianPayload(role: "attending", since: "2024-01-15")

--- a/Tests/PubNubIntegrationTests/DataSyncEntityEventIntegrationTests.swift
+++ b/Tests/PubNubIntegrationTests/DataSyncEntityEventIntegrationTests.swift
@@ -234,9 +234,9 @@ final class DataSyncEntityEventIntegrationTests: XCTestCase {
     let trigger = { [unowned adminClient, unowned self] in
       adminClient.dataSync.createRelationship(
         className: self.attendingPhysicianClass.name,
+        classVersion: self.attendingPhysicianClass.version,
         entityAId: self.practitionerId,
         entityBId: self.patientId,
-        classVersion: self.attendingPhysicianClass.version,
         id: self.relationshipId,
         status: "active",
         payload: TestAttendingPhysicianPayload(role: "attending", since: "2024-01-15")

--- a/Tests/PubNubIntegrationTests/DataSyncRelationshipEndpointIntegrationTests.swift
+++ b/Tests/PubNubIntegrationTests/DataSyncRelationshipEndpointIntegrationTests.swift
@@ -29,9 +29,9 @@ class DataSyncRelationshipEndpointIntegrationTests: XCTestCase {
 
     client.dataSync.createRelationship(
       className: attendingPhysicianClass.name,
+      classVersion: attendingPhysicianClass.version,
       entityAId: practitionerId,
       entityBId: patientId,
-      classVersion: attendingPhysicianClass.version,
       id: relationshipId,
       status: "active",
       payload: payload
@@ -82,9 +82,9 @@ class DataSyncRelationshipEndpointIntegrationTests: XCTestCase {
 
     client.dataSync.createRelationship(
       className: attendingPhysicianClass.name,
+      classVersion: attendingPhysicianClass.version,
       entityAId: practitionerId,
       entityBId: patientId,
-      classVersion: attendingPhysicianClass.version,
       id: relationshipId,
       status: "active",
       payload: TestAttendingPhysicianPayload(role: "attending", since: "2024-01-15")
@@ -138,9 +138,9 @@ class DataSyncRelationshipEndpointIntegrationTests: XCTestCase {
 
     client.dataSync.createRelationship(
       className: attendingPhysicianClass.name,
+      classVersion: attendingPhysicianClass.version,
       entityAId: practitionerId,
       entityBId: patientId,
-      classVersion: attendingPhysicianClass.version,
       id: relationshipId,
       status: "active",
       payload: TestAttendingPhysicianPayload(role: "attending", since: "2024-01-15")
@@ -538,9 +538,9 @@ class DataSyncRelationshipEndpointIntegrationTests: XCTestCase {
 
     client.dataSync.createRelationship(
       className: attendingPhysicianClass.name,
+      classVersion: attendingPhysicianClass.version,
       entityAId: practitionerId,
       entityBId: missingPatientId,
-      classVersion: attendingPhysicianClass.version,
       id: relationshipId,
       status: "active",
       payload: TestAttendingPhysicianPayload(role: "attending", since: "2024-01-15")

--- a/Tests/PubNubIntegrationTests/DataSyncRelationshipEndpointIntegrationTests.swift
+++ b/Tests/PubNubIntegrationTests/DataSyncRelationshipEndpointIntegrationTests.swift
@@ -28,10 +28,10 @@ class DataSyncRelationshipEndpointIntegrationTests: XCTestCase {
     createEntities(client: client, [.practitioner(id: practitionerId), .patient(id: patientId)])
 
     client.dataSync.createRelationship(
-      relationshipClass: attendingPhysicianClass.name,
+      className: attendingPhysicianClass.name,
       entityAId: practitionerId,
       entityBId: patientId,
-      relationshipClassVersion: attendingPhysicianClass.version,
+      classVersion: attendingPhysicianClass.version,
       id: relationshipId,
       status: "active",
       payload: payload
@@ -81,10 +81,10 @@ class DataSyncRelationshipEndpointIntegrationTests: XCTestCase {
     createEntities(client: client, [.practitioner(id: practitionerId), .patient(id: patientId)])
 
     client.dataSync.createRelationship(
-      relationshipClass: attendingPhysicianClass.name,
+      className: attendingPhysicianClass.name,
       entityAId: practitionerId,
       entityBId: patientId,
-      relationshipClassVersion: attendingPhysicianClass.version,
+      classVersion: attendingPhysicianClass.version,
       id: relationshipId,
       status: "active",
       payload: TestAttendingPhysicianPayload(role: "attending", since: "2024-01-15")
@@ -96,7 +96,7 @@ class DataSyncRelationshipEndpointIntegrationTests: XCTestCase {
 
         client.dataSync.setRelationship(
           id: relationshipId,
-          relationshipClassVersion: self.attendingPhysicianClass.version,
+          classVersion: self.attendingPhysicianClass.version,
           status: "inactive",
           payload: replacementPayload
         ) { replaceResult in
@@ -137,10 +137,10 @@ class DataSyncRelationshipEndpointIntegrationTests: XCTestCase {
     createEntities(client: client, [.practitioner(id: practitionerId), .patient(id: patientId)])
 
     client.dataSync.createRelationship(
-      relationshipClass: attendingPhysicianClass.name,
+      className: attendingPhysicianClass.name,
       entityAId: practitionerId,
       entityBId: patientId,
-      relationshipClassVersion: attendingPhysicianClass.version,
+      classVersion: attendingPhysicianClass.version,
       id: relationshipId,
       status: "active",
       payload: TestAttendingPhysicianPayload(role: "attending", since: "2024-01-15")
@@ -200,7 +200,7 @@ class DataSyncRelationshipEndpointIntegrationTests: XCTestCase {
 
     client.dataSync.setRelationship(
       id: relationshipId,
-      relationshipClassVersion: attendingPhysicianClass.version,
+      classVersion: attendingPhysicianClass.version,
       status: "inactive",
       payload: TestAttendingPhysicianPayload(role: "consulting"),
       ifMatchesEtag: "stale-etag"
@@ -241,7 +241,7 @@ class DataSyncRelationshipEndpointIntegrationTests: XCTestCase {
       }
     )
 
-    client.dataSync.getRelationships(relationshipClass: attendingPhysicianClass.name, limit: 100) { result in
+    client.dataSync.getRelationships(className: attendingPhysicianClass.name, limit: 100) { result in
       switch result {
       case let .success((relationships, _)):
         let fetchedIds = Set(relationships.map { $0.id })
@@ -280,7 +280,7 @@ class DataSyncRelationshipEndpointIntegrationTests: XCTestCase {
     )
 
     client.dataSync.getRelationships(
-      relationshipClass: attendingPhysicianClass.name,
+      className: attendingPhysicianClass.name,
       limit: 1
     ) { firstResult in
       switch firstResult {
@@ -322,7 +322,7 @@ class DataSyncRelationshipEndpointIntegrationTests: XCTestCase {
     ])
 
     client.dataSync.getRelationships(
-      relationshipClass: attendingPhysicianClass.name,
+      className: attendingPhysicianClass.name,
       entityAId: practitionerId
     ) { result in
       switch result {
@@ -363,7 +363,7 @@ class DataSyncRelationshipEndpointIntegrationTests: XCTestCase {
     ])
 
     client.dataSync.getRelationships(
-      relationshipClass: attendingPhysicianClass.name,
+      className: attendingPhysicianClass.name,
       entityBId: patientId
     ) { result in
       switch result {
@@ -404,7 +404,7 @@ class DataSyncRelationshipEndpointIntegrationTests: XCTestCase {
     ])
 
     client.dataSync.getRelationships(
-      relationshipClass: facilityAffiliationClass.name,
+      className: facilityAffiliationClass.name,
       entityBId: practitionerId
     ) { result in
       switch result {
@@ -537,10 +537,10 @@ class DataSyncRelationshipEndpointIntegrationTests: XCTestCase {
     createEntities(client: client, [.practitioner(id: practitionerId)])
 
     client.dataSync.createRelationship(
-      relationshipClass: attendingPhysicianClass.name,
+      className: attendingPhysicianClass.name,
       entityAId: practitionerId,
       entityBId: missingPatientId,
-      relationshipClassVersion: attendingPhysicianClass.version,
+      classVersion: attendingPhysicianClass.version,
       id: relationshipId,
       status: "active",
       payload: TestAttendingPhysicianPayload(role: "attending", since: "2024-01-15")

--- a/Tests/PubNubIntegrationTests/SubscriptionIntegrationTests.swift
+++ b/Tests/PubNubIntegrationTests/SubscriptionIntegrationTests.swift
@@ -129,7 +129,7 @@ class SubscriptionIntegrationTests: XCTestCase {
 
     var firstSubscription: Subscription? = pubnub.channel(testChannelName).subscription()
     var secondSubscription: Subscription? = pubnub.channel(testChannelName).subscription()
-    var subscriptionSet: SubscriptionSet? = pubnub.subscription(entities: [pubnub.channel(testChannelName)])
+    var subscriptionSet: SubscriptionSet? = pubnub.subscription(targets: [pubnub.channel(testChannelName)])
 
     listener.didReceiveStatus = { [unowned pubnub] statusEvent in
       switch statusEvent {
@@ -431,7 +431,7 @@ class SubscriptionIntegrationTests: XCTestCase {
     let pubnub = PubNub(configuration: .init(bundle: testsBundle))
     let channel = pubnub.channel("test-channel")
     let channel2 = pubnub.channel("test-channel2")
-    let subscriptionSet = pubnub.subscription(entities: [channel, channel2])
+    let subscriptionSet = pubnub.subscription(targets: [channel, channel2])
 
     subscriptionSet.subscribe()
 

--- a/Tests/PubNubIntegrationTests/Support/DataSyncHealthcareFixtures.swift
+++ b/Tests/PubNubIntegrationTests/Support/DataSyncHealthcareFixtures.swift
@@ -300,9 +300,9 @@ extension XCTestCase {
 
       client.dataSync.createRelationship(
         className: spec.relationshipClass.name,
+        classVersion: spec.relationshipClass.version,
         entityAId: spec.entityAId,
         entityBId: spec.entityBId,
-        classVersion: spec.relationshipClass.version,
         id: spec.id,
         status: spec.status,
         payload: spec.payload

--- a/Tests/PubNubIntegrationTests/Support/DataSyncHealthcareFixtures.swift
+++ b/Tests/PubNubIntegrationTests/Support/DataSyncHealthcareFixtures.swift
@@ -267,8 +267,8 @@ extension XCTestCase {
       }
 
       client.dataSync.createEntity(
-        entityClass: spec.entityClass.name,
-        entityClassVersion: spec.entityClass.version,
+        className: spec.entityClass.name,
+        classVersion: spec.entityClass.version,
         id: spec.id,
         status: spec.status,
         payload: spec.payload
@@ -299,10 +299,10 @@ extension XCTestCase {
       }
 
       client.dataSync.createRelationship(
-        relationshipClass: spec.relationshipClass.name,
+        className: spec.relationshipClass.name,
         entityAId: spec.entityAId,
         entityBId: spec.entityBId,
-        relationshipClassVersion: spec.relationshipClass.version,
+        classVersion: spec.relationshipClass.version,
         id: spec.id,
         status: spec.status,
         payload: spec.payload

--- a/Tests/PubNubUnitTests/Networking/DataSync/DataSyncChannelAPITests.swift
+++ b/Tests/PubNubUnitTests/Networking/DataSync/DataSyncChannelAPITests.swift
@@ -42,8 +42,8 @@ final class DataSyncChannelAPITests: DataSyncAPITestCase {
     let pubnub = TestPubNubFactory.make(session: sessions.session)
 
     pubnub.dataSync.createChannel(
-      classVersion: 2,
       className: "PrivateChannel",
+      classVersion: 2,
       classLevel: .subKey,
       id: "general"
     ) { _ in

--- a/Tests/PubNubUnitTests/Networking/DataSync/DataSyncEntityAPITests.swift
+++ b/Tests/PubNubUnitTests/Networking/DataSync/DataSyncEntityAPITests.swift
@@ -17,7 +17,7 @@ final class DataSyncEntityAPITests: DataSyncAPITestCase {
     let sessions = try MockURLSession.mockSession(for: ["datasync_entity_all_success"])
     let pubnub = TestPubNubFactory.make(session: sessions.session)
 
-    pubnub.dataSync.getEntities(entityClass: "patient", limit: 20) { result in
+    pubnub.dataSync.getEntities(className: "patient", limit: 20) { result in
       switch result {
       case let .success((entities, next)):
         XCTAssertEqual(entities.count, 2)
@@ -54,7 +54,7 @@ final class DataSyncEntityAPITests: DataSyncAPITestCase {
     let sessions = try MockURLSession.mockSession(for: ["datasync_entity_all_success"])
     let pubnub = TestPubNubFactory.make(session: sessions.session)
 
-    pubnub.dataSync.getEntities(entityClass: "patient") { result in
+    pubnub.dataSync.getEntities(className: "patient") { result in
       switch result {
       case let .success((entities, _)):
         let second = entities[1]
@@ -74,7 +74,7 @@ final class DataSyncEntityAPITests: DataSyncAPITestCase {
     let sessions = try MockURLSession.mockSession(for: ["datasync_entity_all_last_page"])
     let pubnub = TestPubNubFactory.make(session: sessions.session)
 
-    pubnub.dataSync.getEntities(entityClass: "patient", limit: 20) { result in
+    pubnub.dataSync.getEntities(className: "patient", limit: 20) { result in
       switch result {
       case let .success((_, next)):
         XCTAssertNil(next?.cursor)
@@ -130,8 +130,8 @@ final class DataSyncEntityAPITests: DataSyncAPITestCase {
     let pubnub = TestPubNubFactory.make(session: sessions.session)
 
     pubnub.dataSync.createEntity(
-      entityClass: "patient",
-      entityClassVersion: 1,
+      className: "patient",
+      classVersion: 1,
       id: "hcn-patient-alice",
       payload: PatientPayload(mrn: "MRN-100001")
     ) { result in
@@ -166,9 +166,9 @@ final class DataSyncEntityAPITests: DataSyncAPITestCase {
     let pubnub = TestPubNubFactory.make(session: sessions.session)
 
     pubnub.dataSync.createEntity(
-      entityClass: "patient",
-      entityClassVersion: 1,
-      entityClassLevel: .subKey,
+      className: "patient",
+      classVersion: 1,
+      classLevel: .subKey,
       id: "hcn-patient-alice"
     ) { _ in
       expectation.fulfill()
@@ -189,7 +189,7 @@ final class DataSyncEntityAPITests: DataSyncAPITestCase {
 
     pubnub.dataSync.setEntity(
       id: "hcn-patient-alice",
-      entityClassVersion: 1,
+      classVersion: 1,
       payload: PatientPayload(mrn: "MRN-100001"),
       ifMatchesEtag: "3w5e111uk7djz"
     ) { result in
@@ -248,7 +248,7 @@ final class DataSyncEntityAPITests: DataSyncAPITestCase {
     let expectation = self.expectation(description: "getEntities empty class")
     let pubnub = TestPubNubFactory.make()
 
-    pubnub.dataSync.getEntities(entityClass: "") { result in
+    pubnub.dataSync.getEntities(className: "") { result in
       switch result {
       case .success:
         XCTFail("Request should not succeed")

--- a/Tests/PubNubUnitTests/Networking/DataSync/DataSyncErrorAPITests.swift
+++ b/Tests/PubNubUnitTests/Networking/DataSync/DataSyncErrorAPITests.swift
@@ -17,7 +17,7 @@ final class DataSyncErrorAPITests: DataSyncAPITestCase {
     let sessions = try MockURLSession.mockSession(for: ["datasync_error_409"])
     let pubnub = TestPubNubFactory.make(session: sessions.session)
 
-    pubnub.dataSync.createEntity(entityClass: "patient", entityClassVersion: 1) { result in
+    pubnub.dataSync.createEntity(className: "patient", classVersion: 1) { result in
       switch result {
       case .success:
         XCTFail("Request should not succeed")
@@ -41,7 +41,7 @@ final class DataSyncErrorAPITests: DataSyncAPITestCase {
     let sessions = try MockURLSession.mockSession(for: ["datasync_error_400"])
     let pubnub = TestPubNubFactory.make(session: sessions.session)
 
-    pubnub.dataSync.getEntities(entityClass: "patient", limit: 0) { result in
+    pubnub.dataSync.getEntities(className: "patient", limit: 0) { result in
       switch result {
       case .success:
         XCTFail("Request should not succeed")
@@ -61,7 +61,7 @@ final class DataSyncErrorAPITests: DataSyncAPITestCase {
 
     pubnub.dataSync.setEntity(
       id: "hcn-patient-alice",
-      entityClassVersion: 1,
+      classVersion: 1,
       ifMatchesEtag: "stale-etag"
     ) { result in
       switch result {

--- a/Tests/PubNubUnitTests/Networking/DataSync/DataSyncQueryParameterAPITests.swift
+++ b/Tests/PubNubUnitTests/Networking/DataSync/DataSyncQueryParameterAPITests.swift
@@ -127,9 +127,9 @@ final class DataSyncQueryParameterAPITests: DataSyncAPITestCase {
 
     pubnub.dataSync.getRelationships(
       className: "attending-physician",
+      classVersion: 2,
       entityAId: "hcn-doctor-alice",
       entityBId: "hcn-patient-bob",
-      classVersion: 2,
       cursor: "TjIw",
       limit: 25
     ) { _ in

--- a/Tests/PubNubUnitTests/Networking/DataSync/DataSyncQueryParameterAPITests.swift
+++ b/Tests/PubNubUnitTests/Networking/DataSync/DataSyncQueryParameterAPITests.swift
@@ -18,9 +18,9 @@ final class DataSyncQueryParameterAPITests: DataSyncAPITestCase {
     let pubnub = TestPubNubFactory.make(session: sessions.session)
 
     pubnub.dataSync.getEntities(
-      entityClass: "patient",
-      entityClassVersion: 2,
-      entityClassLevel: .account,
+      className: "patient",
+      classVersion: 2,
+      classLevel: .account,
       cursor: "TjIw",
       limit: 25
     ) { _ in
@@ -56,7 +56,7 @@ final class DataSyncQueryParameterAPITests: DataSyncAPITestCase {
     let sessions = try MockURLSession.mockSession(for: ["datasync_user_all_success"])
     let pubnub = TestPubNubFactory.make(session: sessions.session)
 
-    pubnub.dataSync.getUsers(classVersion: 2, className: "Admin", classLevel: .subKey) { _ in
+    pubnub.dataSync.getUsers(className: "Admin", classVersion: 2, classLevel: .subKey) { _ in
       expectation.fulfill()
     }
 
@@ -87,7 +87,7 @@ final class DataSyncQueryParameterAPITests: DataSyncAPITestCase {
     let sessions = try MockURLSession.mockSession(for: ["datasync_channel_fetch_success"])
     let pubnub = TestPubNubFactory.make(session: sessions.session)
 
-    pubnub.dataSync.getChannels(classVersion: 2, className: "PrivateChannel", classLevel: .subKey) { _ in
+    pubnub.dataSync.getChannels(className: "PrivateChannel", classVersion: 2, classLevel: .subKey) { _ in
       expectation.fulfill()
     }
 
@@ -126,10 +126,10 @@ final class DataSyncQueryParameterAPITests: DataSyncAPITestCase {
     let pubnub = TestPubNubFactory.make(session: sessions.session)
 
     pubnub.dataSync.getRelationships(
-      relationshipClass: "attending-physician",
+      className: "attending-physician",
       entityAId: "hcn-doctor-alice",
       entityBId: "hcn-patient-bob",
-      relationshipClassVersion: 2,
+      classVersion: 2,
       cursor: "TjIw",
       limit: 25
     ) { _ in
@@ -150,7 +150,7 @@ final class DataSyncQueryParameterAPITests: DataSyncAPITestCase {
     let sessions = try MockURLSession.mockSession(for: ["datasync_entity_all_success"])
     let pubnub = TestPubNubFactory.make(session: sessions.session)
 
-    pubnub.dataSync.getEntities(entityClass: "patient", filter: "status=='active'") { _ in
+    pubnub.dataSync.getEntities(className: "patient", filter: "status=='active'") { _ in
       expectation.fulfill()
     }
 
@@ -163,7 +163,7 @@ final class DataSyncQueryParameterAPITests: DataSyncAPITestCase {
     let sessions = try MockURLSession.mockSession(for: ["datasync_entity_all_success"])
     let pubnub = TestPubNubFactory.make(session: sessions.session)
 
-    pubnub.dataSync.getEntities(entityClass: "patient", filterAdvanced: "a AND b") { _ in
+    pubnub.dataSync.getEntities(className: "patient", filterAdvanced: "a AND b") { _ in
       expectation.fulfill()
     }
 
@@ -176,7 +176,7 @@ final class DataSyncQueryParameterAPITests: DataSyncAPITestCase {
     let sessions = try MockURLSession.mockSession(for: ["datasync_entity_all_success"])
     let pubnub = TestPubNubFactory.make(session: sessions.session)
 
-    pubnub.dataSync.getEntities(entityClass: "patient") { _ in
+    pubnub.dataSync.getEntities(className: "patient") { _ in
       expectation.fulfill()
     }
 
@@ -269,7 +269,7 @@ final class DataSyncQueryParameterAPITests: DataSyncAPITestCase {
     let pubnub = TestPubNubFactory.make(session: sessions.session)
 
     pubnub.dataSync.getRelationships(
-      relationshipClass: "attending-physician",
+      className: "attending-physician",
       filter: "status=='active'"
     ) { _ in
       expectation.fulfill()
@@ -285,7 +285,7 @@ final class DataSyncQueryParameterAPITests: DataSyncAPITestCase {
     let pubnub = TestPubNubFactory.make(session: sessions.session)
 
     pubnub.dataSync.getRelationships(
-      relationshipClass: "attending-physician",
+      className: "attending-physician",
       filterAdvanced: "a AND b"
     ) { _ in
       expectation.fulfill()
@@ -326,7 +326,7 @@ final class DataSyncQueryParameterAPITests: DataSyncAPITestCase {
     let pubnub = TestPubNubFactory.make(session: sessions.session)
 
     pubnub.dataSync.getEntities(
-      entityClass: "patient",
+      className: "patient",
       sort: [.init(property: "fullName", ascending: false), .init(property: "mrn")]
     ) { _ in
       expectation.fulfill()
@@ -341,7 +341,7 @@ final class DataSyncQueryParameterAPITests: DataSyncAPITestCase {
     let sessions = try MockURLSession.mockSession(for: ["datasync_entity_all_success"])
     let pubnub = TestPubNubFactory.make(session: sessions.session)
 
-    pubnub.dataSync.getEntities(entityClass: "patient") { _ in
+    pubnub.dataSync.getEntities(className: "patient") { _ in
       expectation.fulfill()
     }
 
@@ -394,7 +394,7 @@ final class DataSyncQueryParameterAPITests: DataSyncAPITestCase {
     let pubnub = TestPubNubFactory.make(session: sessions.session)
 
     pubnub.dataSync.getRelationships(
-      relationshipClass: "attending-physician",
+      className: "attending-physician",
       sort: [.init(property: "since", ascending: false)]
     ) { _ in
       expectation.fulfill()

--- a/Tests/PubNubUnitTests/Networking/DataSync/DataSyncRelationshipAPITests.swift
+++ b/Tests/PubNubUnitTests/Networking/DataSync/DataSyncRelationshipAPITests.swift
@@ -17,7 +17,7 @@ final class DataSyncRelationshipAPITests: DataSyncAPITestCase {
     let sessions = try MockURLSession.mockSession(for: ["datasync_relationship_all_no_meta"])
     let pubnub = TestPubNubFactory.make(session: sessions.session)
 
-    pubnub.dataSync.getRelationships(relationshipClass: "Treats", limit: 20) { [self] result in
+    pubnub.dataSync.getRelationships(className: "Treats", limit: 20) { [self] result in
       switch result {
       case let .success((relationships, next)):
         XCTAssertNil(next)
@@ -65,10 +65,10 @@ final class DataSyncRelationshipAPITests: DataSyncAPITestCase {
     let pubnub = TestPubNubFactory.make(session: sessions.session)
 
     pubnub.dataSync.createRelationship(
-      relationshipClass: "Treats",
+      className: "Treats",
       entityAId: "hcn-doctor-alice",
       entityBId: "hcn-patient-bob",
-      relationshipClassVersion: 1
+      classVersion: 1
     ) { result in
       switch result {
       case let .success(relationship):
@@ -89,7 +89,7 @@ final class DataSyncRelationshipAPITests: DataSyncAPITestCase {
 
     pubnub.dataSync.setRelationship(
       id: "rel-alice-treats-bob",
-      relationshipClassVersion: 1,
+      classVersion: 1,
       payload: RelationshipPayload(since: "2026-01-01"),
       ifMatchesEtag: "3w5e111uk7djz"
     ) { result in

--- a/Tests/PubNubUnitTests/Networking/DataSync/DataSyncRelationshipAPITests.swift
+++ b/Tests/PubNubUnitTests/Networking/DataSync/DataSyncRelationshipAPITests.swift
@@ -24,7 +24,6 @@ final class DataSyncRelationshipAPITests: DataSyncAPITestCase {
         XCTAssertEqual(relationships.count, 1)
         XCTAssertEqual(relationships[0].id, "rel-alice-treats-bob")
         XCTAssertEqual(relationships[0].className, "Treats")
-        XCTAssertNil(relationships[0].classLevel)
         XCTAssertEqual(relationships[0].classVersion, 1)
         XCTAssertEqual(relationships[0].entityAId, "hcn-doctor-alice")
         XCTAssertEqual(relationships[0].entityBId, "hcn-patient-bob")
@@ -66,9 +65,9 @@ final class DataSyncRelationshipAPITests: DataSyncAPITestCase {
 
     pubnub.dataSync.createRelationship(
       className: "Treats",
+      classVersion: 1,
       entityAId: "hcn-doctor-alice",
-      entityBId: "hcn-patient-bob",
-      classVersion: 1
+      entityBId: "hcn-patient-bob"
     ) { result in
       switch result {
       case let .success(relationship):

--- a/Tests/PubNubUnitTests/Networking/DataSync/DataSyncResponseTests.swift
+++ b/Tests/PubNubUnitTests/Networking/DataSync/DataSyncResponseTests.swift
@@ -84,6 +84,25 @@ final class DataSyncResponseTests: XCTestCase {
     XCTAssertEqual(response.data.payload?["custom"], "fields")
   }
 
+  func test_MembershipRelationship_MapsMembershipEndpointsToRelationshipSides() {
+    let date = Date(timeIntervalSince1970: 1)
+    let membership = PubNubDataSyncMembership(
+      id: "membership",
+      channelId: "channel",
+      userId: "user",
+      className: "Membership",
+      classVersion: 1,
+      createdAt: date,
+      updatedAt: date,
+      eTag: "etag"
+    )
+
+    XCTAssertEqual(membership.relationship.entityAId, membership.channelId)
+    XCTAssertEqual(membership.relationship.entityBId, membership.userId)
+    XCTAssertEqual(membership.relationship.id, membership.id)
+    XCTAssertEqual(membership.relationship.className, membership.className)
+  }
+
   func test_DecodeErrorPayloadWithAndWithoutPath() throws {
     let withPath = """
     {

--- a/Tests/PubNubUnitTests/Networking/DataSync/DataSyncUserAPITests.swift
+++ b/Tests/PubNubUnitTests/Networking/DataSync/DataSyncUserAPITests.swift
@@ -90,8 +90,8 @@ final class DataSyncUserAPITests: DataSyncAPITestCase {
     let pubnub = TestPubNubFactory.make(session: sessions.session)
 
     pubnub.dataSync.createUser(
-      classVersion: 2,
       className: "Admin",
+      classVersion: 2,
       classLevel: .subKey,
       id: "alice"
     ) { _ in

--- a/Tests/PubNubUnitTests/Networking/Routers/SubscribeRouterTests+DataSync.swift
+++ b/Tests/PubNubUnitTests/Networking/Routers/SubscribeRouterTests+DataSync.swift
@@ -192,10 +192,9 @@ extension SubscribeRouterTests {
   }
 
   func test_Subscribe_WithDataSyncRelationshipDeleteEvent_ReceivesRemovedRelationship() throws {
-    let expectedRemoval = PubNubDataSyncRemovedObject(
+    let expectedRemoval = PubNubDataSyncRemovedRelationship(
       id: "hcn-rel-attending-tanaka-dubois",
       className: "attending-physician",
-      classLevel: .subKey,
       classVersion: 1,
       deletedAt: try XCTUnwrap(DateFormatter.iso8601.date(from: "2026-07-28T09:07:47.243657Z"))
     )
@@ -468,10 +467,9 @@ extension SubscribeRouterTests {
 
     XCTAssertEqual(
       removed,
-      PubNubDataSyncRemovedObject(
+      PubNubDataSyncRemovedRelationship(
         id: "general__alice",
         className: "Membership",
-        classLevel: .global,
         classVersion: 1,
         deletedAt: try XCTUnwrap(DateFormatter.iso8601.date(from: "2026-08-13T16:05:15.029431Z"))
       )
@@ -674,10 +672,10 @@ extension SubscribeRouterTests {
 
     XCTAssertEqual(events.legacy.deletedRelationship?.id, "general__alice")
     XCTAssertEqual(events.legacy.deletedRelationship?.className, "Membership")
-    XCTAssertEqual(events.legacy.deletedRelationship?.classLevel, .global)
+    XCTAssertEqual(events.legacy.deletedRelationship?.classVersion, 1)
     XCTAssertEqual(events.modern.deletedRelationship?.id, "general__alice")
     XCTAssertEqual(events.modern.deletedRelationship?.className, "Membership")
-    XCTAssertEqual(events.modern.deletedRelationship?.classLevel, .global)
+    XCTAssertEqual(events.modern.deletedRelationship?.classVersion, 1)
   }
 }
 
@@ -772,7 +770,7 @@ private extension PubNubDataSyncEvent {
     return r
   }
 
-  var deletedRelationship: PubNubDataSyncRemovedObject? {
+  var deletedRelationship: PubNubDataSyncRemovedRelationship? {
     guard case let .relationshipDeleted(r) = self else { return nil }
     return r
   }
@@ -806,7 +804,7 @@ private extension PubNubEvent {
     return r
   }
 
-  var deletedDataSyncRelationship: PubNubDataSyncRemovedObject? {
+  var deletedDataSyncRelationship: PubNubDataSyncRemovedRelationship? {
     guard case let .dataSyncChanged(.relationshipDeleted(r)) = self else { return nil }
     return r
   }

--- a/Tests/PubNubUnitTests/Networking/Routers/SubscribeRouterTests+DataSync.swift
+++ b/Tests/PubNubUnitTests/Networking/Routers/SubscribeRouterTests+DataSync.swift
@@ -127,7 +127,6 @@ extension SubscribeRouterTests {
     let expectedRelationship = PubNubDataSyncRelationship(
       id: "hcn-rel-attending-carter-alice",
       className: "attending-physician",
-      classLevel: .subKey,
       classVersion: 1,
       entityAId: "hcn-practitioner-carter",
       entityBId: "hcn-patient-alice",
@@ -144,7 +143,6 @@ extension SubscribeRouterTests {
 
     XCTAssertEqual(relationship.id, expectedRelationship.id)
     XCTAssertEqual(relationship.className, expectedRelationship.className)
-    XCTAssertEqual(relationship.classLevel, expectedRelationship.classLevel)
     XCTAssertEqual(relationship.classVersion, expectedRelationship.classVersion)
     XCTAssertEqual(relationship.entityAId, expectedRelationship.entityAId)
     XCTAssertEqual(relationship.entityBId, expectedRelationship.entityBId)
@@ -166,7 +164,6 @@ extension SubscribeRouterTests {
     let expectedRelationship = PubNubDataSyncRelationship(
       id: "hcn-rel-attending-carter-alice",
       className: "attending-physician",
-      classLevel: .subKey,
       classVersion: 1,
       entityAId: "hcn-practitioner-carter",
       entityBId: "hcn-patient-alice",
@@ -183,7 +180,6 @@ extension SubscribeRouterTests {
 
     XCTAssertEqual(relationship.id, expectedRelationship.id)
     XCTAssertEqual(relationship.className, expectedRelationship.className)
-    XCTAssertEqual(relationship.classLevel, expectedRelationship.classLevel)
     XCTAssertEqual(relationship.classVersion, expectedRelationship.classVersion)
     XCTAssertEqual(relationship.entityAId, expectedRelationship.entityAId)
     XCTAssertEqual(relationship.entityBId, expectedRelationship.entityBId)

--- a/Tests/PubNubUnitTests/Subscribe/API/SubscriptionSetTests.swift
+++ b/Tests/PubNubUnitTests/Subscribe/API/SubscriptionSetTests.swift
@@ -18,7 +18,7 @@ class SubscriptionSetTests: XCTestCase {
     expectation.expectedFulfillmentCount = 2
 
     let pubnub = TestPubNubFactory.make(publishKey: "pubKey", subscribeKey: "subKey", userId: "userId")
-    let subscription = pubnub.subscription(entities: [pubnub.channel("c1"), pubnub.channel("c2")])
+    let subscription = pubnub.subscription(targets: [pubnub.channel("c1"), pubnub.channel("c2")])
 
     subscription.onMessage = { _ in
       expectation.fulfill()
@@ -36,7 +36,7 @@ class SubscriptionSetTests: XCTestCase {
     expectation.expectedFulfillmentCount = 2
 
     let pubnub = TestPubNubFactory.make(publishKey: "pubKey", subscribeKey: "subKey", userId: "userId")
-    let subscription = pubnub.subscription(entities: [pubnub.channel("c1"), pubnub.channel("c2")])
+    let subscription = pubnub.subscription(targets: [pubnub.channel("c1"), pubnub.channel("c2")])
 
     subscription.onSignal = { _ in
       expectation.fulfill()
@@ -54,7 +54,7 @@ class SubscriptionSetTests: XCTestCase {
     expectation.expectedFulfillmentCount = 2
 
     let pubnub = TestPubNubFactory.make(publishKey: "pubKey", subscribeKey: "subKey", userId: "userId")
-    let subscription = pubnub.subscription(entities: [pubnub.channel("c1"), pubnub.channel("c2")])
+    let subscription = pubnub.subscription(targets: [pubnub.channel("c1"), pubnub.channel("c2")])
 
     subscription.onPresence = { _ in
       expectation.fulfill()
@@ -72,7 +72,7 @@ class SubscriptionSetTests: XCTestCase {
     expectation.expectedFulfillmentCount = 2
 
     let pubnub = TestPubNubFactory.make(publishKey: "pubKey", subscribeKey: "subKey", userId: "userId")
-    let subscription = pubnub.subscription(entities: [pubnub.channel("c1"), pubnub.channel("c2")])
+    let subscription = pubnub.subscription(targets: [pubnub.channel("c1"), pubnub.channel("c2")])
 
     subscription.onAppContext = { _ in
       expectation.fulfill()
@@ -90,7 +90,7 @@ class SubscriptionSetTests: XCTestCase {
     expectation.expectedFulfillmentCount = 2
 
     let pubnub = TestPubNubFactory.make(publishKey: "pubKey", subscribeKey: "subKey", userId: "userId")
-    let subscription = pubnub.subscription(entities: [pubnub.channel("c1"), pubnub.channel("c2")])
+    let subscription = pubnub.subscription(targets: [pubnub.channel("c1"), pubnub.channel("c2")])
 
     subscription.onFileEvent = { _ in
       expectation.fulfill()
@@ -108,7 +108,7 @@ class SubscriptionSetTests: XCTestCase {
     expectation.expectedFulfillmentCount = 2
 
     let pubnub = TestPubNubFactory.make(publishKey: "pubKey", subscribeKey: "subKey", userId: "userId")
-    let subscription = pubnub.subscription(entities: [pubnub.channel("c1"), pubnub.channel("c2")])
+    let subscription = pubnub.subscription(targets: [pubnub.channel("c1"), pubnub.channel("c2")])
 
     subscription.onMessageAction = { _ in
       expectation.fulfill()
@@ -126,7 +126,7 @@ class SubscriptionSetTests: XCTestCase {
     expectation.expectedFulfillmentCount = 2
 
     let pubnub = TestPubNubFactory.make(publishKey: "pubKey", subscribeKey: "subKey", userId: "userId")
-    let subscription = pubnub.subscription(entities: [pubnub.channel("c1"), pubnub.channel("c2")])
+    let subscription = pubnub.subscription(targets: [pubnub.channel("c1"), pubnub.channel("c2")])
 
     subscription.onEvents = { _ in
       expectation.fulfill()
@@ -158,25 +158,24 @@ class SubscriptionSetTests: XCTestCase {
     )
 
     let subscriptionSet = pubnub.subscription(
-      entities: [
+      targets: [
         pubnub.channel("c1"),
         pubnub.channel("c2"),
         pubnub.channelGroup("g1")
       ], options: ReceivePresenceEvents()
     )
 
-    let expectedTopology: [SubscribeTarget: [String]] = [
-      .channel: ["c1", "c1-pnpres", "c2", "c2-pnpres"],
-      .channelGroup: ["g1", "g1-pnpres"]
-    ]
+    // The set iterates an unordered collection of subscriptions, so compare each list sorted
+    let actualTopology = subscriptionSet.subscriptionTopology
 
-    let actualChannels = try XCTUnwrap(subscriptionSet.subscriptionTopology[.channel])
-    let expectedChannels = try XCTUnwrap(expectedTopology[.channel])
-    XCTAssertEqual(actualChannels.sorted(by: <), expectedChannels.sorted(by: <))
-
-    let actualGroups = try XCTUnwrap(subscriptionSet.subscriptionTopology[.channelGroup])
-    let expectedGroups = try XCTUnwrap(expectedTopology[.channelGroup])
-    XCTAssertEqual(actualGroups.sorted(by: <), expectedGroups.sorted(by: <))
+    XCTAssertEqual(
+      actualTopology.channels.sorted(by: <),
+      ["c1", "c1-pnpres", "c2", "c2-pnpres"]
+    )
+    XCTAssertEqual(
+      actualTopology.channelGroups.sorted(by: <),
+      ["g1", "g1-pnpres"]
+    )
   }
 
   func testSubscriptionSet_WithListeners_OnMessage() {
@@ -185,7 +184,7 @@ class SubscriptionSetTests: XCTestCase {
 
     let pubnub = TestPubNubFactory.make(publishKey: "pubKey", subscribeKey: "subKey", userId: "userId")
     let channel = pubnub.channel("test-channel")
-    let subscriptionSet = pubnub.subscription(entities: [channel, pubnub.channel("test-channel2")])
+    let subscriptionSet = pubnub.subscription(targets: [channel, pubnub.channel("test-channel2")])
 
     let listener = EventListener(onMessage: { _ in
       expectation.fulfill()
@@ -205,7 +204,7 @@ class SubscriptionSetTests: XCTestCase {
 
     let pubnub = TestPubNubFactory.make(publishKey: "pubKey", subscribeKey: "subKey", userId: "userId")
     let channel = pubnub.channel("test-channel")
-    let subscriptionSet = pubnub.subscription(entities: [channel, pubnub.channel("test-channel2")])
+    let subscriptionSet = pubnub.subscription(targets: [channel, pubnub.channel("test-channel2")])
 
     let listener = EventListener(onSignal: { _ in
       expectation.fulfill()
@@ -225,7 +224,7 @@ class SubscriptionSetTests: XCTestCase {
 
     let pubnub = TestPubNubFactory.make(publishKey: "pubKey", subscribeKey: "subKey", userId: "userId")
     let channel = pubnub.channel("test-channel")
-    let subscriptionSet = pubnub.subscription(entities: [channel, pubnub.channel("test-channel2")])
+    let subscriptionSet = pubnub.subscription(targets: [channel, pubnub.channel("test-channel2")])
 
     let listener = EventListener(onPresence: { _ in
       expectation.fulfill()
@@ -245,7 +244,7 @@ class SubscriptionSetTests: XCTestCase {
 
     let pubnub = TestPubNubFactory.make(publishKey: "pubKey", subscribeKey: "subKey", userId: "userId")
     let channel = pubnub.channel("test-channel")
-    let subscriptionSet = pubnub.subscription(entities: [channel, pubnub.channel("test-channel2")])
+    let subscriptionSet = pubnub.subscription(targets: [channel, pubnub.channel("test-channel2")])
 
     let listener = EventListener(onMessageAction: { _ in
       expectation.fulfill()
@@ -265,7 +264,7 @@ class SubscriptionSetTests: XCTestCase {
 
     let pubnub = TestPubNubFactory.make(publishKey: "pubKey", subscribeKey: "subKey", userId: "userId")
     let channel = pubnub.channel("test-channel")
-    let subscriptionSet = pubnub.subscription(entities: [channel, pubnub.channel("test-channel2")])
+    let subscriptionSet = pubnub.subscription(targets: [channel, pubnub.channel("test-channel2")])
 
     let listener = EventListener(onFileEvent: { _ in
       expectation.fulfill()
@@ -285,7 +284,7 @@ class SubscriptionSetTests: XCTestCase {
 
     let pubnub = TestPubNubFactory.make(publishKey: "pubKey", subscribeKey: "subKey", userId: "userId")
     let channel = pubnub.channel("test-channel")
-    let subscriptionSet = pubnub.subscription(entities: [channel, pubnub.channel("test-channel2")])
+    let subscriptionSet = pubnub.subscription(targets: [channel, pubnub.channel("test-channel2")])
 
     let listener = EventListener(onAppContext: { _ in
       expectation.fulfill()

--- a/Tests/PubNubUnitTests/Subscribe/API/SubscriptionTests.swift
+++ b/Tests/PubNubUnitTests/Subscribe/API/SubscriptionTests.swift
@@ -288,9 +288,10 @@ class SubscriptionTests: XCTestCase {
     let channel = pubnub.channel("c")
     let subscription = channel.subscription(options: ReceivePresenceEvents())
 
-    XCTAssertEqual(subscription.subscriptionNames, ["c", "c-pnpres"])
-    XCTAssertEqual(subscription.subscribeTarget, .channel)
-    XCTAssertEqual(subscription.subscriptionTopology, [.channel: ["c", "c-pnpres"]])
+    XCTAssertEqual(
+      subscription.subscriptionTopology,
+      SubscriptionTopology(channels: ["c", "c-pnpres"])
+    )
   }
 
   func testSubscription_ReceivePresenceEventsForChannelGroup() {
@@ -298,9 +299,10 @@ class SubscriptionTests: XCTestCase {
     let channel = pubnub.channelGroup("g")
     let subscription = channel.subscription(options: ReceivePresenceEvents())
 
-    XCTAssertEqual(subscription.subscriptionNames, ["g", "g-pnpres"])
-    XCTAssertEqual(subscription.subscribeTarget, .channelGroup)
-    XCTAssertEqual(subscription.subscriptionTopology, [.channelGroup: ["g", "g-pnpres"]])
+    XCTAssertEqual(
+      subscription.subscriptionTopology,
+      SubscriptionTopology(channelGroups: ["g", "g-pnpres"])
+    )
   }
 
   func testSubscription_WithListeners_OnMessage() {

--- a/Tests/PubNubUnitTests/Subscribe/API/SubscriptionTests.swift
+++ b/Tests/PubNubUnitTests/Subscribe/API/SubscriptionTests.swift
@@ -305,6 +305,117 @@ class SubscriptionTests: XCTestCase {
     )
   }
 
+  func testDataSyncSubscribables_UseIdentifierAsChannelWithoutProjection() {
+    let pubnub = TestPubNubFactory.make(
+      publishKey: "pubKey",
+      subscribeKey: "subKey",
+      userId: "userId"
+    )
+    let subscriptions = [
+      pubnub.dataSyncUser("user-id").subscription(),
+      pubnub.dataSyncChannel("channel-id").subscription(),
+      pubnub.dataSyncMembership("membership-id").subscription(),
+      pubnub.dataSyncEntity("entity-id").subscription(),
+      pubnub.dataSyncRelationship("relationship-id").subscription()
+    ]
+
+    XCTAssertEqual(
+      subscriptions.map(\.subscriptionTopology),
+      [
+        SubscriptionTopology(channels: ["user-id"]),
+        SubscriptionTopology(channels: ["channel-id"]),
+        SubscriptionTopology(channels: ["membership-id"]),
+        SubscriptionTopology(channels: ["entity-id"]),
+        SubscriptionTopology(channels: ["relationship-id"])
+      ]
+    )
+  }
+
+  func testDataSyncSubscribables_UseProjectionAndIdentifierAsChannelWithProjection() {
+    let pubnub = TestPubNubFactory.make(
+      publishKey: "pubKey",
+      subscribeKey: "subKey",
+      userId: "userId"
+    )
+    let subscriptions = [
+      pubnub.dataSyncUser("user-id").subscription(projection: "details"),
+      pubnub.dataSyncChannel("channel-id").subscription(projection: "details"),
+      pubnub.dataSyncMembership("membership-id").subscription(projection: "details"),
+      pubnub.dataSyncEntity("entity-id").subscription(projection: "details"),
+      pubnub.dataSyncRelationship("relationship-id").subscription(projection: "details")
+    ]
+
+    XCTAssertEqual(
+      subscriptions.map(\.subscriptionTopology),
+      [
+        SubscriptionTopology(channels: ["__details__user-id"]),
+        SubscriptionTopology(channels: ["__details__channel-id"]),
+        SubscriptionTopology(channels: ["__details__membership-id"]),
+        SubscriptionTopology(channels: ["__details__entity-id"]),
+        SubscriptionTopology(channels: ["__details__relationship-id"])
+      ]
+    )
+  }
+
+  func testDataSyncSubscribables_UseIdentifierAsChannelWithDefaultProjection() {
+    let pubnub = TestPubNubFactory.make(publishKey: "pubKey", subscribeKey: "subKey", userId: "userId")
+    let subscriptions = [
+      pubnub.dataSyncUser("user-id").subscription(projection: "default"),
+      pubnub.dataSyncChannel("channel-id").subscription(projection: "default"),
+      pubnub.dataSyncMembership("membership-id").subscription(projection: "default"),
+      pubnub.dataSyncEntity("entity-id").subscription(projection: "default"),
+      pubnub.dataSyncRelationship("relationship-id").subscription(projection: "default")
+    ]
+
+    XCTAssertEqual(
+      subscriptions.map(\.subscriptionTopology),
+      [
+        SubscriptionTopology(channels: ["user-id"]),
+        SubscriptionTopology(channels: ["channel-id"]),
+        SubscriptionTopology(channels: ["membership-id"]),
+        SubscriptionTopology(channels: ["entity-id"]),
+        SubscriptionTopology(channels: ["relationship-id"])
+      ]
+    )
+  }
+
+  func testKMPDataSyncSubscribables_MirrorSwiftReferencesAndProjectionSubscriptions() {
+    let pubnub = TestPubNubFactory.make(publishKey: "pubKey", subscribeKey: "subKey", userId: "userId")
+    let kmpPubNub = KMPPubNub(pubnub: pubnub)
+    let references: [KMPDataSyncReference] = [
+      kmpPubNub.dataSyncUser(with: "user-id"),
+      kmpPubNub.dataSyncChannel(with: "channel-id"),
+      kmpPubNub.dataSyncMembership(with: "membership-id"),
+      kmpPubNub.dataSyncEntity(with: "entity-id"),
+      kmpPubNub.dataSyncRelationship(with: "relationship-id")
+    ]
+
+    XCTAssertEqual(
+      references.map(\.id),
+      ["user-id", "channel-id", "membership-id", "entity-id", "relationship-id"]
+    )
+    XCTAssertEqual(
+      references.map { KMPSubscription(entity: $0).subscription.subscriptionTopology },
+      [
+        SubscriptionTopology(channels: ["user-id"]),
+        SubscriptionTopology(channels: ["channel-id"]),
+        SubscriptionTopology(channels: ["membership-id"]),
+        SubscriptionTopology(channels: ["entity-id"]),
+        SubscriptionTopology(channels: ["relationship-id"])
+      ]
+    )
+    XCTAssertEqual(
+      references.map { $0.subscription(withProjection: "details").subscription.subscriptionTopology },
+      [
+        SubscriptionTopology(channels: ["__details__user-id"]),
+        SubscriptionTopology(channels: ["__details__channel-id"]),
+        SubscriptionTopology(channels: ["__details__membership-id"]),
+        SubscriptionTopology(channels: ["__details__entity-id"]),
+        SubscriptionTopology(channels: ["__details__relationship-id"])
+      ]
+    )
+  }
+
   func testSubscription_WithListeners_OnMessage() {
     let expectation = XCTestExpectation(description: "Message")
     expectation.assertForOverFulfill = true

--- a/Tests/PubNubUnitTests/Subscribe/Core/SubscriptionSessionTests.swift
+++ b/Tests/PubNubUnitTests/Subscribe/Core/SubscriptionSessionTests.swift
@@ -99,6 +99,63 @@ class SubscriptionSessionTests: XCTestCase {
     defer { listener.cancel() }
     wait(for: [statusExpect], timeout: 1.0)
   }
+
+  // MARK: - Overlapping Subscriptions
+
+  func testSubscriptionSession_UnsubscribeRetainsNameHeldByAnotherSubscription() throws {
+    let mockResponses = ["subscription_handshake_success", "cancelled"]
+    let subscriptionSession = try mockSubscriptionSession(with: mockResponses, and: config)
+    let pubnub = PubNub(configuration: config)
+
+    let firstSubscription = pubnub.channel(testChannel).subscription()
+    let secondSubscription = pubnub.channel(testChannel).subscription()
+
+    subscriptionSession.subscribe(to: [firstSubscription, secondSubscription])
+    XCTAssertEqual(subscriptionSession.subscribedChannels, [testChannel])
+
+    // The second subscription still holds the name, so it must stay in the Subscribe loop
+    subscriptionSession.internalUnsubscribe(from: [firstSubscription])
+    XCTAssertEqual(subscriptionSession.subscribedChannels, [testChannel])
+
+    // With the last subscription holding it gone, the name leaves the Subscribe loop
+    subscriptionSession.internalUnsubscribe(from: [secondSubscription])
+    XCTAssertTrue(subscriptionSession.subscribedChannels.isEmpty)
+  }
+
+  func testSubscriptionSession_UnsubscribeChannelRetainsSameNamedChannelGroup() throws {
+    let mockResponses = ["subscription_handshake_success", "cancelled"]
+    let subscriptionSession = try mockSubscriptionSession(with: mockResponses, and: config)
+    let pubnub = PubNub(configuration: config)
+
+    // A channel and a channel group sharing a name occupy different lists in the Subscribe loop
+    let channelSubscription = pubnub.channel(testChannel).subscription()
+    let groupSubscription = pubnub.channelGroup(testChannel).subscription()
+
+    subscriptionSession.subscribe(to: [channelSubscription], and: [groupSubscription])
+    XCTAssertEqual(subscriptionSession.subscribedChannels, [testChannel])
+    XCTAssertEqual(subscriptionSession.subscribedChannelGroups, [testChannel])
+
+    subscriptionSession.internalUnsubscribe(from: [channelSubscription])
+    XCTAssertTrue(subscriptionSession.subscribedChannels.isEmpty)
+    XCTAssertEqual(subscriptionSession.subscribedChannelGroups, [testChannel])
+  }
+
+  func testSubscriptionSession_UnsubscribeRetainsNameHeldBySubscriptionSet() throws {
+    let mockResponses = ["subscription_handshake_success", "cancelled"]
+    let subscriptionSession = try mockSubscriptionSession(with: mockResponses, and: config)
+    let pubnub = PubNub(configuration: config)
+
+    let standaloneSubscription = pubnub.channel(testChannel).subscription()
+    let subscriptionSet = pubnub.subscription(targets: [pubnub.channel(testChannel)])
+
+    subscriptionSession.subscribe(to: [standaloneSubscription])
+    subscriptionSession.registerAdapter(subscriptionSet.adapter)
+    XCTAssertEqual(subscriptionSession.subscribedChannels, [testChannel])
+
+    // The set's topology covers both lists, and it still holds the name
+    subscriptionSession.internalUnsubscribe(from: [standaloneSubscription])
+    XCTAssertEqual(subscriptionSession.subscribedChannels, [testChannel])
+  }
 }
 
 fileprivate extension SubscriptionSessionTests {


### PR DESCRIPTION
`entity` now means a DataSync record, so the subscribe API stops using the word and DataSync drops redundant prefixes.

**Subscribe**
- `Subscription.entity` → internal `target`; `pubnub.subscription(entities:)` → `subscription(targets:)`
- `Subscription` / `SubscriptionSet` initializers are no longer public — use the `PubNub` factory methods
- `Subscribable` subclasses now provide identifiers through `SubscriptionTopology`
- Added DataSync subscribables
- Added `PubNub` factories such as `dataSyncUser(_:)` and `dataSyncEntity(_:)`
- Data Sync subscribables support `.subscription()` and `.subscription(projection:)`
- Base and `default` projection subscriptions use the resource ID as the channel
- Custom projections derive `__<projection>__<resource_id>`

**DataSync**
- `entityClass` / `entityClassVersion` / `entityClassLevel` → `className` / `classVersion` / `classLevel`
- `relationshipClass` / `relationshipClassVersion` → `className` / `classVersion`
- `className` now precedes `classVersion` on users and channels
- `classVersion` follows `className` on relationships
- User/Channel APIs now return the shared `PubNubDataSyncEntity` model instead of duplicate user/channel models.
- Memberships reveal their `PubNubDataSyncRelationship`, mapping channel and user IDs to entityAId/entityBId
- Deleted relationships use `PubNubDataSyncRemovedRelationship` instead of the entity deletion model
- `PubNubDataSyncRelationship.classLevel` removed — relationship classes cannot be extended
- KMP now mirrors the Swift signatures parameter-for-parameter